### PR TITLE
Improve bin packing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
   run-scala-tests:
     <<: *test-defaults
     # project/CirclePlugin.scala does its own test splitting in SBT based on CIRCLE_NODE_INDEX, CIRCLE_NODE_TOTAL
-    parallelism: 12
+    parallelism: 9
     # Spark runs a lot of tests in parallel, we need 16 GB of RAM for this
     resource_class: xlarge
     steps:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix scala tests bin packing (introduced in #326) to pack overflowing tests into the smallest groups rather than all into the last group.

Given this packing result with 12 containers:
```
[info] Estimated total test time to be 10621.035999999996
...
[info] Estimated test timings per bucket: List(603.7549999999998, 817.3610000000002, 850.6530000000002, 859.7090000000001, 863.885, 867.8600000000001, 872.34, 873.4709999999991, 879.9599999999999, 880.1829999999992, 999.3939999999991, 1252.4650000000001)
```

I'm also reducing the scala parallelism to 9 since the largest bin is 1252 sec ~ 21 min, and according to our estimated total test time we wouldn't need more than ceil(10621/1252 ~ 8.48) containers if we set the maximum bin length to that.

New timings with 9 boxes are as such:
```
[info] Estimated test timings per bucket: List(1042.5720000000001, 1048.0839999999994, 1096.451, 1125.4330000000002, 1139.1910000000005, 1154.237, 1155.5290000000002, 1158.0589999999966, 1547.3039999999999)
```
Therefore our longest test time went up to 25.7 min, but that's acceptable.