### PR TITLE
Fix gradle publishing to correct bintray bucket

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
-rootProject.name = 'spark-docker-gradle'
+// This must be the same as the repo name, palantir/spark is the only bucket this repo is provisioned to write to
+rootProject.name = 'spark'
 
 include ':spark-docker-image-generator'


### PR DESCRIPTION
## What changes were proposed in this pull request?

We were trying to publish the gradle plugin to the wrong bintray bucket - `palantir/spark-docker-gradle` (this was [inferred from the gradle root project name](https://github.com/palantir/spark/blob/d493b4b67339a406fd204b7013f1ce2d815ae40b/gradle/publish.gradle#L36)).

We've now changed that root project name to be `spark` so it will now publish to the correct bucket that the repo has credentials for.

## How was this patch tested?

eyeballs