### PR TITLE
fix curator version in hadoop-palantir profile

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -47,9 +47,9 @@ commons-net-2.2.jar
 commons-pool-1.5.4.jar
 compress-lzf-1.0.3.jar
 core-1.1.2.jar
-curator-client-2.6.0.jar
-curator-framework-2.6.0.jar
-curator-recipes-2.6.0.jar
+curator-client-2.7.1.jar
+curator-framework-2.7.1.jar
+curator-recipes-2.7.1.jar
 datanucleus-api-jdo-3.2.6.jar
 datanucleus-core-3.2.10.jar
 datanucleus-rdbms-3.2.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2650,7 +2650,7 @@
       <id>hadoop-palantir</id>
       <properties>
         <hadoop.version>2.8.0-palantir2</hadoop.version>
-        <jets3t.version>0.9.0</jets3t.version>
+        <jets3t.version>0.9.3</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <curator.version>2.7.1</curator.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2649,10 +2649,10 @@
     <profile>
       <id>hadoop-palantir</id>
       <properties>
-	<hadoop.version>2.8.0-palantir2</hadoop.version>
-	<jets3t.version>0.9.0</jets3t.version>
-	<zookeeper.version>3.4.6</zookeeper.version>
-	<curator.version>2.7.1</curator.version>
+        <hadoop.version>2.8.0-palantir2</hadoop.version>
+        <jets3t.version>0.9.0</jets3t.version>
+        <zookeeper.version>3.4.6</zookeeper.version>
+        <curator.version>2.7.1</curator.version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2650,8 +2650,6 @@
       <id>hadoop-palantir</id>
       <properties>
         <hadoop.version>2.8.0-palantir2</hadoop.version>
-        <jets3t.version>0.9.3</jets3t.version>
-        <zookeeper.version>3.4.6</zookeeper.version>
         <curator.version>2.7.1</curator.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2650,9 +2650,9 @@
       <id>hadoop-palantir</id>
       <properties>
 	<hadoop.version>2.8.0-palantir2</hadoop.version>
-	<jets3t.version>0.9.3</jets3t.version>
+	<jets3t.version>0.9.0</jets3t.version>
 	<zookeeper.version>3.4.6</zookeeper.version>
-	<curator.version>2.6.0</curator.version>
+	<curator.version>2.7.1</curator.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
I wasn't paying enough attention when I initially made the hadoop-palantir profile, and got the curator and jets3t versions wrong. This makes them match the versions in https://github.com/palantir/hadoop/blob/branch-2.8.0/hadoop-project/pom.xml.