### PR TITLE
Launch daemon from conda directory if conda is enabled

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ machine:
     - |
       if [[ ! -d ${CONDA_ROOT} ]]; then
           echo "Installing Miniconda...";
-          wget --quiet https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh &&
-            bash Miniconda2-latest-Linux-x86_64.sh -b -p ${CONDA_ROOT};
+          wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.3.31-Linux-x86_64.sh &&
+            bash Miniconda2-4.3.31-Linux-x86_64.sh -b -p ${CONDA_ROOT};
       else
           echo "Using cached Miniconda install";
       fi

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ machine:
       if [[ ! -d ${CONDA_ROOT} ]]; then
           echo "Installing Miniconda...";
           wget --quiet https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh &&
-            bash Miniconda-latest-Linux-x86_64.sh -b -p ${CONDA_ROOT};
+            bash Miniconda2-latest-Linux-x86_64.sh -b -p ${CONDA_ROOT};
       else
           echo "Using cached Miniconda install";
       fi

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ machine:
     - |
       if [[ ! -d ${CONDA_ROOT} ]]; then
           echo "Installing Miniconda...";
-          wget --quiet https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh &&
+          wget --quiet https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh &&
             bash Miniconda-latest-Linux-x86_64.sh -b -p ${CONDA_ROOT};
       else
           echo "Using cached Miniconda install";

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -351,9 +351,9 @@ private[r] object RRunner {
       "spark.r.backendConnectionTimeout", SparkRDefaults.DEFAULT_CONNECTION_TIMEOUT)
     val rOptions = "--vanilla"
     val rLibDir = condaEnv.map { conda =>
-      Seq(conda.condaEnvDir + "/lib/R/library", RUtils.sparkRPackagePath(isDriver = false))
+      (conda.condaEnvDir + "/lib/R/library") +: RUtils.sparkRPackagePath(isDriver = false)
     }.getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-    val rExecScript = rLibDir(0) + "/SparkR/worker/" + script
+    val rExecScript = RUtils.sparkRInstallLocation(rLibDir, "/SparkR/worker/" + script)
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.
     condaEnv.map(_.activatedEnvironment()).map(_.asJava).foreach(pb.environment().putAll)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -353,9 +353,7 @@ private[r] object RRunner {
     val rLibDir = condaEnv.map { conda =>
        RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library")
     }.getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-    print(rLibDir + "\n")
     val rExecScript = RUtils.sparkRInstallLocation(rLibDir, "/SparkR/worker/" + script)
-    print(rExecScript)
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.
     condaEnv.map(_.activatedEnvironment()).map(_.asJava).foreach(pb.environment().putAll)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -351,9 +351,11 @@ private[r] object RRunner {
       "spark.r.backendConnectionTimeout", SparkRDefaults.DEFAULT_CONNECTION_TIMEOUT)
     val rOptions = "--vanilla"
     val rLibDir = condaEnv.map { conda =>
-      (conda.condaEnvDir + "/lib/R/library") +: RUtils.sparkRPackagePath(isDriver = false)
+       RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library")
     }.getOrElse(RUtils.sparkRPackagePath(isDriver = false))
+    print(rLibDir + "\n")
     val rExecScript = RUtils.sparkRInstallLocation(rLibDir, "/SparkR/worker/" + script)
+    print(rExecScript)
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.
     condaEnv.map(_.activatedEnvironment()).map(_.asJava).foreach(pb.environment().putAll)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -350,7 +350,9 @@ private[r] object RRunner {
     val rConnectionTimeout = sparkConf.getInt(
       "spark.r.backendConnectionTimeout", SparkRDefaults.DEFAULT_CONNECTION_TIMEOUT)
     val rOptions = "--vanilla"
-    val rLibDir = RUtils.sparkRPackagePath(isDriver = false)
+    val rLibDir = condaEnv.map { conda =>
+      Seq(conda.condaEnvDir + "/lib/R/library", RUtils.sparkRPackagePath(isDriver = false))
+    }.getOrElse(RUtils.sparkRPackagePath(isDriver = false))
     val rExecScript = rLibDir(0) + "/SparkR/worker/" + script
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -98,7 +98,7 @@ private[spark] object RUtils {
   /** Finds the rLibDir with SparkR installed on it. */
   def sparkRInstallLocation(rLibDir: Seq[String], scriptPath: String): String = {
     rLibDir.find( dir => new File(dir + scriptPath).exists)
-      .getOrElse(throw new SparkException("SparkR package not installed on executor."))
+      .getOrElse(throw new SparkException("SparkR package not installed on executor.")) + scriptPath
   }
 
   /** Check if R is installed before running tests that use R commands. */

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -95,6 +95,12 @@ private[spark] object RUtils {
     }
   }
 
+  /** Finds the rLibDir with SparkR installed on it. */
+  def sparkRInstallLocation(rLibDir: Seq[String], scriptPath: String): String = {
+    rLibDir.find( dir => new File(dir + scriptPath).exists)
+      .getOrElse(throw new SparkException("SparkR package not installed on executor."))
+  }
+
   /** Check if R is installed before running tests that use R commands. */
   def isRInstalled: Boolean = {
     try {

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -97,7 +97,7 @@ private[spark] object RUtils {
 
   /** Finds the rLibDir with SparkR installed on it. */
   def sparkRInstallLocation(rLibDir: Seq[String], scriptPath: String): String = {
-    rLibDir.find( dir => new File(dir + scriptPath).exists)
+    rLibDir.find(dir => new File(dir + scriptPath).exists)
       .getOrElse(throw new SparkException("SparkR package not installed on executor.")) + scriptPath
   }
 


### PR DESCRIPTION
Currently, executors do not use the correct path to launch the R daemon/worker when using conda. This PR updates rLibDir to use the conda library path if conda is being used.
