### PR TITLE
Filter rLibDir by exists so that daemon.R references the correct file

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -360,10 +360,14 @@ private[r] object RRunner {
     val rConnectionTimeout = sparkConf.getInt(
       "spark.r.backendConnectionTimeout", SparkRDefaults.DEFAULT_CONNECTION_TIMEOUT)
     val rOptions = "--vanilla"
-    val rLibDir = condaEnv.map { conda =>
-       RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library")
-    }.getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-    val rExecScript = RUtils.sparkRInstallLocation(rLibDir, "/SparkR/worker/" + script)
+    val rLibDir = condaEnv.map(conda =>
+      RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library"))
+      .getOrElse(RUtils.sparkRPackagePath(isDriver = false))
+      .filter(dir => new File(dir).exists)
+    if (rLibDir.isEmpty) {
+      throw new SparkException("SparkR package is not installed on executor.")
+    }
+    val rExecScript = rLibDir.head + "/SparkR/worker/" + script
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.
     condaEnv.map(_.activatedEnvironment()).map(_.asJava).foreach(pb.environment().putAll)

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -363,7 +363,7 @@ private[r] object RRunner {
     val rLibDir = condaEnv.map(conda =>
       RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library"))
       .getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-      .filter(dir => new File(dir + script).exists)
+      .filter(dir => new File(dir + "/SparkR/worker/" + script).exists)
     if (rLibDir.isEmpty) {
       throw new SparkException("SparkR package is not installed on executor.")
     }

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -363,7 +363,7 @@ private[r] object RRunner {
     val rLibDir = condaEnv.map(conda =>
       RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library"))
       .getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-      .filter(dir => new File(dir).exists)
+      .filter(dir => new File(dir + script).exists)
     if (rLibDir.isEmpty) {
       throw new SparkException("SparkR package is not installed on executor.")
     }

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -363,11 +363,11 @@ private[r] object RRunner {
     val rLibDir = condaEnv.map(conda =>
       RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library"))
       .getOrElse(RUtils.sparkRPackagePath(isDriver = false))
-      .filter(dir => new File(dir + "/SparkR/worker/" + script).exists)
+      .filter(dir => new File(dir).exists)
     if (rLibDir.isEmpty) {
       throw new SparkException("SparkR package is not installed on executor.")
     }
-    val rExecScript = rLibDir.head + "/SparkR/worker/" + script
+    val rExecScript = RUtils.getSparkRScript(rLibDir, "/SparkR/worker/" + script)
     val pb = new ProcessBuilder(Arrays.asList(rCommand, rOptions, rExecScript))
     // Activate the conda environment by setting the right env variables if applicable.
     condaEnv.map(_.activatedEnvironment()).map(_.asJava).foreach(pb.environment().putAll)

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -97,6 +97,14 @@ private[spark] object RUtils {
     }
   }
 
+  /** Finds a script in a sequence of possible SparkR installation directories. */
+  def getSparkRScript(rLibDir: Seq[String], scriptPath: String): String = {
+    rLibDir.find(dir => new File(dir + scriptPath).exists).getOrElse(
+        throw new SparkException(
+          s"Script $scriptPath not found in any SparkR installation directory.")
+    ) + scriptPath
+  }
+
   /** Check if R is installed before running tests that use R commands. */
   def isRInstalled: Boolean = {
     try {

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -97,12 +97,6 @@ private[spark] object RUtils {
     }
   }
 
-  /** Finds the rLibDir with SparkR installed on it. */
-  def sparkRInstallLocation(rLibDir: Seq[String], scriptPath: String): String = {
-    rLibDir.find(dir => new File(dir + scriptPath).exists)
-      .getOrElse(throw new SparkException("SparkR package not installed on executor.")) + scriptPath
-  }
-
   /** Check if R is installed before running tests that use R commands. */
   def isRInstalled: Boolean = {
     try {


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

Not filed in upstream, touches code for conda.

## What changes were proposed in this pull request?

rLibDir contains a sequence of possible paths for the SparkR package on the executor and is passed on to the R daemon with the SPARKR_RLIBDIR environment variable. This PR filters rLibDir for paths that exist before setting SPARKR_RLIBDIR, retaining existing functionality to preferentially choose a YARN or local SparkR install over conda if both are present.

See daemon.R: https://github.com/palantir/spark/blob/master/R/pkg/inst/worker/daemon.R#L23

Fixes #456 

## How was this patch tested?

Manually testing cherry picked on older version

Please review http://spark.apache.org/contributing.html before opening a pull request.
