### PR TITLE
Bump parquet version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.12.1.1</derby.version>
-    <parquet.version>1.8.1-palantir7</parquet.version>
+    <parquet.version>1.9.0-palantir1</parquet.version>
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>


### PR DESCRIPTION
Changes String comparison for correctness. Note - String statistics written by a version lower than this will be marked as corrupted and not used. 