### PR TITLE
Redact passwords from conda output

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
+import java.util.regex.Pattern
 
 import scala.collection.JavaConverters._
 import scala.sys.process.BasicIO
@@ -202,12 +203,10 @@ object CondaEnvironmentManager extends Logging {
   }
 
   private[this] val httpUrlToken =
-    ("(?<=\\b\\w+://([^:/@]*):)" +
-      "([^/@]+)" +
-      "(?=@([\\w-.]+)(:\\d+)?\\b)").r.unanchored
+    Pattern.compile("(\\b\\w+://[^:/@]*:)([^/@]+)(?=@([\\w-.]+)(:\\d+)?\\b)")
 
   private[conda] def redactCredentials(line: String): String = {
-    httpUrlToken.replaceAllIn(line, "<password>")
+    httpUrlToken.matcher(line).replaceAll("$1<password>")
   }
 
   def fromConf(sparkConf: SparkConf): CondaEnvironmentManager = {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -160,16 +160,21 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
    * @return the stdout of the process
    */
   private[this] def runOrFail(command: ProcessBuilder, description: String): String = {
+    import CondaEnvironmentManager.redactCredentials
     val out = new StringBuffer
     val err = new StringBuffer
     val collectErrOutToBuffer = new ProcessIO(
-    BasicIO.input(false),
-    BasicIO.processFully(out),
-    BasicIO.processFully(line => {
-      err append line
-      err append BasicIO.Newline
-      log.info(s"<conda> $line")
-    }))
+      BasicIO.input(false),
+      BasicIO.processFully((redactCredentials _).andThen(line => {
+        out.append(line)
+        out.append(BasicIO.Newline)
+        ()
+      })),
+      BasicIO.processFully((redactCredentials _).andThen(line => {
+        err.append(line)
+        err.append(BasicIO.Newline)
+        log.info(s"<conda> $line")
+      })))
     val exitCode = command.run(collectErrOutToBuffer).exitValue()
     if (exitCode != 0) {
       throw new SparkException(s"Attempt to $description exited with code: "
@@ -194,6 +199,15 @@ object CondaEnvironmentManager extends Logging {
 
   def isConfigured(sparkConf: SparkConf): Boolean = {
     sparkConf.contains(CONDA_BINARY_PATH)
+  }
+
+  private[this] val httpUrlToken =
+    ("(?<=\\b\\w+://([^:/@]*):)" +
+      "([^/@]+)" +
+      "(?=@([\\w-.]+)(:\\d+)?\\b)").r.unanchored
+
+  private[conda] def redactCredentials(line: String): String = {
+    httpUrlToken.replaceAllIn(line, "<password>")
   }
 
   def fromConf(sparkConf: SparkConf): CondaEnvironmentManager = {

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -36,4 +36,11 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
       ".baz:12345/whatever/else"
     assert(CondaEnvironmentManager.redactCredentials(original) == redacted)
   }
+
+  test("CondaEnvironmentManager.redactTwoCredentials") {
+    val original = "random:https://:creds1@x-5.bar/whatever/else][http://us_r:creds2@yy.bar:222"
+    val redacted = "random:https://:<password>@x-5.bar/whatever/else]" +
+      "[http://us_r:<password>@yy.bar:222"
+    assert(CondaEnvironmentManager.redactCredentials(original) == redacted)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -28,4 +28,12 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
     CondaEnvironmentManager.ensureExecutable(path.toString)
     assert(Files.isExecutable(path), "File should now be executable")
   }
+
+  test("CondaEnvironmentManager.redactCredentials") {
+    val original = "24u0f8 adfghjfouh https://:f35g35b_t5gbn.asfad3@my-host-name-5.foo.bar" +
+      ".baz:12345/whatever/else"
+    val redacted = "24u0f8 adfghjfouh https://:<password>@my-host-name-5.foo.bar" +
+      ".baz:12345/whatever/else"
+    assert(CondaEnvironmentManager.redactCredentials(original) == redacted)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When logging the output of any conda execution, look for URLs which contain credentials and replace the password with `<password>`.

## How was this patch tested?

Unit test