### PR TITLE
Ensure bintray upload happens before repository is no clean.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,6 +456,7 @@ jobs:
           key: v1-maven-dependency-cache-versioned-{{ checksum "pom.xml" }}
       - *restore-build-binaries-cache
 
+      - run: ./gradlew --info bintrayUpload | tee -a "/tmp/publish_docker_image_generator_plugin.log"
       - run: echo "user=$BINTRAY_USERNAME" > .credentials
       - run: echo "password=$BINTRAY_PASSWORD" >> .credentials
       - run: echo "realm=Bintray API Realm" >> .credentials
@@ -468,6 +469,9 @@ jobs:
       - store_artifacts:
           path: /tmp/publish_artifacts.log
           destination: publish_artifacts.log
+      - store_artifacts:
+          path: /tmp/publish_docker_image_generator_plugin.log
+          destination: publish_docker_image_generator_plugin.log
 
 workflows:
   version: 2

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -21,7 +21,6 @@ publish_artifacts() {
   echo "<password>$BINTRAY_PASSWORD</password>" >> $tmp_settings
   echo "</server></servers></settings>" >> $tmp_settings
 
-  ./gradlew --info bintrayUpload
   ./build/mvn -T 1C --settings $tmp_settings -DskipTests "${PALANTIR_FLAGS[@]}" deploy
 }
 


### PR DESCRIPTION
Better would be to avoid putting any non-ignored generated output in the repository, but this is a short term fix.