### PR TITLE
Capture scala test reports in circle

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -400,6 +400,11 @@ def run_scala_tests_sbt(test_modules, test_profiles):
 
     exec_sbt(profiles_and_goals)
 
+    if 'CIRCLE_ARTIFACTS' in os.environ:
+        copy_tests_cmd = test_profiles + ["copyCiArtifactsToCircle"]
+        print("[info] Collecting SBT test results to Circle: ", " ".join(copy_tests_cmd))
+        exec_sbt(copy_tests_cmd)
+
 
 def run_scala_tests(build_tool, hadoop_version, test_modules, excluded_tags):
     """Function to properly execute all tests passed in as a set from the

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -400,9 +400,9 @@ def run_scala_tests_sbt(test_modules, test_profiles):
 
     exec_sbt(profiles_and_goals)
 
-    if 'CIRCLE_ARTIFACTS' in os.environ:
-        copy_tests_cmd = test_profiles + ["copyCiArtifactsToCircle"]
-        print("[info] Collecting SBT test results to Circle: ", " ".join(copy_tests_cmd))
+    if 'CIRCLE_TEST_REPORTS' in os.environ:
+        copy_tests_cmd = test_profiles + ["copyTestReportsToCircle"]
+        print("[info] Copying SBT test reports to Circle: ", " ".join(copy_tests_cmd))
         exec_sbt(copy_tests_cmd)
 
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -757,7 +757,7 @@ object CopyDependencies {
 object TestSettings {
   import BuildCommons._
 
-  val copyCiArtifactsToCircle: TaskKey[Boolean] = taskKey("Copy the test artifacts to circle")
+  val copyTestReportsToCircle: TaskKey[Boolean] = taskKey("Copy the test reports to circle if CIRCLE_TEST_REPORTS is defined")
 
   private val scalaBinaryVersion =
     if (System.getProperty("scala-2.10") == "true") {
@@ -844,14 +844,13 @@ object TestSettings {
       ).mkString(":"),
       "-doc-title", "Spark " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
     ),
-    copyCiArtifactsToCircle := {
+    copyTestReportsToCircle := {
       val reportsDir = target.value / "test-reports"
-      val circleArtifacts = sys.env.get("CIRCLE_ARTIFACTS")
-      circleArtifacts.filter(_ => reportsDir.exists).map { circle =>
-        val project = thisProjectRef.value.project
-        IO.copyDirectory(reportsDir, file(circle) / project / reportsDir.name)
+      val circleReports = sys.env.get("CIRCLE_TEST_REPORTS")
+      circleReports.filter(_ => reportsDir.exists).exists { circle =>
+        IO.copyDirectory(reportsDir, file(circle) / thisProjectRef.value.project)
         true
-      }.getOrElse(false)
+      }
     }
   )
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -32,7 +32,7 @@ import com.typesafe.sbt.pom.{PomBuild, SbtPomKeys}
 import com.typesafe.tools.mima.plugin.MimaKeys
 import org.scalastyle.sbt.ScalastylePlugin._
 import org.scalastyle.sbt.Tasks
-
+import sbt.plugins.JUnitXmlReportPlugin
 import spray.revolver.RevolverPlugin._
 
 object BuildCommons {
@@ -79,6 +79,7 @@ object BuildCommons {
   val scalacJVMVersion = settingKey[String]("source and target JVM version for scalac")
 }
 
+//noinspection ScalaStyle
 object SparkBuild extends PomBuild {
 
   import BuildCommons._
@@ -201,6 +202,7 @@ object SparkBuild extends PomBuild {
     }
   )
 
+
   lazy val sharedSettings = sparkGenjavadocSettings ++
       (if (sys.env.contains("NOLINT_ON_COMPILE")) Nil else enableScalaStyle) ++ Seq(
     exportJars in Compile := true,
@@ -293,8 +295,8 @@ object SparkBuild extends PomBuild {
     }
   )
 
-  def enable(settings: Seq[Setting[_]])(projectRef: ProjectRef) = {
-    val existingSettings = projectsMap.getOrElse(projectRef.project, Seq[Setting[_]]())
+  def enable(settings: Seq[Setting[_]])(projectRef: ProjectRef): Unit = {
+    val existingSettings = projectsMap.getOrElse(projectRef.project, Seq())
     projectsMap += (projectRef.project -> (existingSettings ++ settings))
   }
 
@@ -755,6 +757,8 @@ object CopyDependencies {
 object TestSettings {
   import BuildCommons._
 
+  val copyCiArtifactsToCircle: TaskKey[Boolean] = taskKey("Copy the test artifacts to circle")
+
   private val scalaBinaryVersion =
     if (System.getProperty("scala-2.10") == "true") {
       "2.10"
@@ -839,7 +843,16 @@ object TestSettings {
         "org.apache.spark.util.collection"
       ).mkString(":"),
       "-doc-title", "Spark " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
-    )
+    ),
+    copyCiArtifactsToCircle := {
+      val reportsDir = target.value / "test-reports"
+      val circleArtifacts = sys.env.get("CIRCLE_ARTIFACTS")
+      circleArtifacts.filter(_ => reportsDir.exists).map { circle =>
+        val project = thisProjectRef.value.project
+        IO.copyDirectory(reportsDir, file(circle) / project / reportsDir.name)
+        true
+      }.getOrElse(false)
+    }
   )
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Capture all the scala test reports and expose them to circle for easy failed test identification.
Currently other reports from e.g. python tests are not captured, that will be handled in a future PR.

## How was this patch tested?

![image](https://cloud.githubusercontent.com/assets/222827/23792930/e3307454-0580-11e7-8a9b-8d94dd540d23.png)
