### PR TITLE
Improve build perf by adding more caching, and only cleaning where necessary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -67,7 +67,7 @@ test:
             shift 2
             dist_version="${version}-${dist_name}"
             file_name="spark-dist-${dist_version}.tgz"
-            ./dev/make-distribution.sh --name $dist_name --tgz $build_flags "$@"
+            ./dev/make-distribution.sh --name $dist_name --tgz "$@" $build_flags
             curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/spark-dist/${dist_version}/${file_name}"
           }
 

--- a/circle.yml
+++ b/circle.yml
@@ -47,15 +47,16 @@ test:
             echo "</server></servers></settings>" >> $tmp_settings
 
             ./build/mvn versions:set -DnewVersion=$version
-            ./build/mvn --settings $tmp_settings -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr clean deploy
+            ./build/mvn --settings $tmp_settings -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr deploy
           }
 
           make_dist() {
             dist_name="$1"
             build_flags="$2"
+            shift 2
             dist_version="${version}-${dist_name}"
             file_name="spark-dist-${dist_version}.tgz"
-            ./dev/make-distribution.sh --name $dist_name --tgz $build_flags
+            ./dev/make-distribution.sh --name $dist_name --tgz $build_flags "$@"
             curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/spark-dist/${dist_version}/${file_name}"
           }
 
@@ -67,7 +68,7 @@ test:
             make_dist hadoop-2.8.0-palantir2 "-Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr"
             ;;
           2)
-            make_dist without-hadoop "-Phadoop-provided -Pkubernetes -Pmesos -Pyarn -Psparkr"
+            make_dist without-hadoop "-Phadoop-provided -Pkubernetes -Pmesos -Pyarn -Psparkr" --clean
             ;;
           esac
       :

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,9 @@ dependencies:
       fi
     - ./build/mvn -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr install
       # Copy all of */target/scala_2.11/classes to build_classes/
-    - rsync --info=progress2 -a --delete-excluded --prune-empty-dirs --exclude build_classes/ --include '**/target/scala-2.1?/classes/***' --include '**/' --exclude '*' . build_classes/
+    - >
+      rsync --info=progress2 -a --delete-excluded --prune-empty-dirs --exclude build_classes/ --include '**/target/scala-2.1?/***'
+      --include '**/target/analysis/***' --include '**/' --exclude '*' . build_classes/
   cache_directories:
     - "build_classes"
 

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,16 @@ dependencies:
     - PYENV_VERSION=3.4.4 pip install numpy
     #- PYENV_VERSION=pypy-4.0.1 pip install numpy
   override:
+    - |
+      if [[ -d build_classes ]]; then
+        # Copy contents into current build directory
+        rsync -a build_classes/ .
+      fi
     - ./build/mvn -DskipTests -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pmesos -Pyarn -Phive-thriftserver -Phive -Psparkr install
+      # Copy all of */target/scala_2.11/classes to build_classes/
+    - rsync --info=progress2 -a --delete-excluded --prune-empty-dirs --exclude build_classes/ --include '**/target/scala-2.1?/classes/***' --include '**/' --exclude '*' . build_classes/
+  cache_directories:
+    - "build_classes"
 
 general:
   artifacts:

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -35,6 +35,7 @@ DISTDIR="$SPARK_HOME/dist"
 MAKE_TGZ=false
 MAKE_PIP=false
 MAKE_R=false
+CLEAN=false
 NAME=none
 MVN="$SPARK_HOME/build/mvn"
 
@@ -42,7 +43,7 @@ function exit_with_usage {
   echo "make-distribution.sh - tool for making binary distributions of Spark"
   echo ""
   echo "usage:"
-  cl_options="[--name] [--tgz] [--pip] [--r] [--mvn <mvn-command>]"
+  cl_options="[--name] [--tgz] [--pip] [--r] [--clean] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
   echo "See Spark's \"Building Spark\" doc for correct Maven options."
   echo ""
@@ -60,6 +61,9 @@ while (( "$#" )); do
       ;;
     --r)
       MAKE_R=true
+      ;;
+    --clean)
+      CLEAN=true
       ;;
     --mvn)
       MVN="$2"
@@ -148,10 +152,16 @@ cd "$SPARK_HOME"
 
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=512m}"
 
+if [[ $CLEAN == true ]]; then
+  MAYBE_CLEAN="clean"
+else
+  MAYBE_CLEAN=""
+fi
+
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-BUILD_COMMAND=("$MVN" -T 1C clean package -DskipTests $@)
+BUILD_COMMAND=("$MVN" -T 1C $MAYBE_CLEAN package -DskipTests $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."


### PR DESCRIPTION
## What changes were proposed in this pull request?

* cache all `target/scala-2.1?/` and `target/analysis/` after `mvn install` in the dependency stage
* only clean before building in container 2, where the maven profiles have changed

## How was this patch tested?

ran a build, passed