### PR TITLE
Improve sharing of conda environments across Python and R

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -94,7 +94,7 @@ private[spark] class PythonWorkerFactory(requestedPythonExec: Option[String],
 
   private[this] val condaEnv = {
     // Set up conda environment if there are any conda packages requested
-    condaInstructions.map(CondaEnvironmentManager.createCondaEnvironment)
+    condaInstructions.map(CondaEnvironmentManager.createOrGetCondaEnvironment)
   }
 
   private[this] val envVars: Map[String, String] = {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -94,7 +94,7 @@ private[spark] class PythonWorkerFactory(requestedPythonExec: Option[String],
 
   private[this] val condaEnv = {
     // Set up conda environment if there are any conda packages requested
-    condaInstructions.map(CondaEnvironmentManager.createOrGetCondaEnvironment)
+    condaInstructions.map(CondaEnvironmentManager.getOrCreateCondaEnvironment)
   }
 
   private[this] val envVars: Map[String, String] = {

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -348,7 +348,7 @@ private[r] object RRunner {
     val sparkConf = SparkEnv.get.conf
     val requestedRCommand = Provenance.fromConf("spark.r.command")
       .orElse(Provenance.fromConf("spark.sparkr.r.command"))
-    val condaEnv = condaSetupInstructions.map(CondaEnvironmentManager.createCondaEnvironment)
+    val condaEnv = condaSetupInstructions.map(CondaEnvironmentManager.createOrGetCondaEnvironment)
     val rCommand = condaEnv.map { conda =>
       requestedRCommand.foreach(exec => sys.error(s"It's forbidden to set the r executable " +
         s"when using conda, but found: $exec"))

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -348,7 +348,7 @@ private[r] object RRunner {
     val sparkConf = SparkEnv.get.conf
     val requestedRCommand = Provenance.fromConf("spark.r.command")
       .orElse(Provenance.fromConf("spark.sparkr.r.command"))
-    val condaEnv = condaSetupInstructions.map(CondaEnvironmentManager.createOrGetCondaEnvironment)
+    val condaEnv = condaSetupInstructions.map(CondaEnvironmentManager.getOrCreateCondaEnvironment)
     val rCommand = condaEnv.map { conda =>
       requestedRCommand.foreach(exec => sys.error(s"It's forbidden to set the r executable " +
         s"when using conda, but found: $exec"))


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
This is strictly for conda environment work which is contained entirely in palantir/spark, so there is not any upstream spark ticket

## What changes were proposed in this pull request?

The conda environment manager should share environments regardless of which language is using it. This adds a new cache for conda environments which allows both Python and R environments that happen to be the same to share the same environment.

This cache needs to be protected by a lock to prevent concurrent
modifications since we do not want extra copies of the environment
on disk.

## How was this patch tested?

Please review http://spark.apache.org/contributing.html before opening a pull request.
