### PR TITLE
Change versioning scheme

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -74,7 +74,7 @@ test:
 
 deployment:
   release:
-    tag: /[0-9]+(?:\.[0-9]+)+-palantir[0-9]+(?:-kubernetes[0-9]+)?/
+    tag: /[0-9]+(?:\.[0-9]+){2,}-palantir.[0-9]+(?:\.[0-9]+)*
     commands:
       - dev/publish.sh
       - curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -X POST https://api.bintray.com/content/palantir/releases/spark/$(git describe --tags)/publish

--- a/circle.yml
+++ b/circle.yml
@@ -74,7 +74,7 @@ test:
 
 deployment:
   release:
-    tag: /[0-9]+(?:\.[0-9]+){2,}-palantir.[0-9]+(?:\.[0-9]+)*
+    tag: /[0-9]+(?:\.[0-9]+){2,}-palantir\.[0-9]+(?:\.[0-9]+)*/
     commands:
       - dev/publish.sh
       - curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -X POST https://api.bintray.com/content/palantir/releases/spark/$(git describe --tags)/publish


### PR DESCRIPTION
Since it wasn't correctly ordered, i.e. 2.3.0-palantir11 < 2.3.0-palantir2. Adds a dot so that it would become 2.3.0-palantir.11 and 2.3.0-palantir.2

@ash211