### PR TITLE
Exclude all jackson coming from hadoop-aws

### DIFF
--- a/cloud/pom.xml
+++ b/cloud/pom.xml
@@ -55,6 +55,10 @@
       <scope>${hadoop.deps.scope}</scope>
       <exclusions>
         <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-cbor</artifactId>
         </exclusion>


### PR DESCRIPTION
Turns out we need to exclude more to get correct dependency resolution