### PR TITLE
Fix conda initialisation

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1875,7 +1875,7 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   private[spark] def buildCondaInstructions(): Option[CondaSetupInstructions] = {
-    condaEnvironment.map(_.buildSetupInstructions)
+    condaEnvironment().map(_.buildSetupInstructions)
   }
 
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -339,7 +339,7 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   // Retrieve the Conda Environment from CondaRunner if it has set one up for us
-  val condaEnvironment: Option[CondaEnvironment] = CondaRunner.condaEnvironment
+  def condaEnvironment: Option[CondaEnvironment] = CondaRunner.condaEnvironment.get()
 
   /* ------------------------------------------------------------------------------------- *
    | Initialization. This code initializes the context in a manner that is exception-safe. |

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -339,7 +339,7 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   // Retrieve the Conda Environment from CondaRunner if it has set one up for us
-  def condaEnvironment: Option[CondaEnvironment] = CondaRunner.condaEnvironment.get()
+  def condaEnvironment(): Option[CondaEnvironment] = CondaRunner.condaEnvironment.get()
 
   /* ------------------------------------------------------------------------------------- *
    | Initialization. This code initializes the context in a manner that is exception-safe. |
@@ -1858,7 +1858,7 @@ class SparkContext(config: SparkConf) extends Logging {
   def listJars(): Seq[String] = addedJars.keySet.toSeq
 
   private[this] def condaEnvironmentOrFail(): CondaEnvironment = {
-    condaEnvironment.getOrElse(sys.error("A conda environment was not set up."))
+    condaEnvironment().getOrElse(sys.error("A conda environment was not set up."))
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

No longer require that `CondaRunner` be run before creating a SparkContext.
This was the case before because SparkContext got and stored the (potential) CondaEnvironment from CondaRunner on construction, whereas now it gets it dynamically.
