### PR TITLE
Update dockerfile with correct path

### DIFF
--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/spark-base/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/spark-base/Dockerfile
@@ -33,7 +33,7 @@ COPY jars /opt/spark/jars
 COPY bin /opt/spark/bin
 COPY sbin /opt/spark/sbin
 COPY conf /opt/spark/conf
-COPY dockerfiles/spark-base/entrypoint.sh /opt/
+COPY kubernetes/docker/spark-base/entrypoint.sh /opt/
 
 ENV SPARK_HOME /opt/spark
 


### PR DESCRIPTION
The docker image for kubernetes is not currently building because when the merge with upstream changed the output path from `dockerfiles` to `kubernetes/docker`, the path in the Dockerfile was not updated to match.

@robert3005 @jamding