### PR TITLE
Fix dynamic allocation with external shuffle service

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -610,7 +610,8 @@ private[spark] class ExecutorAllocationManager(
         // blocks we are concerned with are reported to the driver. Note that this
         // does not include broadcast blocks.
         val hasCachedBlocks = blockManagerMaster.hasCachedBlocks(executorId)
-        val hasAnyShuffleBlocks = mapOutputTracker.hasOutputsOnExecutor(executorId)
+        val hasAnyShuffleBlocks =
+          mapOutputTracker.hasOutputsOnExecutor(executorId) && !externalShuffleServiceEnabled
         val now = clock.getTimeMillis()
 
         // Use the maximum of all the timeouts that apply.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -601,17 +601,17 @@ private[spark] class ExecutorAllocationManager(
    */
   private def onExecutorIdle(executorId: String): Unit = synchronized {
     if (executorIds.contains(executorId)) {
-      val hasActiveShuffleBlocks =
+      val hasActiveShuffleBlocks = !externalShuffleServiceEnabled &&
         mapOutputTracker.hasOutputsOnExecutor(executorId, activeOnly = true)
       if (!removeTimes.contains(executorId)
         && !executorsPendingToRemove.contains(executorId)
-        && (externalShuffleServiceEnabled || !hasActiveShuffleBlocks)) {
+        && !hasActiveShuffleBlocks) {
         // Note that it is not necessary to query the executors since all the cached
         // blocks we are concerned with are reported to the driver. Note that this
         // does not include broadcast blocks.
         val hasCachedBlocks = blockManagerMaster.hasCachedBlocks(executorId)
         val hasAnyShuffleBlocks =
-          mapOutputTracker.hasOutputsOnExecutor(executorId) && !externalShuffleServiceEnabled
+          !externalShuffleServiceEnabled && mapOutputTracker.hasOutputsOnExecutor(executorId)
         val now = clock.getTimeMillis()
 
         // Use the maximum of all the timeouts that apply.


### PR DESCRIPTION
CC @lwwmanning @robert3005 @mccheah 

I realized this morning that #427 will unintentionally reduce the effectiveness of dynamic allocation with the external shuffle service.

Shuffle blocks are only tracked by `executorId`, and when using the external shuffle service, the blockManagerId still uses the executor's ID (see [BlockManager.scala:266](https://github.com/palantir/spark/blob/master/core/src/main/scala/org/apache/spark/storage/BlockManager.scala#L266)).
This means that even when using the external shuffle service, we currently will consider those executors to contain active shuffle blocks and thus won't remove them.

I think we just need to override the new behaviour here and ignore their shuffle status if the external shuffle service is enabled.

I tested this quickly on YARN with external shuffle enabled and confirmed that executors would not get released until the shuffle blocks became inactive.  This PR fixed it, causing them to be immediately released when their tasks were done.