### PR TITLE
[SPARK-20001] Conda Runner & full Python conda support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,16 @@ machine:
   post:
     - sudo apt-get --assume-yes install r-base r-base-dev
     - pyenv global 2.7.11 3.4.4 #pypy-4.0.1
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - $CONDA_BIN config --set always_yes yes --set changeps1 no
+    - $CONDA_BIN update -q conda
+      # Useful for debugging any issues with conda
+    - $CONDA_BIN info -a
   environment:
     TERM: dumb
     R_HOME: /usr/lib/R
+    CONDA_BIN: $HOME/miniconda/bin/conda
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,15 @@ machine:
     version: oraclejdk8
   post:
     - sudo apt-get --assume-yes install r-base r-base-dev
-    - pyenv install miniconda3-latest --skip-existing
-    - ln -s $(pyenv root)/versions/miniconda3-latest ~/miniconda
+    - |
+      if [[ ! -d ${CONDA_ROOT} ]]; then
+          echo "Installing Miniconda...";
+          wget --quiet https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh &&
+            bash Miniconda-latest-Linux-x86_64.sh -b -p ${CONDA_ROOT};
+      else
+          echo "Using cached Miniconda install";
+      fi
+    - ln -s ~/miniconda $(pyenv root)/versions/miniconda3-latest
     - 'pyenv versions | grep -q miniconda3-latest/envs/python2 || $CONDA_BIN create -y -n python2 python==2.7.11 numpy'
     - 'pyenv versions | grep -q miniconda3-latest/envs/python3 || $CONDA_BIN create -y -n python3 python==3.4.4 numpy'
     - pyenv global miniconda3-latest/envs/python2 miniconda3-latest/envs/python3 #pypy-4.0.1
@@ -13,6 +20,7 @@ machine:
     TERM: dumb
     R_HOME: /usr/lib/R
     CONDA_BIN: $HOME/miniconda/bin/conda
+    CONDA_ROOT: $HOME/miniconda
 
 checkout:
   post:
@@ -37,6 +45,7 @@ dependencies:
   cache_directories:
     - "build_classes"
     - "build"
+    - "~/miniconda"
 
 general:
   artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -36,9 +36,7 @@ dependencies:
       --include '**/target/analysis/***' --include '**/' --exclude '*' . build_classes/
   cache_directories:
     - "build_classes"
-    - "build/zinc-0.3.11"
-    - "build/apache-maven-3.3.9"
-    - "build/scala-2.11.8"
+    - "build"
 
 general:
   artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -3,13 +3,12 @@ machine:
     version: oraclejdk8
   post:
     - sudo apt-get --assume-yes install r-base r-base-dev
-    - pyenv global 2.7.11 3.4.4 #pypy-4.0.1
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - $CONDA_BIN config --set always_yes yes --set changeps1 no
-    - $CONDA_BIN update -q conda
-      # Useful for debugging any issues with conda
-    - $CONDA_BIN info -a
+    - pyenv install miniconda3-latest --skip-existing
+    - ln -s $(pyenv root)/versions/miniconda3-latest ~/miniconda
+    - 'pyenv versions | grep -q miniconda3-latest/envs/python2 || $CONDA_BIN create -y -n python2 python==2.7.11 numpy'
+    - 'pyenv versions | grep -q miniconda3-latest/envs/python3 || $CONDA_BIN create -y -n python3 python==3.4.4 numpy'
+    - pyenv global miniconda3-latest/envs/python2 miniconda3-latest/envs/python3 #pypy-4.0.1
+    - pyenv rehash
   environment:
     TERM: dumb
     R_HOME: /usr/lib/R
@@ -24,10 +23,6 @@ checkout:
     - echo "host=api.bintray.com" >> .credentials
 
 dependencies:
-  pre:
-    - PYENV_VERSION=2.7.11 pip install numpy
-    - PYENV_VERSION=3.4.4 pip install numpy
-    #- PYENV_VERSION=pypy-4.0.1 pip install numpy
   override:
     - ./build/mvn -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr install
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,10 @@ dependencies:
     #- PYENV_VERSION=pypy-4.0.1 pip install numpy
   override:
     - ./build/mvn -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr install
+  cache_directories:
+    - "build/zinc-0.3.11"
+    - "build/apache-maven-3.3.9"
+    - "build/scala-2.11.8"
 
 general:
   artifacts:

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1868,8 +1868,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * https://conda.io/docs/spec.html#build-version-spec">package match specification</a>
    * for all tasks to be executed on this SparkContext in the future.
    */
-  def addCondaPackages(packages: Seq[String], withDeps: Boolean): Unit = {
-    condaEnvironment().installPackages(packages, withDeps)
+  def addCondaPackages(packages: Seq[String]): Unit = {
+    condaEnvironment().installPackages(packages)
   }
 
   def addCondaChannel(url: String): Unit = {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -71,7 +71,7 @@ class SparkEnv (
 
   private[spark] var isStopped = false
 
-  case class PythonWorkerKey(pythonExec: String, envVars: Map[String, String],
+  case class PythonWorkerKey(pythonExec: Option[String], envVars: Map[String, String],
                              condaPackages: List[String])
   private val pythonWorkers = mutable.HashMap[PythonWorkerKey, PythonWorkerFactory]()
 
@@ -113,7 +113,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def createPythonWorker(pythonExec: String, envVars: Map[String, String],
+  def createPythonWorker(pythonExec: Option[String], envVars: Map[String, String],
                          condaPackages: List[String]): java.net.Socket = {
     synchronized {
       val key = PythonWorkerKey(pythonExec, envVars, condaPackages)
@@ -123,7 +123,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def destroyPythonWorker(pythonExec: String, envVars: Map[String, String],
+  def destroyPythonWorker(pythonExec: Option[String], envVars: Map[String, String],
                           condaPackages: List[String], worker: Socket) {
     synchronized {
       val key = PythonWorkerKey(pythonExec, envVars, condaPackages)
@@ -132,7 +132,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def releasePythonWorker(pythonExec: String, envVars: Map[String, String],
+  def releasePythonWorker(pythonExec: Option[String], envVars: Map[String, String],
                           condaPackages: List[String], worker: Socket) {
     synchronized {
       val key = PythonWorkerKey(pythonExec, envVars, condaPackages)

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -16,15 +16,23 @@
  */
 package org.apache.spark.api.conda
 
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.{Map => JMap}
 
 import scala.sys.process.Process
 
 import org.apache.spark.internal.Logging
 
-final case class CondaEnvironment(condaEnvDir: String) extends Logging {
+final case class CondaEnvironment(condaEnvDir: Path) extends Logging {
+  def this(condaEnvDir: String) = this(Paths.get(condaEnvDir))
+
+  def envRoot: Path = condaEnvDir.getParent
+
+  def envName: String = condaEnvDir.getFileName.toString
+
   def activatedEnvironment(startEnv: Map[String, String] = Map.empty): Map[String, String] = {
-    val newStartEnv: Seq[(String, String)] = (startEnv + ("CONDA_PREFIX" -> condaEnvDir)).toSeq
+    val newStartEnv = (startEnv + ("CONDA_PREFIX" -> condaEnvDir.toString)).toSeq
     // Activate the conda environment, then capture the environment
     val env0sep = Process(List("bash", "-c",
       s"source $$CONDA_PREFIX/bin/activate $$CONDA_PREFIX && " +

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -45,8 +45,8 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
   val condaEnvDir: Path = rootPath.resolve("envs").resolve(envName)
 
   def activatedEnvironment(startEnv: Map[String, String] = Map.empty): Map[String, String] = {
-    require(!startEnv.contains("PATH"),
-      s"It's not allowed to define PATH in the startEnv, but found: ${startEnv("PATH")}")
+    require(!startEnv.contains("PATH"), "Defining PATH in a CondaEnvironment's startEnv is " +
+      s"prohibited; found PATH=${startEnv("PATH")}")
     import collection.JavaConverters._
     val newVars = System.getenv().asScala.toIterator ++ startEnv ++ List(
       "CONDA_PREFIX" -> condaEnvDir.toString,

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -35,8 +35,7 @@ final case class CondaEnvironment(condaEnvDir: Path) extends Logging {
     val newStartEnv = (startEnv + ("CONDA_PREFIX" -> condaEnvDir.toString)).toSeq
     // Activate the conda environment, then capture the environment
     val env0sep = Process(List("bash", "-c",
-      s"source $$CONDA_PREFIX/bin/activate $$CONDA_PREFIX && " +
-        "/usr/local/opt/coreutils/libexec/gnubin/env -0"),
+      s"source $$CONDA_PREFIX/bin/activate $$CONDA_PREFIX && env -0"),
       None, newStartEnv: _*).!!
     env0sep.split('\u0000').iterator.filter(_.trim.nonEmpty).map(_.split("=", 2) match {
       case Array(k, v) => (k, v)

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -42,7 +42,7 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
   private[this] val packages = mutable.Buffer(bootstrapPackages: _*)
   private[this] val channels = bootstrapChannels.toBuffer
 
-  val condaEnvDir: Path = rootPath resolve "envs" resolve envName
+  val condaEnvDir: Path = rootPath.resolve("envs").resolve(envName)
 
   def activatedEnvironment(startEnv: Map[String, String] = Map.empty): Map[String, String] = {
     require(!startEnv.contains("PATH"),
@@ -51,7 +51,7 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
     val newVars = System.getenv().asScala.toIterator ++ startEnv ++ List(
       "CONDA_PREFIX" -> condaEnvDir.toString,
       "CONDA_DEFAULT_ENV" -> condaEnvDir.toString,
-      "PATH" -> ((condaEnvDir resolve "bin").toString +
+      "PATH" -> (condaEnvDir.resolve("bin").toString +
         sys.env.get("PATH").map(File.pathSeparator + _).getOrElse(""))
     )
     newVars.toMap

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.api.conda
+
+import java.util.{Map => JMap}
+
+import scala.sys.process.Process
+
+import org.apache.spark.internal.Logging
+
+final case class CondaEnvironment(condaEnvDir: String) extends Logging {
+  def activatedEnvironment(startEnv: Map[String, String] = Map.empty): Map[String, String] = {
+    val newStartEnv: Seq[(String, String)] = (startEnv + ("CONDA_PREFIX" -> condaEnvDir)).toSeq
+    // Activate the conda environment, then capture the environment
+    val env0sep = Process(List("bash", "-c",
+      s"source $$CONDA_PREFIX/bin/activate $$CONDA_PREFIX && " +
+        "/usr/local/opt/coreutils/libexec/gnubin/env -0"),
+      None, newStartEnv: _*).!!
+    env0sep.split('\u0000').iterator.filter(_.trim.nonEmpty).map(_.split("=", 2) match {
+      case Array(k, v) => (k, v)
+      case arr => sys.error(s"Unparseable env var: ${arr.toSeq}")
+    }).toMap
+  }
+
+  /**
+   * Clears the given java environment and replaces all variables with the environment
+   * produced after calling `activate` inside this conda environment.
+   */
+  def initializeJavaEnvironment(env: JMap[String, String]): Unit = {
+    env.clear()
+    val activatedEnv = activatedEnvironment()
+    activatedEnv.foreach { case (k, v) => env.put(k, v) }
+    logDebug(s"Initialised environment from conda: $activatedEnv")
+  }
+}
+
+object CondaEnvironment {
+  private[spark] val CONDA_ENVIRONMENT_PREFIX = "spark.conda.environmentPrefix"
+
+  /** Returns the environment if one was already set up in this JVM */
+  def fromSystemProperty(): Option[CondaEnvironment] = {
+    sys.props.get(CONDA_ENVIRONMENT_PREFIX).map(new CondaEnvironment(_))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -139,10 +139,10 @@ object CondaEnvironmentManager {
 
   def fromConf(sparkConf: SparkConf): CondaEnvironmentManager = {
     val condaBinaryPath = sparkConf.get(CONDA_BINARY_PATH).getOrElse(
-      sys.error(s"Expected $CONDA_BINARY_PATH to be set"))
+      sys.error(s"Expected config ${CONDA_BINARY_PATH.key} to be set"))
     val condaChannelUrls = sparkConf.get(CONDA_CHANNEL_URLS)
     require(condaChannelUrls.nonEmpty,
-      s"Must define at least one conda channel in $CONDA_CHANNEL_URLS")
+      s"Must define at least one conda channel in config ${CONDA_CHANNEL_URLS.key}")
     val verbosity = sparkConf.get(CONDA_VERBOSITY)
     new CondaEnvironmentManager(condaBinaryPath, condaChannelUrls, verbosity)
   }

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.api.conda
+
+import scala.sys.process.Process
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.CONDA_BINARY_PATH
+import org.apache.spark.internal.config.CONDA_CHANNEL_URLS
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkException
+
+final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: Seq[String])
+    extends Logging {
+  require(condaChannelUrls.nonEmpty, "Can't have an empty list of conda channel URLs")
+
+  def create(condaEnvDir: String, bootstrapDeps: Seq[String]): CondaEnvironment = {
+    require(bootstrapDeps.nonEmpty, "Expected at least one bootstrap dependency.")
+    // Attempt to create environment
+    val command = Process(
+      List(condaBinaryPath, "create", "-p", condaEnvDir, "-y", "--override-channels")
+        ++: condaChannelUrls.flatMap(Iterator("--channel", _))
+        ++: bootstrapDeps)
+    logInfo(s"About to execute: $command")
+    val exitCode = command.!
+    if (exitCode != 0) {
+      throw new SparkException("Attempt to create conda env exited with code: "
+        + f"$exitCode%nCommand was: $command")
+    }
+
+    new CondaEnvironment(condaEnvDir)
+  }
+
+  def installPackages(condaEnv: CondaEnvironment, deps: String*): Unit = {
+    val command = Process(
+      List(condaBinaryPath, "install", "-p", condaEnv.condaEnvDir, "-y", "--override-channels")
+        ++: condaChannelUrls.flatMap(Iterator("--channel", _))
+        ++: deps)
+    logInfo(s"About to execute: $command")
+    val exitCode = command.!
+    if (exitCode != 0) {
+      throw new SparkException("Attempt to install dependencies in conda env exited with code: "
+        + f"$exitCode%nCommand was: $command")
+    }
+  }
+
+  /** For use from pyspark. */
+  def installPackage(condaEnv: CondaEnvironment, dep: String): Unit = {
+    installPackages(condaEnv, dep)
+  }
+}
+
+object CondaEnvironmentManager {
+  def isConfigured(sparkConf: SparkConf): Boolean = {
+    sparkConf.contains(CONDA_BINARY_PATH)
+  }
+
+  def fromConf(sparkConf: SparkConf): CondaEnvironmentManager = {
+    val condaBinaryPath = sparkConf.get(CONDA_BINARY_PATH).getOrElse(
+      sys.error(s"Expected $CONDA_BINARY_PATH to be set"))
+    val condaChannelUrls = sparkConf.get(CONDA_CHANNEL_URLS)
+    require(condaChannelUrls.nonEmpty,
+      s"Must define at least one conda channel in $CONDA_CHANNEL_URLS")
+    new CondaEnvironmentManager(condaBinaryPath, condaChannelUrls)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -87,6 +87,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
          | - $condaPkgsPath
          |envs_dirs:
          | - $baseRoot/envs
+         |show_channel_urls: false
       """.stripMargin
     Files.write(condarc, List(condarcContents).asJava)
     logInfo(f"Using condarc at $condarc:%n$condarcContents")

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -95,18 +95,23 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
     // Attempt to create fake home dir
     Files.createDirectories(fakeHomeDir)
 
-    val command = Process(
-      condaBinaryPath :: args,
-      None,
+    val extraEnv = List(
       "CONDARC" -> condarc.toString,
       "HOME" -> fakeHomeDir.toString
     )
 
+    val command = Process(
+      condaBinaryPath :: args,
+      None,
+      extraEnv: _*
+    )
+
+    logInfo(s"About to execute $command with environment $extraEnv")
     runOrFail(command, description)
+    logInfo(s"Successfully executed $command with environment $extraEnv")
   }
 
   private[this] def runOrFail(command: ProcessBuilder, description: String): Unit = {
-    logInfo(s"About to execute: $command")
     val buffer = new StringBuffer
     val collectErrOutToBuffer = new ProcessIO(
     BasicIO.input(false),

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -46,9 +46,9 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
     // must link in /tmp to reduce path length in case baseDir is very long...
     // If baseDir path is too long, this breaks conda's 220 character limit for binary replacement.
     // Don't even try to use java.io.tmpdir - yarn sets this to a very long path
-    val linkedBaseDir = Utils.createTempDir("/tmp", "conda").toPath resolve "real"
+    val linkedBaseDir = Utils.createTempDir("/tmp", "conda").toPath.resolve("real")
     logInfo(s"Creating symlink $linkedBaseDir -> $baseDir")
-    Files.createSymbolicLink(linkedBaseDir, Paths get baseDir)
+    Files.createSymbolicLink(linkedBaseDir, Paths.get(baseDir))
 
     // Attempt to create environment
     runCondaProcess(
@@ -73,8 +73,8 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
    * This hack is necessary otherwise conda tries to use the homedir for pkgs cache.
    */
   private[this] def generateCondarc(baseRoot: Path): Path = {
-    val condaPkgsPath = Paths.get(condaBinaryPath).getParent.getParent resolve "pkgs"
-    val condarc = baseRoot resolve "condarc"
+    val condaPkgsPath = Paths.get(condaBinaryPath).getParent.getParent.resolve("pkgs")
+    val condarc = baseRoot.resolve("condarc")
     val condarcContents =
       s"""pkgs_dirs:
          | - $baseRoot/pkgs
@@ -91,7 +91,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
                                      args: List[String],
                                      description: String): Unit = {
     val condarc = generateCondarc(baseRoot)
-    val fakeHomeDir = baseRoot resolve "home"
+    val fakeHomeDir = baseRoot.resolve("home")
     // Attempt to create fake home dir
     Files.createDirectories(fakeHomeDir)
 

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -700,8 +700,8 @@ class JavaSparkContext(val sc: SparkContext)
    * https://conda.io/docs/spec.html#build-version-spec">package match specification</a>
    * for all tasks to be executed on this SparkContext in the future.
    */
-  def addCondaPackages(packages: java.util.List[String], withDeps: Boolean): Unit = {
-    sc.addCondaPackages(packages.asScala, withDeps)
+  def addCondaPackages(packages: java.util.List[String]): Unit = {
+    sc.addCondaPackages(packages.asScala)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -696,6 +696,15 @@ class JavaSparkContext(val sc: SparkContext)
   }
 
   /**
+   * Add a set of conda packages (identified by <a href="
+   * https://conda.io/docs/spec.html#build-version-spec">package match specification</a>
+   * for all tasks to be executed on this SparkContext in the future.
+   */
+  def addCondaPackages(packages: java.util.List[String], withDeps: Boolean): Unit = {
+    sc.addCondaPackages(packages.asScala, withDeps)
+  }
+
+  /**
    * Returns the Hadoop configuration used for the Hadoop code (e.g. file systems) we reuse.
    *
    * @note As it will be reused in all Hadoop RDDs, it's better not to modify it unless you

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -72,6 +72,7 @@ private[spark] case class PythonFunction(
     command: Array[Byte],
     envVars: JMap[String, String],
     pythonIncludes: JList[String],
+    condaPackages: JList[String],
     pythonExec: String,
     pythonVer: String,
     broadcastVars: JList[Broadcast[PythonBroadcast]],

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -111,23 +111,14 @@ private[spark] class PythonRunner(
   private[this] val localdirs =
     SparkEnv.get.blockManager.diskBlockManager.localDirs.map(f => f.getPath).mkString(",")
 
-  private[this] val firstFunc = funcs.head.funcs.head
-
   // All the Python functions should have the same exec, version and envvars.
-  private[this] val envVars = {
-    val vars = firstFunc.envVars
-    vars.put("SPARK_LOCAL_DIRS", localdirs) // it's also used in monitor thread
-    if (reuse_worker) {
-      vars.put("SPARK_REUSE_WORKER", "1")
-    }
-    vars.asScala.toMap
-  }
-  private[this] val pythonExec = firstFunc.pythonExec
-  private[this] val pythonVer = firstFunc.pythonVer
-  private[this] val condaInstructions = firstFunc.condaSetupInstructions
+  private val envVars = funcs.head.funcs.head.envVars
+  private val pythonExec = funcs.head.funcs.head.pythonExec
+  private val pythonVer = funcs.head.funcs.head.pythonVer
+  private val condaInstructions = funcs.head.funcs.head.condaSetupInstructions
 
   // TODO: support accumulator in multiple UDF
-  private[this] val accumulator = firstFunc.accumulator
+  private val accumulator = funcs.head.funcs.head.accumulator
 
   def compute(
       inputIterator: Iterator[_],
@@ -135,15 +126,20 @@ private[spark] class PythonRunner(
       context: TaskContext): Iterator[Array[Byte]] = {
     val startTime = System.currentTimeMillis
     val env = SparkEnv.get
-
-    val worker: Socket = env.createPythonWorker(pythonExec, envVars, condaInstructions)
+    val localdir = env.blockManager.diskBlockManager.localDirs.map(f => f.getPath()).mkString(",")
+    envVars.put("SPARK_LOCAL_DIRS", localdirs) // it's also used in monitor thread
+    if (reuse_worker) {
+      envVars.put("SPARK_REUSE_WORKER", "1")
+    }
+    val worker: Socket = env
+      .createPythonWorker(pythonExec, envVars.asScala.toMap, condaInstructions)
     // Whether the worker is released into the idle pool
     @volatile var released = false
 
     // Start a thread to feed the process input from our parent's iterator
     val writerThread = new WriterThread(env, worker, inputIterator, partitionIndex, context)
 
-    context.addTaskCompletionListener { _ =>
+    context.addTaskCompletionListener { context =>
       writerThread.shutdownOnTaskCompletion()
       if (!reuse_worker || !released) {
         try {
@@ -216,7 +212,7 @@ private[spark] class PythonRunner(
               // Check whether the worker is ready to be re-used.
               if (stream.readInt() == SpecialLengths.END_OF_STREAM) {
                 if (reuse_worker) {
-                  env.releasePythonWorker(pythonExec, envVars, condaInstructions, worker)
+                  env.releasePythonWorker(pythonExec, envVars.asScala.toMap, condaInstructions, worker)
                   released = true
                 }
               }
@@ -336,7 +332,7 @@ private[spark] class PythonRunner(
           }
         } else {
           dataOut.writeInt(0)
-          val command = firstFunc.command
+          val command = funcs.head.funcs.head.command
           dataOut.writeInt(command.length)
           dataOut.write(command)
         }
@@ -382,7 +378,7 @@ private[spark] class PythonRunner(
       if (!context.isCompleted) {
         try {
           logWarning("Incomplete task interrupted: Attempting to kill Python Worker")
-          env.destroyPythonWorker(pythonExec, envVars, condaInstructions, worker)
+          env.destroyPythonWorker(pythonExec, envVars.asScala.toMap, condaInstructions, worker)
         } catch {
           case e: Exception =>
             logError("Exception when trying to kill worker", e)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -73,7 +73,7 @@ private[spark] case class PythonFunction(
     envVars: JMap[String, String],
     pythonIncludes: JList[String],
     condaPackages: JList[String],
-    pythonExec: String,
+    pythonExec: Option[String],
     pythonVer: String,
     broadcastVars: JList[Broadcast[PythonBroadcast]],
     accumulator: PythonAccumulatorV2)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -212,7 +212,8 @@ private[spark] class PythonRunner(
               // Check whether the worker is ready to be re-used.
               if (stream.readInt() == SpecialLengths.END_OF_STREAM) {
                 if (reuse_worker) {
-                  env.releasePythonWorker(pythonExec, envVars.asScala.toMap, condaInstructions, worker)
+                  env.releasePythonWorker(pythonExec, envVars.asScala.toMap,
+                    condaInstructions, worker)
                   released = true
                 }
               }

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -27,7 +27,6 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark._
 import org.apache.spark.api.conda.CondaEnvironment.CondaSetupInstructions
-import org.apache.spark.api.conda.CondaEnvironment.PackageRequests
 import org.apache.spark.api.conda.CondaEnvironmentManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.CONDA_BOOTSTRAP_PACKAGES
@@ -70,14 +69,7 @@ private[spark] class PythonWorkerFactory(requestedPythonExec: Option[String],
         val dirId = hash % localDirs.length
         Utils.createTempDir(localDirs(dirId).getAbsolutePath, "conda").getAbsolutePath
       }
-      val condaBootstrapPackages = env.conf.get(CONDA_BOOTSTRAP_PACKAGES)
-      val condaEnvironment = condaEnvManager.create(envDir, condaBootstrapPackages)
-      // Now install as per the instructions
-      condaPackages.foreach {
-        case PackageRequests(pkgs, withDeps) =>
-          condaEnvironment.installPackages(pkgs, withDeps)
-      }
-      condaEnvironment
+      condaEnvManager.create(envDir, condaPackages)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -79,13 +79,12 @@ private[spark] class PythonWorkerFactory(requestedPythonExec: Option[String],
 
   private[this] val pythonExec = {
     condaEnv.map { conda =>
-      requestedPythonExec.foreach(exec => sys.error(
-        s"It's forbidden to set the PYSPARK_PYTHON when using conda, but found: $exec"))
+      requestedPythonExec.foreach(exec => sys.error(s"It's forbidden to set the PYSPARK_PYTHON " +
+        s"when using conda, but found: $exec"))
 
       conda.condaEnvDir + "/bin/python"
-    }
-      .orElse(requestedPythonExec)
-      .getOrElse("python")
+    }.orElse(requestedPythonExec)
+     .getOrElse("python")
   }
 
   val pythonPath = PythonUtils.mergePythonPaths(

--- a/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
@@ -34,11 +34,11 @@ abstract class CondaRunner extends Logging {
 
     if (CondaEnvironmentManager.isConfigured(sparkConf)) {
       val condaBootstrapDeps = sparkConf.get(CONDA_BOOTSTRAP_PACKAGES)
-      val condaEnvDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), "conda").getAbsolutePath
+      val condaBaseDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), "conda").getAbsolutePath
       val condaEnvironmentManager = CondaEnvironmentManager.fromConf(sparkConf)
-      val environment = condaEnvironmentManager.create(condaEnvDir, condaBootstrapDeps)
+      val environment = condaEnvironmentManager.create(condaBaseDir, condaBootstrapDeps)
 
-      sys.props += CondaEnvironment.CONDA_ENVIRONMENT_PREFIX -> condaEnvDir
+      sys.props += CondaEnvironment.CONDA_ENVIRONMENT_PREFIX -> environment.condaEnvDir.toString
 
       run(args, Some(environment))
     } else {

--- a/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
@@ -38,7 +38,9 @@ abstract class CondaRunner extends Logging {
       val condaEnvironmentManager = CondaEnvironmentManager.fromConf(sparkConf)
       val environment = condaEnvironmentManager.create(condaBaseDir, condaBootstrapDeps)
 
-      sys.props += CondaEnvironment.CONDA_ENVIRONMENT_PREFIX -> environment.condaEnvDir.toString
+      // Save this as a global in order for SparkContext to be able to access it later, in case we
+      // are shelling out, but providing a bridge back into this JVM.
+      CondaRunner.condaEnvironment = Some(environment)
 
       run(args, Some(environment))
     } else {
@@ -47,4 +49,8 @@ abstract class CondaRunner extends Logging {
   }
 
   def run(args: Array[String], maybeConda: Option[CondaEnvironment]): Unit
+}
+
+object CondaRunner {
+  private[spark] var condaEnvironment: Option[CondaEnvironment] = None
 }

--- a/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import org.apache.spark.SparkConf
+import org.apache.spark.api.conda.CondaEnvironment
+import org.apache.spark.api.conda.CondaEnvironmentManager
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.util.Utils
+
+/**
+ * A runner template used to launch applications using Conda. It bootstraps a Conda env,
+ * then delegates to the [[CondaRunner.run]].
+ */
+abstract class CondaRunner extends Logging {
+  final def main(args: Array[String]): Unit = {
+    val sparkConf = new SparkConf()
+
+    if (CondaEnvironmentManager.isConfigured(sparkConf)) {
+      val condaBootstrapDeps = sparkConf.get(CONDA_BOOTSTRAP_PACKAGES)
+      val condaEnvDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), "conda").getAbsolutePath
+      val condaEnvironmentManager = CondaEnvironmentManager.fromConf(sparkConf)
+      val environment = condaEnvironmentManager.create(condaEnvDir, condaBootstrapDeps)
+
+      sys.props += CondaEnvironment.CONDA_ENVIRONMENT_PREFIX -> condaEnvDir
+
+      run(args, Some(environment))
+    } else {
+      run(args, None)
+    }
+  }
+
+  def run(args: Array[String], maybeConda: Option[CondaEnvironment]): Unit
+}

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.deploy
 
 import java.io.File
-import java.lang.ProcessBuilder.Redirect
 import java.net.URI
 
 import scala.collection.mutable.ArrayBuffer
@@ -54,9 +53,8 @@ object PythonRunner extends CondaRunner with Logging {
           s"It's forbidden to set the PYSPARK python path when using conda, but found: $exec")
       }
       conda.condaEnvDir + "/bin/python"
-    }
-      .orElse(presetPythonExec)
-      .getOrElse("python")
+    }.orElse(presetPythonExec)
+     .getOrElse("python")
 
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
@@ -104,7 +102,6 @@ object PythonRunner extends CondaRunner with Logging {
     sys.env.get("PYTHONHASHSEED").foreach(env.put("PYTHONHASHSEED", _))
     builder.redirectErrorStream(true)
     try {
-      logInfo(s"About to start python process: ${builder.command()}")
       val process = builder.start()
 
       new RedirectThread(process.getInputStream, System.out, "redirect output").start()

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -113,9 +113,8 @@ object PythonRunner extends CondaRunner with Logging {
     // pass conf spark.pyspark.python to python process, the only way to pass info to
     // python process is through environment variable.
     sparkConf.get(PYSPARK_PYTHON).foreach(env.put("PYSPARK_PYTHON", _))
-
     sys.env.get("PYTHONHASHSEED").foreach(env.put("PYTHONHASHSEED", _))
-    builder.redirectErrorStream(true)
+    builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
     try {
       val process = builder.start()
 

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -48,13 +48,11 @@ object PythonRunner extends CondaRunner with Logging {
       .orElse(sys.env.get("PYSPARK_PYTHON"))
 
     val pythonExec = maybeConda.map { conda =>
-      val actualBinFile = presetPythonExec.map { exec =>
-        require (!exec.contains("/"), s"It's forbidden to set the PYSPARK python path " +
-          s"to anything but a file name when using conda, but found: $exec")
-        exec
-      }.getOrElse("python")
-
-      conda.condaEnvDir + "/bin/" + actualBinFile
+      presetPythonExec.foreach { exec =>
+        sys.error(
+          s"It's forbidden to set the PYSPARK python path when using conda, but found: $exec")
+      }
+      conda.condaEnvDir + "/bin/python"
     }
       .orElse(presetPythonExec)
       .getOrElse("python")

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -56,6 +56,8 @@ object PythonRunner extends CondaRunner with Logging {
     }.orElse(presetPythonExec)
      .getOrElse("python")
 
+    logInfo(s"Python binary that will be called: $pythonExec")
+
     // Format python file paths before adding them to the PYTHONPATH
     val formattedPythonFile = formatPath(pythonFile)
     val formattedPyFiles = formatPaths(pyFiles)

--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -41,16 +41,18 @@ object RRunner extends CondaRunner {
 
     // Time to wait for SparkR backend to initialize in seconds
     val backendTimeout = sys.env.getOrElse("SPARKR_BACKEND_TIMEOUT", "120").toInt
-    val rCommand = maybeConda.map(_.condaEnvDir + "/bin/r").getOrElse {
-      // "spark.sparkr.r.command" is deprecated and replaced by "spark.r.command",
-      // but kept here for backward compatibility.
-      var cmd = sys.props.getOrElse("spark.sparkr.r.command", "Rscript")
-      cmd = sys.props.getOrElse("spark.r.command", cmd)
-      if (sys.props.getOrElse("spark.submit.deployMode", "client") == "client") {
-        cmd = sys.props.getOrElse("spark.r.driver.command", cmd)
+    val rCommand = maybeConda
+      .map(_ => sys.error("RRunner doesn't support running from a Conda environment yet."))
+      .getOrElse {
+        // "spark.sparkr.r.command" is deprecated and replaced by "spark.r.command",
+        // but kept here for backward compatibility.
+        var cmd = sys.props.getOrElse("spark.sparkr.r.command", "Rscript")
+        cmd = sys.props.getOrElse("spark.r.command", cmd)
+        if (sys.props.getOrElse("spark.submit.deployMode", "client") == "client") {
+          cmd = sys.props.getOrElse("spark.r.driver.command", cmd)
+        }
+        cmd
       }
-      cmd
-    }
 
     //  Connection timeout set by R process on its connection to RBackend in seconds.
     val backendConnectionTimeout = sys.props.getOrElse(

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -188,12 +188,6 @@ package object config {
     .stringConf
     .createOptional
 
-  private[spark] val CONDA_DELEGATE_RUNNER = ConfigBuilder("spark.conda.delegateRunnerClass")
-    .doc("The runner class to delegate to after the Conda environment has been set up. "
-      + "Only relevant when main class is CondaRunner.")
-    .stringConf
-    .createOptional
-
   // To limit memory usage, we only track information for a fixed number of tasks
   private[spark] val UI_RETAINED_TASKS = ConfigBuilder("spark.ui.retainedTasks")
     .intConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -169,6 +169,31 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val CONDA_BOOTSTRAP_PACKAGES = ConfigBuilder("spark.conda.bootstrapPackages")
+    .doc("The packages that will be added to the conda environment. "
+      + "Only relevant when main class is CondaRunner.")
+    .stringConf
+    .toSequence
+    .createWithDefault(Nil)
+
+  private[spark] val CONDA_CHANNEL_URLS = ConfigBuilder("spark.conda.channelUrls")
+    .doc("The URLs the Conda channels to use when resolving the conda packages. "
+      + "Only relevant when main class is CondaRunner.")
+    .stringConf
+    .toSequence
+    .createWithDefault(Nil)
+
+  private[spark] val CONDA_BINARY_PATH = ConfigBuilder("spark.conda.binaryPath")
+    .doc("The location of the conda binary. Only relevant when main class is CondaRunner.")
+    .stringConf
+    .createOptional
+
+  private[spark] val CONDA_DELEGATE_RUNNER = ConfigBuilder("spark.conda.delegateRunnerClass")
+    .doc("The runner class to delegate to after the Conda environment has been set up. "
+      + "Only relevant when main class is CondaRunner.")
+    .stringConf
+    .createOptional
+
   // To limit memory usage, we only track information for a fixed number of tasks
   private[spark] val UI_RETAINED_TASKS = ConfigBuilder("spark.ui.retainedTasks")
     .intConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -188,6 +188,11 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val CONDA_VERBOSITY = ConfigBuilder("spark.conda.verbosity")
+    .doc("How many times to apply -v to conda. A number between 0 and 3, with 0 being default.")
+    .intConf
+    .createWithDefault(0)
+
   // To limit memory usage, we only track information for a fixed number of tasks
   private[spark] val UI_RETAINED_TASKS = ConfigBuilder("spark.ui.retainedTasks")
     .intConf

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -64,7 +64,10 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.TaskData.<init>$default$11"),
 
     // [SPARK-17161] Removing Python-friendly constructors not needed
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.OneVsRestModel.this")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.OneVsRestModel.this"),
+
+    // CondaRunner is meant to own the main() method then delegate to another method
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.deploy.CondaRunner.main")
   )
 
   // Exclude rules for 2.1.x

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -49,6 +49,9 @@ object MimaExcludes {
     // [SPARK-18537] Add a REST api to spark streaming
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.streaming.scheduler.StreamingListener.onStreamingStarted"),
 
+    // CondaRunner is meant to own the main() method then delegate to another method
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.deploy.CondaRunner.main"),
+
     // [SPARK-19148][SQL] do not expose the external table concept in Catalog
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.catalog.Catalog.createTable"),
 
@@ -64,10 +67,7 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.TaskData.<init>$default$11"),
 
     // [SPARK-17161] Removing Python-friendly constructors not needed
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.OneVsRestModel.this"),
-
-    // CondaRunner is meant to own the main() method then delegate to another method
-    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.deploy.CondaRunner.main")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.classification.OneVsRestModel.this")
   )
 
   // Exclude rules for 2.1.x

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -190,7 +190,7 @@ class SparkContext(object):
         self._javaAccumulator = self._jvm.PythonAccumulatorV2(host, port)
         self._jsc.sc().register(self._javaAccumulator)
 
-        self.pythonExec = os.environ.get("PYSPARK_PYTHON", 'python')
+        self.pythonExec = self._jvm.scala.Option.apply(os.environ.get("PYSPARK_PYTHON"))
         self.pythonVer = "%d.%d" % sys.version_info[:2]
 
         if sys.version_info < (2, 7):

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -221,9 +221,10 @@ class SparkContext(object):
                                   'MODULE$')
 
         packagesSeq = self._conf.get(internal_config.CONDA_BOOTSTRAP_PACKAGES())
-        packagesList = self._jvm.scala.collection.JavaConversions.seqAsJavaList(packagesSeq)
-        # Add the bootstrap packages to the list to be installed on executors
-        self._conda_packages += (pkg for pkg in packagesList)
+        if packagesSeq is not None:
+            packagesList = self._jvm.scala.collection.JavaConversions.seqAsJavaList(packagesSeq)
+            # Add the bootstrap packages to the list to be installed on executors
+            self._conda_packages += (pkg for pkg in packagesList)
 
         # Deploy code dependencies set by spark-submit; these will already have been added
         # with SparkContext.addFile, so we just need to add them to the PYTHONPATH

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -837,13 +837,13 @@ class SparkContext(object):
             import importlib
             importlib.invalidate_caches()
 
-    def addCondaPackages(self, *packages, withDeps=True):
+    def addCondaPackages(self, *packages):
         """
         Add a conda `package match specification
         <https://conda.io/docs/spec.html#build-version-spec>`_ for all tasks to be executed on
         this SparkContext in the future.
         """
-        self._jsc.addCondaPackages(packages, withDeps)
+        self._jsc.addCondaPackages(packages)
 
     def addCondaChannel(self, url):
         self._jsc.sc().addCondaChannel(url)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -71,6 +71,8 @@ class SparkContext(object):
     _active_spark_context = None
     _lock = RLock()
     _python_includes = None  # zip and egg files that need to be added to PYTHONPATH
+    _conda_packages = None
+    _conda_environ = None
 
     PACKAGE_EXTENSIONS = ('.zip', '.egg', '.jar')
 
@@ -208,6 +210,20 @@ class SparkContext(object):
         self._python_includes = list()
         for path in (pyFiles or []):
             self.addPyFile(path)
+
+        conda_env = self._jvm.CondaEnvironment.fromSystemProperty()
+        if conda_env.isDefined():
+            self._conda_environ = conda_env.get()
+            self._conda_env_manager = self._jvm.CondaEnvironmentManager.fromConf(self._conf._jconf)
+
+        self._conda_packages = list()
+        internal_config = getattr(getattr(self._jvm.org.apache.spark.internal.config, 'package$'),
+                                  'MODULE$')
+
+        packagesSeq = self._conf.get(internal_config.CONDA_BOOTSTRAP_PACKAGES())
+        packagesList = self._jvm.scala.collection.JavaConversions.seqAsJavaList(packagesSeq)
+        # Add the bootstrap packages to the list to be installed on executors
+        self._conda_packages += (pkg for pkg in packagesList)
 
         # Deploy code dependencies set by spark-submit; these will already have been added
         # with SparkContext.addFile, so we just need to add them to the PYTHONPATH
@@ -836,6 +852,17 @@ class SparkContext(object):
         if sys.version > '3':
             import importlib
             importlib.invalidate_caches()
+
+    def addCondaPackage(self, packageMatchSpecification):
+        """
+        Add a conda `package match specification
+        <https://conda.io/docs/spec.html#build-version-spec>`_ for all tasks to be executed on
+        this SparkContext in the future.
+        """
+        if self._conda_environ is None:
+            raise Exception("There is no conda environment set up on the driver")
+        self._conda_env_manager.installPackage(self._conda_environ, packageMatchSpecification)
+        self._conda_packages.append(packageMatchSpecification)
 
     def setCheckpointDir(self, dirName):
         """

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -862,7 +862,8 @@ class SparkContext(object):
         """
         if self._conda_environ is None:
             raise Exception("There is no conda environment set up on the driver")
-        self._conda_env_manager.installPackage(self._conda_environ, packageMatchSpecification)
+        # If the user calls this method, we should install the deps as well.
+        self._conda_env_manager.installPackage(self._conda_environ, packageMatchSpecification, False)
         self._conda_packages.append(packageMatchSpecification)
 
     def setCheckpointDir(self, dirName):

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -115,9 +115,9 @@ def launch_gateway(conf=None):
 
     # Import the classes used by PySpark
     java_import(gateway.jvm, "org.apache.spark.SparkConf")
+    java_import(gateway.jvm, "org.apache.spark.api.conda.*")
     java_import(gateway.jvm, "org.apache.spark.api.java.*")
     java_import(gateway.jvm, "org.apache.spark.api.python.*")
-    java_import(gateway.jvm, "org.apache.spark.api.conda.*")
     java_import(gateway.jvm, "org.apache.spark.ml.python.*")
     java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
     # TODO(davies): move into sql

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -117,6 +117,7 @@ def launch_gateway(conf=None):
     java_import(gateway.jvm, "org.apache.spark.SparkConf")
     java_import(gateway.jvm, "org.apache.spark.api.java.*")
     java_import(gateway.jvm, "org.apache.spark.api.python.*")
+    java_import(gateway.jvm, "org.apache.spark.api.conda.*")
     java_import(gateway.jvm, "org.apache.spark.ml.python.*")
     java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
     # TODO(davies): move into sql

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2371,8 +2371,8 @@ def _wrap_function(sc, func, deserializer, serializer, profiler=None):
     command = (func, profiler, deserializer, serializer)
     pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
     return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
-                                  sc._conda_packages, sc.pythonExec, sc.pythonVer, broadcast_vars,
-                                  sc._javaAccumulator)
+                                  sc._build_conda_instructions(), sc.pythonExec, sc.pythonVer,
+                                  broadcast_vars, sc._javaAccumulator)
 
 
 class PipelinedRDD(RDD):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2362,15 +2362,15 @@ def _prepare_for_python_RDD(sc, command):
         pickled_command = ser.dumps(broadcast)
     broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_vars]
     sc._pickled_broadcast_vars.clear()
-    return pickled_command, broadcast_vars
+    return pickled_command, broadcast_vars, sc.environment, sc._python_includes
 
 
 def _wrap_function(sc, func, deserializer, serializer, profiler=None):
     assert deserializer, "deserializer should not be empty"
     assert serializer, "serializer should not be empty"
     command = (func, profiler, deserializer, serializer)
-    pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
-    return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
+    pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
+    return sc._jvm.PythonFunction(bytearray(pickled_command), env, includes,
                                   sc._build_conda_instructions(), sc.pythonExec, sc.pythonVer,
                                   broadcast_vars, sc._javaAccumulator)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2362,16 +2362,17 @@ def _prepare_for_python_RDD(sc, command):
         pickled_command = ser.dumps(broadcast)
     broadcast_vars = [x._jbroadcast for x in sc._pickled_broadcast_vars]
     sc._pickled_broadcast_vars.clear()
-    return pickled_command, broadcast_vars, sc.environment, sc._python_includes
+    return pickled_command, broadcast_vars
 
 
 def _wrap_function(sc, func, deserializer, serializer, profiler=None):
     assert deserializer, "deserializer should not be empty"
     assert serializer, "serializer should not be empty"
     command = (func, profiler, deserializer, serializer)
-    pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
-    return sc._jvm.PythonFunction(bytearray(pickled_command), env, includes, sc.pythonExec,
-                                  sc.pythonVer, broadcast_vars, sc._javaAccumulator)
+    pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
+    return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
+                                  sc._conda_packages, sc.pythonExec, sc.pythonVer, broadcast_vars,
+                                  sc._javaAccumulator)
 
 
 class PipelinedRDD(RDD):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1858,8 +1858,8 @@ def sort_array(col, asc=True):
 
 def _wrap_function(sc, func, returnType):
     command = (func, returnType)
-    pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
-    return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
+    pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
+    return sc._jvm.PythonFunction(bytearray(pickled_command), env, includes,
                                   sc._build_conda_instructions(), sc.pythonExec, sc.pythonVer,
                                   broadcast_vars, sc._javaAccumulator)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1858,9 +1858,10 @@ def sort_array(col, asc=True):
 
 def _wrap_function(sc, func, returnType):
     command = (func, returnType)
-    pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
-    return sc._jvm.PythonFunction(bytearray(pickled_command), env, includes, sc.pythonExec,
-                                  sc.pythonVer, broadcast_vars, sc._javaAccumulator)
+    pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
+    return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
+                                  sc._conda_packages, sc.pythonExec, sc.pythonVer, broadcast_vars,
+                                  sc._javaAccumulator)
 
 
 class UserDefinedFunction(object):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1860,8 +1860,8 @@ def _wrap_function(sc, func, returnType):
     command = (func, returnType)
     pickled_command, broadcast_vars = _prepare_for_python_RDD(sc, command)
     return sc._jvm.PythonFunction(bytearray(pickled_command), sc.environment, sc._python_includes,
-                                  sc._conda_packages, sc.pythonExec, sc.pythonVer, broadcast_vars,
-                                  sc._javaAccumulator)
+                                  sc._build_conda_instructions(), sc.pythonExec, sc.pythonVer,
+                                  broadcast_vars, sc._javaAccumulator)
 
 
 class UserDefinedFunction(object):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2063,7 +2063,7 @@ class SparkSubmitTests(unittest.TestCase):
                     |from pyspark import SparkContext
                     |
                     |sc = SparkContext()
-                    |sc.addCondaPackage('numpy=1.11.1')
+                    |sc.addCondaPackages('numpy=1.11.1')
                     |
                     |# Ensure numpy is accessible on the driver
                     |import numpy

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2057,6 +2057,35 @@ class SparkSubmitTests(unittest.TestCase):
         out, err = proc.communicate()
         self.assertEqual(0, proc.returncode, msg="Process failed with error:\n {0}".format(out))
 
+    def test_conda(self):
+        """Submit and test a single script file via conda"""
+        script = self.createTempFile("test.py", """
+                    |from pyspark import SparkContext
+                    |
+                    |sc = SparkContext()
+                    |sc.addCondaPackage('numpy=1.11.1')
+                    |
+                    |# Ensure numpy is accessible on the driver
+                    |import numpy
+                    |arr = [1, 2, 3]
+                    |def mul2(x):
+                    |  # Also ensure numpy accessible from executor
+                    |  assert numpy.version.version == "1.11.1"
+                    |  return x * 2
+                    |print(sc.parallelize(arr).map(mul2).collect())
+                    """)
+        props = self.createTempFile("properties", """
+            |spark.conda.binaryPath        {}
+            |spark.conda.channelUrls       https://repo.continuum.io/pkgs/free
+            |spark.conda.bootstrapPackages python=3.5
+        """.format(os.path.expanduser("~/miniconda/bin/conda")))
+        proc = subprocess.Popen([self.sparkSubmit,
+                                 "--properties-file", props,
+                                 script], stdout=subprocess.PIPE)
+        out, err = proc.communicate()
+        self.assertEqual(0, proc.returncode)
+        self.assertIn("[2, 4, 6]", out.decode('utf-8'))
+
 
 class ContextTests(unittest.TestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -2078,7 +2078,7 @@ class SparkSubmitTests(unittest.TestCase):
             |spark.conda.binaryPath        {}
             |spark.conda.channelUrls       https://repo.continuum.io/pkgs/free
             |spark.conda.bootstrapPackages python=3.5
-        """.format(os.path.expanduser("~/miniconda/bin/conda")))
+        """.format(os.environ["CONDA_BIN"]))
         proc = subprocess.Popen([self.sparkSubmit,
                                  "--properties-file", props,
                                  script], stdout=subprocess.PIPE)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -137,7 +137,8 @@ abstract class BaseYarnClusterSuite
       extraClassPath: Seq[String] = Nil,
       extraJars: Seq[String] = Nil,
       extraConf: Map[String, String] = Map(),
-      extraEnv: Map[String, String] = Map()): SparkAppHandle.State = {
+      extraEnv: Map[String, String] = Map(),
+      timeoutDuration: FiniteDuration = 2.minutes): SparkAppHandle.State = {
     val deployMode = if (clientMode) "client" else "cluster"
     val propsFile = createConfFile(extraClassPath = extraClassPath, extraConf = extraConf)
     val env = Map("YARN_CONF_DIR" -> hadoopConfDir.getAbsolutePath()) ++ extraEnv
@@ -167,7 +168,7 @@ abstract class BaseYarnClusterSuite
 
     val handle = launcher.startApplication()
     try {
-      eventually(timeout(2 minutes), interval(1 second)) {
+      eventually(timeout(timeoutDuration), interval(1 second)) {
         assert(handle.getState().isFinal())
       }
     } finally {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -86,7 +86,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |        exit(-1)
     |    sc = SparkContext(conf=SparkConf())
     |
-    |    sc.addCondaPackage('numpy=1.11.1')
+    |    sc.addCondaPackages('numpy=1.11.1')
     |    import numpy
     |
     |    status = open(sys.argv[1],'w')

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -325,7 +325,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       s"$sparkHome/python/lib/py4j-0.10.4-src.zip",
       s"$sparkHome/python")
     val extraEnvVars = Map(
-      "REQUESTS_CA_BUNDLE" -> "/Users/dsanduleac/certs/ca-bundle.crt",
       "PYSPARK_ARCHIVES_PATH" -> pythonPath.map("local:" + _).mkString(File.pathSeparator),
       "PYTHONPATH" -> pythonPath.mkString(File.pathSeparator)) ++ extraEnv
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -330,7 +330,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       "PYTHONPATH" -> pythonPath.mkString(File.pathSeparator)) ++ extraEnv
 
     val extraConf: Map[String, String] = Map(
-      "spark.conda.binaryPath" -> (sys.props("user.home") + "/miniconda/bin/conda"),
+      "spark.conda.binaryPath" -> sys.env("CONDA_BIN"),
       "spark.conda.channelUrls" -> "https://repo.continuum.io/pkgs/free",
       "spark.conda.bootstrapPackages" -> "python=3.5"
     )

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -356,7 +356,8 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       sparkArgs = Seq("--py-files" -> pyFiles),
       appArgs = Seq(result.getAbsolutePath()),
       extraEnv = extraEnvVars,
-      extraConf = extraConf)
+      extraConf = extraConf,
+      timeoutDuration = 4.minutes) // give it a bit longer
     checkResult(finalState, result)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -99,6 +99,7 @@ class DummyUDF extends PythonFunction(
   command = Array[Byte](),
   envVars = Map("" -> "").asJava,
   pythonIncludes = ArrayBuffer("").asJava,
+  condaPackages = ArrayBuffer("").asJava,
   pythonExec = "",
   pythonVer = "",
   broadcastVars = null,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -99,7 +99,7 @@ class DummyUDF extends PythonFunction(
   command = Array[Byte](),
   envVars = Map("" -> "").asJava,
   pythonIncludes = ArrayBuffer("").asJava,
-  condaPackages = ArrayBuffer("").asJava,
+  condaSetupInstructions = None,
   pythonExec = None,
   pythonVer = "",
   broadcastVars = null,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -100,7 +100,7 @@ class DummyUDF extends PythonFunction(
   envVars = Map("" -> "").asJava,
   pythonIncludes = ArrayBuffer("").asJava,
   condaPackages = ArrayBuffer("").asJava,
-  pythonExec = "",
+  pythonExec = None,
   pythonVer = "",
   broadcastVars = null,
   accumulator = null)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a CondaRunner abstract class that implements `main(String[])` where it sets up a conda environment when certain options are set, then delegates its arguments to an abstract method, along with the optional `CondaEnvironment`. 

Then, changed `PythonRunner` and `RRunner` to implement `CondaRunner` and run their respective subprocess from within the conda env, if one is set up.
NOTE: actually R needs more changes, so for now `RRunner` will just fail early if conda settings are found. 

As for the executor-side logic:
* Updated `context.py` with a  `addCondaPackage` method, which will add the package to the locally set up conda environment (if one is defined), and for distribution on the executors
* Updated `PythonRDD` to set up the desired conda env (that should match the one on the driver, which includes any additional packages supplied to `addCondaPackage`) before shelling out to python inside that env

## How was this patch tested?

### End-to-end python test that
* bootstraps an env with only python installed (`python=3.5`)
* calls `addCondaPackage('numpy=1.11.1')`
* attempts to import numpy on the driver which should succeed
* maps on the executor with a function that attempts to use the numpy import, and asserts that the version is the expected one

### End-to-end yarn test that
* runs in both client and cluster mode
* essentially very similar to the above - tests that an added package is available on both driver & executor