### PR TITLE
Move RBackend to member variable

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -40,6 +40,8 @@ import org.apache.spark.util.RedirectThread
  * subprocess and then has it connect back to the JVM to access system properties etc.
  */
 object RRunner extends CondaRunner with Logging {
+  val sparkRBackend = new RBackend()
+
   override def run(args: Array[String], maybeConda: Option[CondaEnvironment]): Unit = {
     val rFile = PythonRunner.formatPath(args(0))
 
@@ -84,7 +86,6 @@ object RRunner extends CondaRunner with Logging {
 
     // Launch a SparkR backend server for the R process to connect to; this will let it see our
     // Java system properties etc.
-    val sparkRBackend = new RBackend()
     @volatile var sparkRBackendPort = 0
     val initialized = new Semaphore(0)
     val sparkRBackendThread = new Thread("SparkR backend") {


### PR DESCRIPTION
This PR proposes to expose the RBackend instantiated in RRunner as a member variable of the Scala object. Doing so allows access to the object tracker used by SparkR to maintain mappings between r object wrappers to the underlying Datasets in Java.