### PR TITLE
Improve ParseError stop location when offending symbol is a token

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -192,8 +192,16 @@ case object ParseErrorListener extends BaseErrorListener {
       charPositionInLine: Int,
       msg: String,
       e: RecognitionException): Unit = {
-    val position = Origin(Some(line), Some(charPositionInLine))
-    throw new ParseException(None, msg, position, position)
+    val (start, stop) = offendingSymbol match {
+      case token: CommonToken =>
+        val start = Origin (Some (line), Some (token.getStartIndex) )
+        val stop = Origin (Some (line), Some (token.getStopIndex) )
+        (start, stop)
+      case _ =>
+        val start = Origin (Some (line), Some (charPositionInLine) )
+        (start, start)
+    }
+    throw new ParseException (None, msg, start, stop)
   }
 }
 


### PR DESCRIPTION
In the case where the offending symbol is a CommonToken, this PR increases the accuracy of the start and stop origin by leveraging the start and stop index information from CommonToken.

## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

[Upstream PR link](https://github.com/apache/spark/pull/21334)
