### PR TITLE
Handle nulls in k8s responses correctly.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
@@ -117,15 +117,22 @@ private[k8s] class LoggingPodStatusWatcherImpl(
       ("node name", pod.getSpec.getNodeName()),
 
       // status
-      ("start time", pod.getStatus.getStartTime.getTime),
+      ("start time", Option.apply(pod.getStatus)
+        .flatMap(status => Option.apply(status.getStartTime))
+        .map(_.getTime)
+        .getOrElse("unknown")),
       ("container images",
-        pod.getStatus.getContainerStatuses()
-          .asScala
-          .map(_.getImage)
-          .mkString(", ")),
-      ("phase", pod.getStatus.getPhase()),
-      ("status", pod.getStatus.getContainerStatuses().toString)
-    )
+        Option.apply(pod.getStatus)
+          .flatMap(status => Option.apply(status.getContainerStatuses()))
+          .map(_.asScala
+            .map(_.getImage)
+            .mkString(", "))
+          .getOrElse("unknown")),
+      ("phase", Option.apply(pod.getStatus).map(_.getPhase).getOrElse("unknown")),
+      ("status", Option.apply(pod.getStatus)
+        .flatMap(status => Option.apply(status.getContainerStatuses))
+        .map(_.toString)
+        .getOrElse("unknown")))
     formatPairsBundle(details)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

k8s apiserver can returns nulls as the status object (or parts of it). Handles them as 

## How was this patch tested?

Untested.
