### PR TITLE
Shuffle biased task scheduling

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -656,8 +656,8 @@ private[spark] class MapOutputTrackerMaster(
   def getExecutorShuffleStatus: scala.collection.Map[String, ExecutorShuffleStatus] = {
     shuffleStatuses.values
       .flatMap(status => status.executorsWithOutputs().map(_ -> status.isActive))
-      .groupBy(_._1)
-      .mapValues(_.exists(_._2))
+      .groupBy(_._1) // group by executor ID
+      .mapValues(_.exists(_._2)) // true if any are Active
       .mapValues(if (_) ExecutorShuffleStatus.Active else ExecutorShuffleStatus.Inactive)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -392,65 +392,7 @@ private[spark] class TaskSchedulerImpl(
     }
 
     for (shuffledOffers <- partitionedAndShuffledOffers.map(_._2)) {
-      // Build a list of tasks to assign to each worker.
-      val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
-      val availableCpus = shuffledOffers.map(o => o.cores).toArray
-      val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
-
-      // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
-      // of locality levels so that it gets a chance to launch local tasks on all of them.
-      // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
-      for (taskSet <- sortedTaskSets) {
-        // Skip the barrier taskSet if the available slots are less than the number of pending tasks
-        if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
-          // Skip the launch process.
-          // TODO SPARK-24819 If the job requires more slots than available (both busy and free
-          // slots), fail the job on submit.
-          logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-            s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
-            s"number of available slots is $availableSlots.")
-        } else {
-          var launchedAnyTask = false
-          // Record all the executor IDs assigned barrier tasks on.
-          val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
-          for (currentMaxLocality <- taskSet.myLocalityLevels) {
-            var launchedTaskAtCurrentMaxLocality = false
-            do {
-              launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
-                currentMaxLocality, shuffledOffers, availableCpus, tasks, addressesWithDescs)
-              launchedAnyTask |= launchedTaskAtCurrentMaxLocality
-            } while (launchedTaskAtCurrentMaxLocality)
-          }
-          if (!launchedAnyTask) {
-            taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
-          }
-          if (launchedAnyTask && taskSet.isBarrier) {
-            // Check whether the barrier tasks are partially launched.
-            // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
-            // requirements are not fulfilled, and we should revert the launched tasks).
-            require(addressesWithDescs.size == taskSet.numTasks,
-              s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-                s"because only ${addressesWithDescs.size} out of a total number of " +
-                s"${taskSet.numTasks} tasks got resource offers. The resource offers may have " +
-                "been blacklisted or cannot fulfill task locality requirements.")
-
-            // materialize the barrier coordinator.
-            maybeInitBarrierCoordinator()
-
-            // Update the taskInfos into all the barrier task properties.
-            val addressesStr = addressesWithDescs
-              // Addresses ordered by partitionId
-              .sortBy(_._2.partitionId)
-              .map(_._1)
-              .mkString(",")
-            addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
-
-            logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for " +
-              s"barrier stage ${taskSet.stageId}.")
-          }
-        }
-      }
-      allTasks ++= tasks
+      allTasks ++= doResourceOffers(shuffledOffers, sortedTaskSets)
     }
 
     // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get
@@ -459,6 +401,70 @@ private[spark] class TaskSchedulerImpl(
       hasLaunchedTask = true
     }
     return allTasks
+  }
+
+  private def doResourceOffers(
+      shuffledOffers: IndexedSeq[WorkerOffer],
+      sortedTaskSets: IndexedSeq[TaskSetManager]): Seq[Seq[TaskDescription]] = {
+    // Build a list of tasks to assign to each worker.
+    val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
+    val availableCpus = shuffledOffers.map(o => o.cores).toArray
+    val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
+
+    // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
+    // of locality levels so that it gets a chance to launch local tasks on all of them.
+    // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
+    for (taskSet <- sortedTaskSets) {
+      // Skip the barrier taskSet if the available slots are less than the number of pending tasks
+      if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
+        // Skip the launch process.
+        // TODO SPARK-24819 If the job requires more slots than available (both busy and free
+        // slots), fail the job on submit.
+        logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
+          s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
+          s"number of available slots is $availableSlots.")
+      } else {
+        var launchedAnyTask = false
+        // Record all the executor IDs assigned barrier tasks on.
+        val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
+        for (currentMaxLocality <- taskSet.myLocalityLevels) {
+          var launchedTaskAtCurrentMaxLocality = false
+          do {
+            launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
+              currentMaxLocality, shuffledOffers, availableCpus, tasks, addressesWithDescs)
+            launchedAnyTask |= launchedTaskAtCurrentMaxLocality
+          } while (launchedTaskAtCurrentMaxLocality)
+        }
+        if (!launchedAnyTask) {
+          taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
+        }
+        if (launchedAnyTask && taskSet.isBarrier) {
+          // Check whether the barrier tasks are partially launched.
+          // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
+          // requirements are not fulfilled, and we should revert the launched tasks).
+          require(addressesWithDescs.size == taskSet.numTasks,
+            s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
+              s"because only ${addressesWithDescs.size} out of a total number of " +
+              s"${taskSet.numTasks} tasks got resource offers. The resource offers may have " +
+              "been blacklisted or cannot fulfill task locality requirements.")
+
+          // materialize the barrier coordinator.
+          maybeInitBarrierCoordinator()
+
+          // Update the taskInfos into all the barrier task properties.
+          val addressesStr = addressesWithDescs
+            // Addresses ordered by partitionId
+            .sortBy(_._2.partitionId)
+            .map(_._1)
+            .mkString(",")
+          addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
+
+          logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for " +
+            s"barrier stage ${taskSet.stageId}.")
+        }
+      }
+    }
+    tasks
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -81,6 +81,9 @@ private[spark] class TaskSchedulerImpl(
   private val speculationScheduler =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("task-scheduler-speculation")
 
+  // whether to prefer assigning tasks to executors that contain shuffle files
+  val SHUFFLE_BIASED_SCHEDULING_ENABLED = Utils.isShuffleBiasedTaskSchedulingEnabled(conf)
+
   // Threshold above which we warn user initial TaskSet may be starved
   val STARVATION_TIMEOUT_MS = conf.getTimeAsMs("spark.starvation.timeout", "15s")
 
@@ -377,11 +380,8 @@ private[spark] class TaskSchedulerImpl(
       }
     }.getOrElse(offers)
 
-    val shuffledOffers = shuffleOffers(filteredOffers)
-    // Build a list of tasks to assign to each worker.
-    val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
-    val availableCpus = shuffledOffers.map(o => o.cores).toArray
-    val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
+    val partitionedAndShuffledOffers = partitionShuffleOffers(filteredOffers)
+    var allTasks: Seq[Seq[TaskDescription]] = Nil
     val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
@@ -391,73 +391,102 @@ private[spark] class TaskSchedulerImpl(
       }
     }
 
-    // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
-    // of locality levels so that it gets a chance to launch local tasks on all of them.
-    // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
-    for (taskSet <- sortedTaskSets) {
-      // Skip the barrier taskSet if the available slots are less than the number of pending tasks.
-      if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
-        // Skip the launch process.
-        // TODO SPARK-24819 If the job requires more slots than available (both busy and free
-        // slots), fail the job on submit.
-        logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-          s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
-          s"number of available slots is $availableSlots.")
-      } else {
-        var launchedAnyTask = false
-        // Record all the executor IDs assigned barrier tasks on.
-        val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
-        for (currentMaxLocality <- taskSet.myLocalityLevels) {
-          var launchedTaskAtCurrentMaxLocality = false
-          do {
-            launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
-              currentMaxLocality, shuffledOffers, availableCpus, tasks, addressesWithDescs)
-            launchedAnyTask |= launchedTaskAtCurrentMaxLocality
-          } while (launchedTaskAtCurrentMaxLocality)
-        }
-        if (!launchedAnyTask) {
-          taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
-        }
-        if (launchedAnyTask && taskSet.isBarrier) {
-          // Check whether the barrier tasks are partially launched.
-          // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
-          // requirements are not fulfilled, and we should revert the launched tasks).
-          require(addressesWithDescs.size == taskSet.numTasks,
-            s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-              s"because only ${addressesWithDescs.size} out of a total number of " +
-              s"${taskSet.numTasks} tasks got resource offers. The resource offers may have " +
-              "been blacklisted or cannot fulfill task locality requirements.")
+    for (shuffledOffers <- partitionedAndShuffledOffers.map(_._2)) {
+      // Build a list of tasks to assign to each worker.
+      val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
+      val availableCpus = shuffledOffers.map(o => o.cores).toArray
+      val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
 
-          // materialize the barrier coordinator.
-          maybeInitBarrierCoordinator()
+      // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
+      // of locality levels so that it gets a chance to launch local tasks on all of them.
+      // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
+      for (taskSet <- sortedTaskSets) {
+        // Skip the barrier taskSet if the available slots are less than the number of pending tasks
+        if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
+          // Skip the launch process.
+          // TODO SPARK-24819 If the job requires more slots than available (both busy and free
+          // slots), fail the job on submit.
+          logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
+            s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
+            s"number of available slots is $availableSlots.")
+        } else {
+          var launchedAnyTask = false
+          // Record all the executor IDs assigned barrier tasks on.
+          val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
+          for (currentMaxLocality <- taskSet.myLocalityLevels) {
+            var launchedTaskAtCurrentMaxLocality = false
+            do {
+              launchedTaskAtCurrentMaxLocality = resourceOfferSingleTaskSet(taskSet,
+                currentMaxLocality, shuffledOffers, availableCpus, tasks, addressesWithDescs)
+              launchedAnyTask |= launchedTaskAtCurrentMaxLocality
+            } while (launchedTaskAtCurrentMaxLocality)
+          }
+          if (!launchedAnyTask) {
+            taskSet.abortIfCompletelyBlacklisted(hostToExecutors)
+          }
+          if (launchedAnyTask && taskSet.isBarrier) {
+            // Check whether the barrier tasks are partially launched.
+            // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
+            // requirements are not fulfilled, and we should revert the launched tasks).
+            require(addressesWithDescs.size == taskSet.numTasks,
+              s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
+                s"because only ${addressesWithDescs.size} out of a total number of " +
+                s"${taskSet.numTasks} tasks got resource offers. The resource offers may have " +
+                "been blacklisted or cannot fulfill task locality requirements.")
 
-          // Update the taskInfos into all the barrier task properties.
-          val addressesStr = addressesWithDescs
-            // Addresses ordered by partitionId
-            .sortBy(_._2.partitionId)
-            .map(_._1)
-            .mkString(",")
-          addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
+            // materialize the barrier coordinator.
+            maybeInitBarrierCoordinator()
 
-          logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
-            s"stage ${taskSet.stageId}.")
+            // Update the taskInfos into all the barrier task properties.
+            val addressesStr = addressesWithDescs
+              // Addresses ordered by partitionId
+              .sortBy(_._2.partitionId)
+              .map(_._1)
+              .mkString(",")
+            addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
+
+            logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for " +
+              s"barrier stage ${taskSet.stageId}.")
+          }
         }
       }
+      allTasks ++= tasks
     }
 
     // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get
     // launched within a configured time.
-    if (tasks.size > 0) {
+    if (allTasks.size > 0) {
       hasLaunchedTask = true
     }
-    return tasks
+    return allTasks
   }
 
   /**
-   * Shuffle offers around to avoid always placing tasks on the same workers.  Exposed to allow
-   * overriding in tests, so it can be deterministic.
+   * Shuffle offers around to avoid always placing tasks on the same workers.
+   * If shuffle-biased task scheduling is enabled, this function will bias tasks
+   * towards executors with active shuffles.
    */
-  protected def shuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
+  def partitionShuffleOffers(offers: IndexedSeq[WorkerOffer])
+  : IndexedSeq[(ExecutorShuffleStatus.Value, IndexedSeq[WorkerOffer])] = {
+    if (SHUFFLE_BIASED_SCHEDULING_ENABLED && offers.length > 1) {
+      // bias towards executors that have active shuffle outputs
+      val execShuffles = mapOutputTracker.getExecutorShuffleStatus
+      offers
+        .groupBy(offer => execShuffles.getOrElse(offer.executorId, ExecutorShuffleStatus.Unknown))
+        .mapValues(doShuffleOffers)
+        .toStream
+        .sortBy(_._1) // order: Active, Inactive, Unknown
+        .toIndexedSeq
+    } else {
+      IndexedSeq((ExecutorShuffleStatus.Unknown, doShuffleOffers(offers)))
+    }
+  }
+
+  /**
+   * Does the shuffling for [[partitionShuffleOffers()]]. Exposed to allow overriding in tests,
+   * so that it can be deterministic.
+   */
+  protected def doShuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
     Random.shuffle(offers)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -82,7 +82,8 @@ private[spark] class TaskSchedulerImpl(
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("task-scheduler-speculation")
 
   // whether to prefer assigning tasks to executors that contain shuffle files
-  val SHUFFLE_BIASED_SCHEDULING_ENABLED = Utils.isShuffleBiasedTaskSchedulingEnabled(conf)
+  val shuffledBiasedTaskSchedulingEnabled =
+    conf.getBoolean("spark.scheduler.shuffleBiasedTaskScheduling.enabled", false)
 
   // Threshold above which we warn user initial TaskSet may be starved
   val STARVATION_TIMEOUT_MS = conf.getTimeAsMs("spark.starvation.timeout", "15s")
@@ -474,7 +475,7 @@ private[spark] class TaskSchedulerImpl(
    */
   def partitionShuffleOffers(offers: IndexedSeq[WorkerOffer])
   : IndexedSeq[(ExecutorShuffleStatus.Value, IndexedSeq[WorkerOffer])] = {
-    if (SHUFFLE_BIASED_SCHEDULING_ENABLED && offers.length > 1) {
+    if (shuffledBiasedTaskSchedulingEnabled && offers.length > 1) {
       // bias towards executors that have active shuffle outputs
       val execShuffles = mapOutputTracker.getExecutorShuffleStatus
       offers

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -380,8 +380,7 @@ private[spark] class TaskSchedulerImpl(
       }
     }.getOrElse(offers)
 
-    val partitionedAndShuffledOffers = partitionShuffleOffers(filteredOffers)
-    var allTasks: Seq[Seq[TaskDescription]] = Nil
+    var tasks: Seq[Seq[TaskDescription]] = Nil
     val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
@@ -391,16 +390,17 @@ private[spark] class TaskSchedulerImpl(
       }
     }
 
+    val partitionedAndShuffledOffers = partitionShuffleOffers(filteredOffers)
     for (shuffledOffers <- partitionedAndShuffledOffers.map(_._2)) {
-      allTasks ++= doResourceOffers(shuffledOffers, sortedTaskSets)
+      tasks ++= doResourceOffers(shuffledOffers, sortedTaskSets)
     }
 
     // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get
     // launched within a configured time.
-    if (allTasks.size > 0) {
+    if (tasks.size > 0) {
       hasLaunchedTask = true
     }
-    return allTasks
+    return tasks
   }
 
   private def doResourceOffers(

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2511,6 +2511,10 @@ private[spark] object Utils extends Logging {
       (!isLocalMaster(conf) || conf.getBoolean("spark.dynamicAllocation.testing", false))
   }
 
+  def isShuffleBiasedTaskSchedulingEnabled(conf: SparkConf): Boolean = {
+      conf.getBoolean("spark.scheduler.shuffleBiasedTaskScheduling.enabled", false)
+  }
+
   /**
    * Return the initial number of executors for dynamic allocation.
    */

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2511,10 +2511,6 @@ private[spark] object Utils extends Logging {
       (!isLocalMaster(conf) || conf.getBoolean("spark.dynamicAllocation.testing", false))
   }
 
-  def isShuffleBiasedTaskSchedulingEnabled(conf: SparkConf): Boolean = {
-      conf.getBoolean("spark.scheduler.shuffleBiasedTaskScheduling.enabled", false)
-  }
-
   /**
    * Return the initial number of executors for dynamic allocation.
    */

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -27,6 +27,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
 
 import org.apache.spark._
+import org.apache.spark.ExecutorShuffleStatus._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
 import org.apache.spark.storage.BlockManagerId
@@ -893,7 +894,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     mapOutputTracker.registerMapOutput(1, 0, makeMapStatus(offers(1)))
     mapOutputTracker.markShuffleInactive(0)
 
-    import ExecutorShuffleStatus._
     val execStatus = mapOutputTracker.getExecutorShuffleStatus
     assert(execStatus.equals(Map("exec1" -> Inactive, "exec2" -> Active)))
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -29,6 +29,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
+import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.ManualClock
 
 class FakeSchedulerBackend extends SchedulerBackend {
@@ -836,7 +837,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // We customize the task scheduler just to let us control the way offers are shuffled, so we
     // can be sure we try both permutations, and to control the clock on the tasksetmanager.
     val taskScheduler = new TaskSchedulerImpl(sc) {
-      override def shuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
+      override def doShuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
         // Don't shuffle the offers around for this test.  Instead, we'll just pass in all
         // the permutations we care about directly.
         offers
@@ -871,6 +872,41 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
         assert(taskDescs.head.executorId === "exec1")
       }
     }
+  }
+
+  test("Shuffle-biased task scheduling enabled should lead to non-random offer shuffling") {
+    setupScheduler("spark.scheduler.shuffleBiasedTaskScheduling.enabled" -> "true")
+
+    // Make offers in different executors, so they can be a mix of active, inactive, unknown
+    val offers = IndexedSeq(
+      WorkerOffer("exec1", "host1", 2), // inactive
+      WorkerOffer("exec2", "host2", 2), // active
+      WorkerOffer("exec3", "host3", 2) // unknown
+    )
+    val makeMapStatus = (offer: WorkerOffer) =>
+      MapStatus(BlockManagerId(offer.executorId, offer.host, 1), Array(10))
+    val mapOutputTracker = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+    mapOutputTracker.registerShuffle(0, 2)
+    mapOutputTracker.registerShuffle(1, 1)
+    mapOutputTracker.registerMapOutput(0, 0, makeMapStatus(offers(0)))
+    mapOutputTracker.registerMapOutput(0, 1, makeMapStatus(offers(1)))
+    mapOutputTracker.registerMapOutput(1, 0, makeMapStatus(offers(1)))
+    mapOutputTracker.markShuffleInactive(0)
+
+    import ExecutorShuffleStatus._
+    val execStatus = mapOutputTracker.getExecutorShuffleStatus
+    assert(execStatus.equals(Map("exec1" -> Inactive, "exec2" -> Active)))
+
+    assert(taskScheduler.partitionShuffleOffers(offers).map(_._1)
+      .equals(IndexedSeq(Active, Inactive, Unknown)))
+    assert(taskScheduler.partitionShuffleOffers(offers).flatMap(_._2).map(offers.indexOf(_))
+      .equals(IndexedSeq(1, 0, 2)))
+
+    taskScheduler.submitTasks(FakeTask.createTaskSet(3, stageId = 1, stageAttemptId = 0))
+    // should go to active first, then inactive
+    val taskDescs = taskScheduler.resourceOffers(offers).flatten
+    assert(taskDescs.size === 3)
+    assert(taskDescs.map(_.executorId).equals(Seq("exec2", "exec2", "exec1")))
   }
 
   test("With delay scheduling off, tasks can be run at any locality level immediately") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -897,9 +897,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     val execStatus = mapOutputTracker.getExecutorShuffleStatus
     assert(execStatus.equals(Map("exec1" -> Inactive, "exec2" -> Active)))
 
-    assert(taskScheduler.partitionShuffleOffers(offers).map(_._1)
+    assert(taskScheduler.partitionAndShuffleOffers(offers).map(_._1)
       .equals(IndexedSeq(Active, Inactive, Unknown)))
-    assert(taskScheduler.partitionShuffleOffers(offers).flatMap(_._2).map(offers.indexOf(_))
+    assert(taskScheduler.partitionAndShuffleOffers(offers).flatMap(_._2).map(offers.indexOf(_))
       .equals(IndexedSeq(1, 0, 2)))
 
     taskScheduler.submitTasks(FakeTask.createTaskSet(3, stageId = 1, stageAttemptId = 0))

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DynamicAllocationTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DynamicAllocationTestsSuite.scala
@@ -83,6 +83,7 @@ private[spark] trait DynamicAllocationTestsSuite { k8sSuite: KubernetesSuite =>
             .addToArgs("--conf", "spark.dynamicAllocation.enabled=true")
             .addToArgs("--conf", "spark.dynamicAllocation.minExecutors=0")
             .addToArgs("--conf", "spark.dynamicAllocation.maxExecutors=1")
+            .addToArgs("--conf", "spark.scheduler.shuffleBiasedTaskScheduling.enabled=true")
             .addToArgs("--conf",
               s"spark.driver.host=" +
                 s"${driverService.getMetadata.getName}.${kubernetesTestComponents.namespace}.svc")


### PR DESCRIPTION
Another optimization to the work begun in #427 

When scheduling tasks, bias towards putting them on executors which hold active shuffle data, so we are more likely to be able to remove executors that don't.

This code is taken from the original PR and re-introduced here as a separate PR.

Still needs to be live-tested.