### PR TITLE
Get rid of default channels in conda

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -88,6 +88,8 @@ final class CondaEnvironmentManager(condaBinaryPath: String, condaChannelUrls: S
          |envs_dirs:
          | - $baseRoot/envs
          |show_channel_urls: false
+         |channels: []
+         |default_channels: []
       """.stripMargin
     Files.write(condarc, List(condarcContents).asJava)
     logInfo(f"Using condarc at $condarc:%n$condarcContents")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hotfixes #115:
Fixed the way we enforce that Conda only use the specified channels. `--override-channels` doesn't work when using `conda create` because of an ongoing Conda bug.

## How was this patch tested?

normal tests