### PR TITLE
Add reminder for upstream ticket/PR to github template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,3 +1,5 @@
+## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
+
 ## What changes were proposed in this pull request?
 
 (Please fill in changes proposed in this fix)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a note to the PR template to file and submit upstream tickets and PRs

## How was this patch tested?

N/A
