### PR TITLE
DatasourceScanExec uses runtime sparksession

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -71,16 +71,17 @@ object FileSourceStrategy extends Strategy with Logging {
         }
       }
 
+      val sparkSession = SparkSession.getActiveSession.get
       val partitionColumns =
         l.resolve(
-          fsRelation.partitionSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
+          fsRelation.partitionSchema, sparkSession.sessionState.analyzer.resolver)
       val partitionSet = AttributeSet(partitionColumns)
       val partitionKeyFilters =
         ExpressionSet(normalizedFilters.filter(_.references.subsetOf(partitionSet)))
       logInfo(s"Pruning directories with: ${partitionKeyFilters.mkString(",")}")
 
       val dataColumns =
-        l.resolve(fsRelation.dataSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
+        l.resolve(fsRelation.dataSchema, sparkSession.sessionState.analyzer.resolver)
 
       // Partition keys are not available in the statistics of the files.
       val dataFilters = normalizedFilters.filter(_.references.intersect(partitionSet).isEmpty)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
@@ -47,7 +48,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         }
       }
 
-      val sparkSession = fsRelation.sparkSession
+      val sparkSession = SparkSession.getActiveSession.get
       val partitionColumns =
         logicalRelation.resolve(
           partitionSchema, sparkSession.sessionState.analyzer.resolver)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -22,13 +22,15 @@ import java.net.URI
 import java.sql.{Date, Timestamp}
 
 import com.google.common.collect.{HashMultiset, Multiset}
-import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path, RawLocalFileSystem}
+
+import org.apache.hadoop.fs.{FSDataInputStream, FileSystem, Path, RawLocalFileSystem}
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.{DataSourceScanExec, FileSourceScanExec}
+import org.apache.spark.sql.execution.datasources.FileScanRDD
 import org.apache.spark.sql.execution.datasources.parquet.TestingUDT.{NestedStruct, NestedStructUDT, SingleElement}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
@@ -835,6 +837,37 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
         val columnMiss: Column = df.col("value").eqNullSafe(newDate)
         val filterMiss = df.filter(columnMiss)
         assert(filterMiss.rdd.partitions.length == 0 && filterMiss.count == 0)
+      }
+    }
+  }
+
+  test("DataSourceScanExec uses active spark session") {
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        dir.getAbsoluteFile
+        val path = "file://" + dir.getCanonicalPath
+        spark.range(4).coalesce(1).write.parquet(path)
+        val df = spark.read.parquet(path)
+
+        val Some((scan1, fileScanRDD1)) = df.queryExecution.executedPlan.collectFirst {
+          case scan: FileSourceScanExec if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+            (scan, scan.inputRDDs().head.asInstanceOf[FileScanRDD])
+        }
+
+        val supportsBatchInitially = scan1.supportsBatch
+
+        val newSession = spark.newSession()
+        newSession.conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, "false")
+        SparkSession.setActiveSession(newSession)
+        val Some((scan2, fileScanRDD2)) = df.queryExecution.executedPlan.collectFirst {
+          case scan: FileSourceScanExec if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+            (scan, scan.inputRDDs().head.asInstanceOf[FileScanRDD])
+        }
+
+        assert(scan1 == scan2)
+        assert(supportsBatchInitially)
+        assert(supportsBatchInitially != scan2.supportsBatch)
+        assert(fileScanRDD1 != fileScanRDD2)
       }
     }
   }


### PR DESCRIPTION
Very annoying feature of datasources where they would use sparksession from the time of creation. This should convert it to use the one that's active when executing. @pwoody @ash211 @mccheah 

Will send upstream once we iron out the tests