### PR TITLE
bound patquet metadata cache

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -509,6 +509,7 @@ object ParquetFileFormat extends Logging {
       .expireAfterAccess(4, TimeUnit.HOURS)
       .concurrencyLevel(1)
       .softValues()
+      .maximumSize(1024)
       .removalListener(new RemovalListener[Path, ParquetFileSplitter] {
           override def onRemoval(removalNotification:
                                  RemovalNotification[Path, ParquetFileSplitter]): Unit = {


### PR DESCRIPTION
As per @aash211's suggestion in #259, I've bounded the cache because it's been observed to cause significant memory pressure.