### PR TITLE
Fix split calculation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
@@ -91,7 +91,7 @@ class ParquetMetadataFileSplitter(
     val statFilter: (FileStatus => Seq[FileSplit]) = { stat =>
       val filePath = stat.getPath
       if (referencedFiles.contains(filePath)) {
-        eligible.getOrElse(filePath, Seq())
+        eligible.getOrElse(filePath, Nil)
       } else {
         log.warn(s"Found _metadata file for $root," +
           s" but no entries for blocks in ${filePath}. Retaining whole file.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
@@ -40,14 +40,14 @@ import org.apache.spark.util.ThreadUtils
 abstract class ParquetFileSplitter {
   def buildSplitter(filters: Seq[Filter]): (FileStatus => Seq[FileSplit])
 
-  def singleFileSplit(stat: FileStatus): Seq[FileSplit] = {
-    Seq(new FileSplit(stat.getPath, 0, stat.getLen, Array.empty))
+  def singleFileSplit(path: Path, length: Long): Seq[FileSplit] = {
+    Seq(new FileSplit(path, 0, length, Array.empty))
   }
 }
 
 object ParquetDefaultFileSplitter extends ParquetFileSplitter {
   override def buildSplitter(filters: Seq[Filter]): (FileStatus => Seq[FileSplit]) = {
-    stat => singleFileSplit(stat)
+    stat => singleFileSplit(stat.getPath, stat.getLen)
   }
 }
 
@@ -82,18 +82,20 @@ class ParquetMetadataFileSplitter(
       (applied, unapplied, filteredBlocks)
     }
 
+    // Group eligible splits by file Path.
     val eligible = applyParquetFilter(unapplied, filteredBlocks).map { bmd =>
       val blockPath = new Path(root, bmd.getPath)
       new FileSplit(blockPath, bmd.getStartingPos, bmd.getCompressedSize, Array.empty)
-    }
+    }.groupBy(_.getPath)
 
     val statFilter: (FileStatus => Seq[FileSplit]) = { stat =>
-      if (referencedFiles.contains(stat.getPath)) {
-        eligible.filter(_.getPath == stat.getPath)
+      val filePath = stat.getPath
+      if (referencedFiles.contains(filePath)) {
+        eligible(filePath)
       } else {
         log.warn(s"Found _metadata file for $root," +
-          s" but no entries for blocks in ${stat.getPath}. Retaining whole file.")
-        singleFileSplit(stat)
+          s" but no entries for blocks in ${filePath}. Retaining whole file.")
+        singleFileSplit(filePath, stat.getLen)
       }
     }
     statFilter

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileSplitter.scala
@@ -91,7 +91,7 @@ class ParquetMetadataFileSplitter(
     val statFilter: (FileStatus => Seq[FileSplit]) = { stat =>
       val filePath = stat.getPath
       if (referencedFiles.contains(filePath)) {
-        eligible(filePath)
+        eligible.getOrElse(filePath, Seq())
       } else {
         log.warn(s"Found _metadata file for $root," +
           s" but no entries for blocks in ${filePath}. Retaining whole file.")


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

This only pertains to the splitter in our fork.

## What changes were proposed in this pull request?

Remove excess calls to FileStatus.getPath and pre-build the grouped map rather than scanning all blocks for each input file.

