### PR TITLE
[SPARK-21319][SQL] Fix memory leak in UnsafeExternalRowSorter.RowComparator

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowSorter.java
@@ -211,7 +211,10 @@ public final class UnsafeExternalRowSorter {
       // TODO: Why are the sizes -1?
       row1.pointTo(baseObj1, baseOff1, -1);
       row2.pointTo(baseObj2, baseOff2, -1);
-      return ordering.compare(row1, row2);
+      int comparison = ordering.compare(row1, row2);
+      row1.pointTo(null, 0L, -1);
+      row2.pointTo(null, 0L, -1);
+      return comparison;
     }
   }
 }


### PR DESCRIPTION
See https://github.com/apache/spark/pull/18543 for more details.