### PR TITLE
Fix RDDOperationScope serialization issues

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -22,7 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonProperty, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.ser.OptionSerializer
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -44,7 +46,8 @@ import org.apache.spark.internal.Logging
 @JsonPropertyOrder(Array("id", "name", "parent"))
 private[spark] case class RDDOperationScope(
     @JsonProperty("name") name: String,
-    @JsonProperty("parent") parent: Option[RDDOperationScope] = None,
+    @JsonProperty("parent") @JsonSerialize(using = classOf[OptionSerializer])
+    parent: Option[RDDOperationScope] = None,
     @JsonProperty("id") id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOr
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.common.base.Objects
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -43,10 +42,10 @@ import org.apache.spark.internal.Logging
  */
 @JsonInclude(Include.NON_ABSENT)
 @JsonPropertyOrder(Array("id", "name", "parent"))
-private[spark] class RDDOperationScope(
-    val name: String,
-    val parent: Option[RDDOperationScope] = None,
-    val id: String = RDDOperationScope.nextScopeId().toString) {
+private[spark] case class RDDOperationScope(
+    name: String,
+    parent: Option[RDDOperationScope] = None,
+    id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {
     RDDOperationScope.jsonMapper.writeValueAsString(this)
@@ -60,16 +59,6 @@ private[spark] class RDDOperationScope(
   def getAllScopes: Seq[RDDOperationScope] = {
     parent.map(_.getAllScopes).getOrElse(Seq.empty) ++ Seq(this)
   }
-
-  override def equals(other: Any): Boolean = {
-    other match {
-      case s: RDDOperationScope =>
-        id == s.id && name == s.name && parent == s.parent
-      case _ => false
-    }
-  }
-
-  override def hashCode(): Int = Objects.hashCode(id, name, parent)
 
   override def toString: String = toJson
 }

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -21,10 +21,11 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import com.fasterxml.jackson.databind.{MapperFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.base.Objects
+
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -48,7 +48,7 @@ private[spark] case class RDDOperationScope(
     id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {
-    RDDOperationScope.jsonMapper.writeValueAsString(this)
+    RDDOperationScope.jsonWriter.writeValueAsString(this)
   }
 
   /**
@@ -68,11 +68,14 @@ private[spark] case class RDDOperationScope(
  * An RDD scope tracks the series of operations that created a given RDD.
  */
 private[spark] object RDDOperationScope extends Logging {
-  private val jsonMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private val (jsonReader, jsonWriter) = {
+    val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+    (mapper.readerFor(classOf[RDDOperationScope]), mapper.writerFor(classOf[RDDOperationScope]))
+  }
   private val scopeCounter = new AtomicInteger(0)
 
   def fromJson(s: String): RDDOperationScope = {
-    jsonMapper.readValue(s, classOf[RDDOperationScope])
+    jsonReader.readValue[RDDOperationScope](s)
   }
 
   /** Return a globally unique operation scope ID. */

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -21,11 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonProperty, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.{MapperFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.ser.OptionSerializer
-
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
 
@@ -46,8 +43,7 @@ import org.apache.spark.internal.Logging
 @JsonPropertyOrder(Array("id", "name", "parent"))
 private[spark] case class RDDOperationScope(
     @JsonProperty("name") name: String,
-    @JsonProperty("parent") @JsonSerialize(using = classOf[OptionSerializer])
-    parent: Option[RDDOperationScope] = None,
+    @JsonProperty("parent") parent: Option[RDDOperationScope] = None,
     @JsonProperty("id") id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {
@@ -73,8 +69,7 @@ private[spark] case class RDDOperationScope(
 private[spark] object RDDOperationScope extends Logging {
   private val (jsonReader, jsonWriter) = {
     val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
-    mapper.getSerializerProviderInstance
-      .findTypedValueSerializer(classOf[RDDOperationScope], true, null)
+      .enable(MapperFeature.USE_STATIC_TYPING)
     (mapper.readerFor(classOf[RDDOperationScope]), mapper.writerFor(classOf[RDDOperationScope]))
   }
   private val scopeCounter = new AtomicInteger(0)

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonProperty, 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{MapperFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -70,6 +70,8 @@ private[spark] case class RDDOperationScope(
 private[spark] object RDDOperationScope extends Logging {
   private val (jsonReader, jsonWriter) = {
     val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+    mapper.getSerializerProviderInstance
+      .findTypedValueSerializer(classOf[RDDOperationScope], true, null)
     (mapper.readerFor(classOf[RDDOperationScope]), mapper.writerFor(classOf[RDDOperationScope]))
   }
   private val scopeCounter = new AtomicInteger(0)

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -19,7 +19,7 @@ package org.apache.spark.rdd
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonProperty, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -43,9 +43,9 @@ import org.apache.spark.internal.Logging
 @JsonInclude(Include.NON_ABSENT)
 @JsonPropertyOrder(Array("id", "name", "parent"))
 private[spark] case class RDDOperationScope(
-    name: String,
-    parent: Option[RDDOperationScope] = None,
-    id: String = RDDOperationScope.nextScopeId().toString) {
+    @JsonProperty("name") name: String,
+    @JsonProperty("parent") parent: Option[RDDOperationScope] = None,
+    @JsonProperty("id") id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {
     RDDOperationScope.jsonWriter.writeValueAsString(this)

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.base.Objects
 
@@ -46,7 +45,6 @@ import org.apache.spark.internal.Logging
 @JsonPropertyOrder(Array("id", "name", "parent"))
 private[spark] class RDDOperationScope(
     val name: String,
-    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     val parent: Option[RDDOperationScope] = None,
     val id: String = RDDOperationScope.nextScopeId().toString) {
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.base.Objects
 
@@ -45,6 +46,7 @@ import org.apache.spark.internal.Logging
 @JsonPropertyOrder(Array("id", "name", "parent"))
 private[spark] class RDDOperationScope(
     val name: String,
+    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     val parent: Option[RDDOperationScope] = None,
     val id: String = RDDOperationScope.nextScopeId().toString) {
 


### PR DESCRIPTION
Since we bumped jackson in #359 we have been having non deterministic serialization issues with RDDOperationScope. All issues indicate that it can't find the serializer for the Option (parent variable) and serializes it using defaults. This force jackson to use static typing, i.e. use the class types and not values determined using reflection at runtime