### PR TITLE
Fix publish local script

### DIFF
--- a/dev/publish-local.sh
+++ b/dev/publish-local.sh
@@ -5,7 +5,7 @@ version=$(git describe --tags --first-parent)
 
 PALANTIR_FLAGS=(-Phadoop-cloud -Phadoop-palantir -Pkinesis-asl -Pkubernetes -Pyarn -Psparkr)
 
-MVN_LOCAL="~/.m2/repository"
+MVN_LOCAL=~/.m2/repository
 
 publish_artifacts() {
   ./build/mvn versions:set -DnewVersion=$version

--- a/dev/publish-local.sh
+++ b/dev/publish-local.sh
@@ -15,11 +15,12 @@ publish_artifacts() {
 make_dist() {
   build_flags="$1"
   shift 1
-  artifact_name="spark-dist_2.11-hadoop-palantir"
-  file_name="${artifact_name}-${version}.tgz"
+  hadoop_name="hadoop-palantir"
+  artifact_name="spark-dist_2.11-${hadoop_name}"
+  file_name="spark-dist-${version}-${hadoop_name}.tgz"
   ./dev/make-distribution.sh --name "hadoop-palantir" --tgz "$@" $build_flags
   mkdir -p $MVN_LOCAL/org/apache/spark/${artifact_name}/${version} && \
-  cp $file_name $MVN_LOCAL/org/apache/spark/${artifact_name}/${version}/
+  cp $file_name $MVN_LOCAL/org/apache/spark/${artifact_name}/${version}/${artifact_name}-${version}.tgz
 }
 
 publish_artifacts


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

Change to palantir-only build script.

## What changes were proposed in this pull request?

Fix publish-local.sh build script

## How was this patch tested?

Previously I found 2 problems with this script:
1. MVN_LOCAL was being set as `MVN_LOCAL="~/.m2/repository"`.  The issue is that tilde-expansion doesn't occur inside double-quotes, so this ends up with a literal `~` in the path.  And then when it's used later, since tilde-expansion occurs before parameter-expansion, we once again end up with a literal `~`.  So the tgz ends up getting copied to `./~/.m2/repository` instead of my actual home dir.
2. The artifact names don't match up.  The intended output artifact name (for example) `spark-dist_2.11-hadoop-palantir-3.0.0-SNAPSHOT.tgz` is not the same as the artifact that's produced initially (`spark-dist-3.0.0-SNAPSHOT-hadoop-palantir.tgz`).  So we have to take both names into account.  Note that this is the same logic as in `dev/publish_functions.sh`.
