### PR TITLE
FilterPushdownBenchmark SparkSession should be lazy

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -45,19 +45,19 @@ import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.types.DataTypes.*;
 
 public class JavaDataFrameSuite {
-  private static TestSparkSession spark;
-  private static JavaSparkContext jsc;
+  private transient TestSparkSession spark;
+  private transient JavaSparkContext jsc;
 
-  @BeforeClass
-  public static void setUp() {
+  @Before
+  public void setUp() {
     // Trigger static initializer of TestData
     spark = new TestSparkSession();
     jsc = new JavaSparkContext(spark.sparkContext());
     spark.loadTestData();
   }
 
-  @AfterClass
-  public static void tearDown() {
+  @After
+  public void tearDown() {
     spark.stop();
     spark = null;
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -55,7 +55,7 @@ class FilterPushdownBenchmark extends SparkFunSuite with BenchmarkBeforeAndAfter
   private val mid = numRows / 2
   private val blockSize = 1048576
 
-  private val spark = SparkSession.builder().config(conf).getOrCreate()
+  private lazy val spark = SparkSession.builder().config(conf).getOrCreate()
 
   private var out: OutputStream = _
 


### PR DESCRIPTION
Tracking down miscellaneous flakes leads me to this hanging spark context