### PR TITLE
Prepackage deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,9 +345,6 @@ jobs:
       - store_artifacts:
           path: /tmp/publish_artifacts.log
           destination: publish_artifacts.log
-      - deploy:
-          command: |
-            curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -X POST https://api.bintray.com/content/palantir/releases/spark/$(git describe --tags)/publish
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,13 @@ all-branches-and-tags: &all-branches-and-tags
     tags:
       only: /.*/
 
+deployable-branches-and-tags: &deployable-branches-and-tags
+  filters:
+    tags:
+      only: /[0-9]+(?:\.[0-9]+){2,}-palantir\.[0-9]+(?:\.[0-9]+)*/
+    branches:
+      only: master
+
 
 jobs:
   build-maven:
@@ -291,19 +298,41 @@ jobs:
       - store_artifacts:
           path: /tmp/yarn-tests
 
-  deploy:
+  build-maven-versioned:
     <<: *defaults
     # Some part of the maven setup fails if there's no R, so we need to use the R image here
     docker:
       - image: palantirtechnologies/circle-spark-r
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - restore_cache:
           key: maven-dependency-cache-{{ checksum "pom.xml" }}
       - restore_cache:
           key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+      - run:
+          command: dev/set_version_and_package.sh
+      # This is potentially costly but we can't use the workspace as it would conflict with
+      # compilation results from build-sbt
+      - save_cache:
+          key: v1-maven-build-with-version-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+            - .
+
+  deploy:
+    <<: *defaults
+    # Some part of the maven setup fails if there's no R, so we need to use the R image here
+    docker:
+      - image: palantirtechnologies/circle-spark-r
+    steps:
+      # This cache contains the whole project after version was set and mvn package was called
+      # Restoring first (and instead of checkout) as mvn versions:set mutates real source code...
+      - restore_cache:
+          key: v1-maven-build-with-version-{{ .Branch }}-{{ .BuildNum }}
+      - restore_cache:
+          key: maven-dependency-cache-{{ checksum "pom.xml" }}
+      - restore_cache:
+          key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+
       - run: echo "user=$BINTRAY_USERNAME" > .credentials
       - run: echo "password=$BINTRAY_PASSWORD" >> .credentials
       - run: echo "realm=Bintray API Realm" >> .credentials
@@ -311,8 +340,8 @@ jobs:
       - deploy:
           command: dev/publish.sh
       - store_artifacts:
-          path: /tmp/make-distribution.log
-          destination: make-distribution.log
+          path: /tmp/make-dist.log
+          destination: make-dist.log
       - store_artifacts:
           path: /tmp/publish_artifacts.log
           destination: publish_artifacts.log
@@ -354,6 +383,10 @@ workflows:
           requires:
             - build-sbt
           <<: *all-branches-and-tags
+      - build-maven-versioned:
+          requires:
+            - build-maven
+          <<: *deployable-branches-and-tags
       - deploy:
           requires:
             - build-maven
@@ -364,8 +397,5 @@ workflows:
             - run-scala-tests
             - run-python-tests
             - run-r-tests
-          filters:
-            tags:
-              only: /[0-9]+(?:\.[0-9]+){2,}-palantir\.[0-9]+(?:\.[0-9]+)*/
-            branches:
-              only: master
+            - build-maven-versioned
+          <<: *deployable-branches-and-tags

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -107,6 +107,8 @@ circle.yml
 .credentials
 publish.sh
 publish-local.sh
+publish_functions.sh
+set_version_and_package.sh
 structured-streaming/*
 kafka-source-initial-offset-version-2.1.0.bin
 kafka-source-initial-offset-future-version.bin

--- a/dev/publish-local.sh
+++ b/dev/publish-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-version=$(git describe --tags)
+version=$(git describe --tags --first-parent)
 
 PALANTIR_FLAGS=(-Phadoop-cloud -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Phive -Pyarn -Psparkr)
 

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -33,4 +33,5 @@ make_dist() {
   file_name="spark-dist-${version}-${hadoop_name}.tgz"
   ./dev/make-distribution.sh --name "hadoop-palantir" --tgz "$@" $build_flags
   curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T "$file_name" "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/${artifact_name}/${version}/${artifact_name}-${version}.tgz"
+  curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -X POST "https://api.bintray.com/content/palantir/releases/spark/${version}/publish"
 }

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PALANTIR_FLAGS=(-Phadoop-cloud -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Phive -Pyarn -Psparkr)
+
+set_version_and_package() {
+  ./build/mvn versions:set -DnewVersion="$version"
+  ./build/mvn -DskipTests "${PALANTIR_FLAGS[@]}" package
+}
+
+publish_artifacts() {
+  tmp_settings="tmp-settings.xml"
+  echo "<settings><servers><server>" > $tmp_settings
+  echo "<id>bintray-palantir-release</id><username>$BINTRAY_USERNAME</username>" >> $tmp_settings
+  echo "<password>$BINTRAY_PASSWORD</password>" >> $tmp_settings
+  echo "</server></servers></settings>" >> $tmp_settings
+
+  ./build/mvn --settings $tmp_settings -DskipTests "${PALANTIR_FLAGS[@]}" deploy
+}
+
+make_dist() {
+  build_flags="$1"
+  shift 1
+  hadoop_name="hadoop-palantir"
+  artifact_name="spark-dist_2.11-${hadoop_name}"
+  file_name="spark-dist-${version}-${hadoop_name}.tgz"
+  ./dev/make-distribution.sh --name "hadoop-palantir" --tgz "$@" $build_flags
+  curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/${artifact_name}/${version}/${artifact_name}-${version}.tgz"
+}

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 
 PALANTIR_FLAGS=(-Phadoop-cloud -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Phive -Pyarn -Psparkr)
 
+get_version() {
+  git describe --tags --first-parent
+}
+
 set_version_and_package() {
+  version=$(get_version)
   ./build/mvn versions:set -DnewVersion="$version"
   ./build/mvn -DskipTests "${PALANTIR_FLAGS[@]}" package
 }
@@ -22,9 +27,10 @@ publish_artifacts() {
 make_dist() {
   build_flags="$1"
   shift 1
+  version=$(get_version)
   hadoop_name="hadoop-palantir"
   artifact_name="spark-dist_2.11-${hadoop_name}"
   file_name="spark-dist-${version}-${hadoop_name}.tgz"
   ./dev/make-distribution.sh --name "hadoop-palantir" --tgz "$@" $build_flags
-  curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T $file_name "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/${artifact_name}/${version}/${artifact_name}-${version}.tgz"
+  curl -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T "$file_name" "https://api.bintray.com/content/palantir/releases/spark/${version}/org/apache/spark/${artifact_name}/${version}/${artifact_name}-${version}.tgz"
 }

--- a/dev/set_version_and_package.sh
+++ b/dev/set_version_and_package.sh
@@ -6,5 +6,4 @@ FWDIR="$(cd "`dirname "${BASH_SOURCE[0]}"`"; pwd)"
 
 source "$FWDIR/publish_functions.sh"
 
-publish_artifacts | tee -a "/tmp/publish_artifacts.log"
-make_dist "${PALANTIR_FLAGS[*]}" | tee -a "/tmp/make-dist.log"
+set_version_and_package


### PR DESCRIPTION
## What changes were proposed in this pull request?

An additional circle job `build-maven-versioned` that 
* sets the maven version (this modifies actual poms so dirties the working directory)
* runs mvn package on the whole project
* caches the whole project directory

In order to speed up the deploy job, which then won't need to recompile things anymore.

The deploy job then just restores the cache from

It's important that the pre-packaging job starts from a clean source (it only restores .m2 / mvn binary caches), but we can take advantage of circle's parallelism to do this way ahead of time, such that by the time tests have run, this is would have finished too.

## Testing

Can't really test the deploy job, but tested the `build-maven-versioned` job separately in this build (stripping out the rest of the unrelated jobs) - https://circleci.com/workflow-run/c0a96f10-d82e-404e-9159-79b0f20028d6