### PR TITLE
override simpleString for save into datasource command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -46,4 +46,13 @@ case class SaveIntoDataSourceCommand(
 
     Seq.empty[Row]
   }
+
+  override def simpleString: String = {
+    s"SaveIntoDataSourceCommand ${dataSource}, ${sanitize(options)}, $mode"
+  }
+
+  private def sanitize(options: Map[String, String]) = options.map {
+    case (k, v) if k == "password" => (k, "REDACTED")
+    case (k, v) => (k, v)
+  }
 }


### PR DESCRIPTION
With this pr executing this on spark-shell:
```
val listener = new QueryExecutionListener {
  override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {}

  override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
    System.out.println(qe.toString())
  }
}
spark.listenerManager.register(listener)

spark.range(100).write
  .format("jdbc")
  .option("url", "jdbc:postgresql:sparkdb")
  .option("password", "pass")
  .option("driver", "org.postgresql.Driver")
  .option("dbtable", "test9")
  .save()

```

results in:
```
== Parsed Logical Plan ==
SaveIntoDataSourceCommand org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider@7315264e, Map(dbtable -> test9, driver -> org.postgresql.Driver, url -> jdbc:postgresql:sparkdb, password -> REDACTED), ErrorIfExists
   +- Range (0, 100, step=1, splits=Some(8))

== Analyzed Logical Plan ==
SaveIntoDataSourceCommand org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider@7315264e, Map(dbtable -> test9, driver -> org.postgresql.Driver, url -> jdbc:postgresql:sparkdb, password -> REDACTED), ErrorIfExists
   +- Range (0, 100, step=1, splits=Some(8))

== Optimized Logical Plan ==
SaveIntoDataSourceCommand org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider@7315264e, Map(dbtable -> test9, driver -> org.postgresql.Driver, url -> jdbc:postgresql:sparkdb, password -> REDACTED), ErrorIfExists
   +- Range (0, 100, step=1, splits=Some(8))

== Physical Plan ==
Execute SaveIntoDataSourceCommand
   +- SaveIntoDataSourceCommand org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider@7315264e, Map(dbtable -> test9, driver -> org.postgresql.Driver, url -> jdbc:postgresql:sparkdb, password -> REDACTED), ErrorIfExists
         +- Range (0, 100, step=1, splits=Some(8))
```