### PR TITLE
propagate mdc to child thread

### DIFF
--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/launcher/src/main/java/org/apache/spark/launcher/InProcessAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/InProcessAppHandle.java
@@ -63,7 +63,9 @@ class InProcessAppHandle extends AbstractAppHandle {
 
     Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
     app = new Thread(() -> {
-      MDC.setContextMap(mdcContextMap);
+      if (mdcContextMap != null) {
+        MDC.setContextMap(mdcContextMap);
+      }
       try {
         main.invoke(null, (Object) args);
       } catch (Throwable t) {

--- a/launcher/src/main/java/org/apache/spark/launcher/InProcessAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/InProcessAppHandle.java
@@ -17,7 +17,10 @@
 
 package org.apache.spark.launcher;
 
+import org.slf4j.MDC;
+
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,7 +61,9 @@ class InProcessAppHandle extends AbstractAppHandle {
       appName = "..." + appName.substring(appName.length() - MAX_APP_NAME_LEN);
     }
 
+    Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
     app = new Thread(() -> {
+      MDC.setContextMap(mdcContextMap);
       try {
         main.invoke(null, (Object) args);
       } catch (Throwable t) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -195,7 +195,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
 
 object PROCESS_TABLES extends QueryTest with SQLTestUtils {
   // Tests the latest version of every release line.
-  val testingVersions = Seq("2.0.2", "2.1.2", "2.2.1", "2.3.1")
+  val testingVersions = Seq("2.1.3", "2.2.2", "2.3.1")
 
   protected var spark: SparkSession = _
 


### PR DESCRIPTION
upstream PR: https://github.com/apache/spark/pull/21743

jira ticket: https://issues.apache.org/jira/browse/SPARK-24767

This is so we can get logging with the sparkModuleId during in-process launching