### PR TITLE
make dist land in maven style directory pattern

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,10 +36,11 @@ test:
           make_dist() {
             dist_name="$1"
             build_flags="$2"
-            file_name="spark-${version}-bin-${dist_name}.tgz"
-            sudo apt-get --assume-yes install r-base r-base-dev 
+            dist_version="${version}-${dist_name}"
+            file_name="spark-dist-${dist_version}.tgz"
+            sudo apt-get --assume-yes install r-base r-base-dev
             ./dev/make-distribution.sh --name $dist_name --tgz $build_flags
-            curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/dist/${file_name}"
+            curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/spark-dist/${dist_version}/${file_name}"
           }
 
           case $CIRCLE_NODE_INDEX in

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -137,7 +137,7 @@ fi
 echo "Spark version is $VERSION"
 VERSION_SET=$("$MVN" versions:set -DnewVersion=$VERSION | tail -n 1)
 if [ "$MAKE_TGZ" == "true" ]; then
-  echo "Making spark-$VERSION-bin-$NAME.tgz"
+  echo "Making spark-dist-$VERSION-$NAME.tgz"
 else
   echo "Making distribution for Spark $VERSION in $DISTDIR..."
 fi
@@ -216,7 +216,7 @@ if [ -d "$SPARK_HOME"/R/lib/SparkR ]; then
 fi
 
 if [ "$MAKE_TGZ" == "true" ]; then
-  TARDIR_NAME=spark-$VERSION-bin-$NAME
+  TARDIR_NAME=spark-dist-$VERSION-$NAME
   TARDIR="$SPARK_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
   cp -r "$DISTDIR" "$TARDIR"

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -220,6 +220,6 @@ if [ "$MAKE_TGZ" == "true" ]; then
   TARDIR="$SPARK_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
   cp -r "$DISTDIR" "$TARDIR"
-  tar czf "spark-$VERSION-bin-$NAME.tgz" -C "$SPARK_HOME" "$TARDIR_NAME"
+  tar czf "$TARDIR_NAME.tgz" -C "$SPARK_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
 fi


### PR DESCRIPTION
Changes the place where we put dist so it conforms to maven layout

org/apache/spark/spark-dist/$version/spark-dist-$version.tgz

@pwoody @ash211 @mccheah . I will have to merge it to test.