### PR TITLE
Add SafeLogging to more classes

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -18,4 +18,5 @@
 # Added
 
 * Gradle plugin to easily create custom docker images for use with k8s
-* Filter rLibDir by exists so that daemon.R references the correct file [460](https://github.com/palantir/spark/pull/460) 
+* Filter rLibDir by exists so that daemon.R references the correct file [460](https://github.com/palantir/spark/pull/460)
+* SafeLogging

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -620,7 +620,8 @@ class SparkContext(config: SparkConf) extends SafeLogging {
       }
     } catch {
       case e: Exception =>
-        safeLogError("Exception getting thread dump from executor", e,
+        safeLogError("Exception getting thread dump from executor",
+          e,
           SafeArg.of("executorId", executorId))
         None
     }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -28,8 +28,9 @@ import scala.collection.Map
 import scala.collection.generic.Growable
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
+
 import com.google.common.collect.MapMaker
 import com.palantir.logsafe.{SafeArg, UnsafeArg}
 import org.apache.commons.lang3.SerializationUtils
@@ -39,6 +40,7 @@ import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, Doub
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.api.conda.CondaEnvironment
 import org.apache.spark.api.conda.CondaEnvironment.CondaSetupInstructions
@@ -618,7 +620,7 @@ class SparkContext(config: SparkConf) extends SafeLogging {
       }
     } catch {
       case e: Exception =>
-        safeLogError("Exception getting thread dump from executor $executorId", e,
+        safeLogError("Exception getting thread dump from executor", e,
           SafeArg.of("executorId", executorId))
         None
     }
@@ -2446,7 +2448,7 @@ class SparkContext(config: SparkConf) extends SafeLogging {
         listeners.foreach { listener =>
           listenerBus.addToSharedQueue(listener)
           safeLogInfo("Registered listener",
-            SafeArg.of("ListenerName", listener.getClass().getName()))
+            SafeArg.of("listenerName", listener.getClass().getName()))
         }
       }
     } catch {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -28,10 +28,10 @@ import scala.collection.Map
 import scala.collection.generic.Growable
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.{ClassTag, classTag}
 import scala.util.control.NonFatal
-
 import com.google.common.collect.MapMaker
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
 import org.apache.commons.lang3.SerializationUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -39,14 +39,13 @@ import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, Doub
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
-
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.api.conda.CondaEnvironment
 import org.apache.spark.api.conda.CondaEnvironment.CondaSetupInstructions
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.{CondaRunner, LocalSparkCluster, SparkHadoopUtil}
 import org.apache.spark.input.{FixedLengthBinaryInputFormat, PortableDataStream, StreamInputFormat, WholeTextFileInputFormat}
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.internal.config._
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.partial.{ApproximateEvaluator, PartialResult}
@@ -72,7 +71,7 @@ import org.apache.spark.util._
  * @param config a Spark Config object describing the application configuration. Any settings in
  *   this config overrides the default configs as well as system properties.
  */
-class SparkContext(config: SparkConf) extends Logging {
+class SparkContext(config: SparkConf) extends SafeLogging {
 
   // The call site where this SparkContext was constructed.
   private val creationSite: CallSite = Utils.getCallSite()
@@ -182,7 +181,7 @@ class SparkContext(config: SparkConf) extends Logging {
     this(master, appName, sparkHome, jars, Map())
 
   // log out Spark Version in Spark driver log
-  logInfo(s"Running Spark version $SPARK_VERSION")
+  safeLogInfo("Running Spark version", SafeArg.of("SPARK_VERSION", SPARK_VERSION))
 
   /* ------------------------------------------------------------------------------------- *
    | Private variables. These variables keep the internal state of the context, and are    |
@@ -348,7 +347,7 @@ class SparkContext(config: SparkConf) extends Logging {
    * ------------------------------------------------------------------------------------- */
 
   private def warnSparkMem(value: String): String = {
-    logWarning("Using SPARK_MEM to set amount of memory to use per executor process is " +
+    safeLogWarning("Using SPARK_MEM to set amount of memory to use per executor process is " +
       "deprecated, please use spark.executor.memory instead.")
     value
   }
@@ -378,7 +377,7 @@ class SparkContext(config: SparkConf) extends Logging {
     }
 
     // log out spark.app.name in the Spark driver logs
-    logInfo(s"Submitted application: $appName")
+    safeLogInfo("Submitted application", SafeArg.of("appName", appName))
 
     // System property spark.yarn.app.id must be set if user code ran by AM on a YARN cluster
     if (master == "yarn" && deployMode == "cluster" && !_conf.contains("spark.yarn.app.id")) {
@@ -387,7 +386,7 @@ class SparkContext(config: SparkConf) extends Logging {
     }
 
     if (_conf.getBoolean("spark.logConf", false)) {
-      logInfo("Spark configuration:\n" + _conf.toDebugString)
+      safeLogInfo("Spark configuration", UnsafeArg.of("conf", _conf.toDebugString))
     }
 
     // Set Spark driver host and port system properties. This explicitly sets the configuration
@@ -439,7 +438,7 @@ class SparkContext(config: SparkConf) extends Logging {
     _statusTracker = new SparkStatusTracker(this, _statusStore)
 
     _progressBar =
-      if (_conf.get(UI_SHOW_CONSOLE_PROGRESS) && !log.isInfoEnabled) {
+      if (_conf.get(UI_SHOW_CONSOLE_PROGRESS) && !safeLogIsInfoEnabled) {
         Some(new ConsoleProgressBar(this))
       } else {
         None
@@ -579,25 +578,25 @@ class SparkContext(config: SparkConf) extends Logging {
     // Make sure the context is stopped if the user forgets about it. This avoids leaving
     // unfinished event logs around after the JVM exits cleanly. It doesn't help if the JVM
     // is killed, though.
-    logDebug("Adding shutdown hook") // force eager creation of logger
+    safeLogDebug("Adding shutdown hook") // force eager creation of logger
     _shutdownHookRef = ShutdownHookManager.addShutdownHook(
       ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY) { () =>
-      logInfo("Invoking stop() from shutdown hook")
+      safeLogInfo("Invoking stop() from shutdown hook")
       try {
         stop()
       } catch {
         case e: Throwable =>
-          logWarning("Ignoring Exception while stopping SparkContext from shutdown hook", e)
+          safeLogWarning("Ignoring Exception while stopping SparkContext from shutdown hook", e)
       }
     }
   } catch {
     case NonFatal(e) =>
-      logError("Error initializing SparkContext.", e)
+      safeLogError("Error initializing SparkContext.", e)
       try {
         stop()
       } catch {
         case NonFatal(inner) =>
-          logError("Error stopping SparkContext after init error.", inner)
+          safeLogError("Error stopping SparkContext after init error.", inner)
       } finally {
         throw e
       }
@@ -619,7 +618,8 @@ class SparkContext(config: SparkConf) extends Logging {
       }
     } catch {
       case e: Exception =>
-        logError(s"Exception getting thread dump from executor $executorId", e)
+        safeLogError("Exception getting thread dump from executor $executorId", e,
+          SafeArg.of("executorId", executorId))
         None
     }
   }
@@ -1500,7 +1500,9 @@ class SparkContext(config: SparkConf) extends Logging {
       "Can not directly broadcast RDDs; instead, call collect() and broadcast the result.")
     val bc = env.broadcastManager.newBroadcast[T](value, isLocal)
     val callSite = getCallSite
-    logInfo("Created broadcast " + bc.id + " from " + callSite.shortForm)
+    safeLogInfo("Created broadcast",
+      SafeArg.of("broadcastId", bc.id),
+      UnsafeArg.of("from", callSite.shortForm))
     cleaner.foreach(_.registerBroadcastForCleanup(bc))
     bc
   }
@@ -1543,7 +1545,7 @@ class SparkContext(config: SparkConf) extends Logging {
     val schemeCorrectedPath = uri.getScheme match {
       case null => new File(path).getCanonicalFile.toURI.toString
       case "local" =>
-        logWarning("File with 'local' scheme is not supported to add to file server, since " +
+        safeLogWarning("File with 'local' scheme is not supported to add to file server, since " +
           "it is already available on every node.")
         return
       case _ => path
@@ -1574,15 +1576,19 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     val timestamp = System.currentTimeMillis
     if (addedFiles.putIfAbsent(key, timestamp).isEmpty) {
-      logInfo(s"Added file $path at $key with timestamp $timestamp")
+      safeLogInfo("Added file",
+        UnsafeArg.of("path", path),
+        UnsafeArg.of("key", key),
+        SafeArg.of("timestamp", timestamp))
       // Fetch the file locally so that closures which are run on the driver can still use the
       // SparkFiles API to access files.
       Utils.fetchFile(uri.toString, new File(SparkFiles.getRootDirectory()), conf,
         env.securityManager, hadoopConfiguration, timestamp, useCache = false)
       postEnvironmentUpdate()
     } else {
-      logWarning(s"The path $path has been added already. Overwriting of added paths " +
-       "is not supported in the current version.")
+      safeLogWarning("The path has been added already. Overwriting of added paths " +
+       "is not supported in the current version.",
+        UnsafeArg.of("path", path))
     }
   }
 
@@ -1609,7 +1615,7 @@ class SparkContext(config: SparkConf) extends Logging {
       case b: ExecutorAllocationClient =>
         b.getExecutorIds()
       case _ =>
-        logWarning("Requesting executors is not supported by current scheduler.")
+        safeLogWarning("Requesting executors is not supported by current scheduler.")
         Nil
     }
   }
@@ -1647,7 +1653,7 @@ class SparkContext(config: SparkConf) extends Logging {
       case b: ExecutorAllocationClient =>
         b.requestTotalExecutors(numExecutors, localityAwareTasks, hostToLocalTaskCount)
       case _ =>
-        logWarning("Requesting executors is not supported by current scheduler.")
+        safeLogWarning("Requesting executors is not supported by current scheduler.")
         false
     }
   }
@@ -1663,7 +1669,7 @@ class SparkContext(config: SparkConf) extends Logging {
       case b: ExecutorAllocationClient =>
         b.requestExecutors(numAdditionalExecutors)
       case _ =>
-        logWarning("Requesting executors is not supported by current scheduler.")
+        safeLogWarning("Requesting executors is not supported by current scheduler.")
         false
     }
   }
@@ -1690,7 +1696,7 @@ class SparkContext(config: SparkConf) extends Logging {
         b.killExecutors(executorIds, adjustTargetNumExecutors = true, countFailures = false,
           force = true).nonEmpty
       case _ =>
-        logWarning("Killing executors is not supported by current scheduler.")
+        safeLogWarning("Killing executors is not supported by current scheduler.")
         false
     }
   }
@@ -1729,7 +1735,7 @@ class SparkContext(config: SparkConf) extends Logging {
         b.killExecutors(Seq(executorId), adjustTargetNumExecutors = false, countFailures = true,
           force = true).nonEmpty
       case _ =>
-        logWarning("Killing executors is not supported by current scheduler.")
+        safeLogWarning("Killing executors is not supported by current scheduler.")
         false
     }
   }
@@ -1856,13 +1862,13 @@ class SparkContext(config: SparkConf) extends Logging {
         env.rpcEnv.fileServer.addJar(file)
       } catch {
         case NonFatal(e) =>
-          logError(s"Failed to add $path to Spark environment", e)
+          safeLogError("Failed to add jar to Spark environment", e, UnsafeArg.of("path", path))
           null
       }
     }
 
     if (path == null) {
-      logWarning("null specified as parameter to addJar")
+      safeLogWarning("null specified as parameter to addJar")
     } else {
       val key = if (path.contains("\\")) {
         // For local paths with backslashes on Windows, URI throws an exception
@@ -1886,11 +1892,15 @@ class SparkContext(config: SparkConf) extends Logging {
       if (key != null) {
         val timestamp = System.currentTimeMillis
         if (addedJars.putIfAbsent(key, timestamp).isEmpty) {
-          logInfo(s"Added JAR $path at $key with timestamp $timestamp")
+          safeLogInfo("Added JAR",
+            UnsafeArg.of("path", path),
+            UnsafeArg.of("key", key),
+            SafeArg.of("timestamp", timestamp))
           postEnvironmentUpdate()
         } else {
-          logWarning(s"The jar $path has been added already. Overwriting of added jars " +
-            "is not supported in the current version.")
+          safeLogWarning("The jar has been added already. Overwriting of added jars " +
+            "is not supported in the current version.",
+            UnsafeArg.of("path", path))
         }
       }
     }
@@ -1941,7 +1951,7 @@ class SparkContext(config: SparkConf) extends Logging {
           SparkContext.this.stop()
         } catch {
           case e: Throwable =>
-            logError(e.getMessage, e)
+            safeLogError("Error", e, UnsafeArg.of("message", e.getMessage))
             throw e
         }
       }
@@ -1958,7 +1968,7 @@ class SparkContext(config: SparkConf) extends Logging {
     // Use the stopping variable to ensure no contention for the stop scenario.
     // Still track the stopped variable for use elsewhere in the code.
     if (!stopped.compareAndSet(false, true)) {
-      logInfo("SparkContext already stopped.")
+      safeLogInfo("SparkContext already stopped.")
       return
     }
     if (_shutdownHookRef != null) {
@@ -2027,7 +2037,7 @@ class SparkContext(config: SparkConf) extends Logging {
     localProperties.remove()
     // Unset YARN mode system env variable, to allow switching between cluster types.
     SparkContext.clearActiveContext()
-    logInfo("Successfully stopped SparkContext")
+    safeLogInfo("Successfully stopped SparkContext")
   }
 
 
@@ -2098,9 +2108,10 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     val callSite = getCallSite
     val cleanedFunc = clean(func)
-    logInfo("Starting job: " + callSite.shortForm)
+    safeLogInfo("Starting job", UnsafeArg.of("callSite", callSite.shortForm))
     if (conf.getBoolean("spark.logLineage", false)) {
-      logInfo("RDD's recursive dependencies:\n" + rdd.toDebugString)
+      safeLogInfo("RDD's recursive dependencies",
+        UnsafeArg.of("dependencies", rdd.toDebugString))
     }
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, resultHandler, localProperties.get)
     progressBar.foreach(_.finishAll())
@@ -2221,13 +2232,15 @@ class SparkContext(config: SparkConf) extends Logging {
       timeout: Long): PartialResult[R] = {
     assertNotStopped()
     val callSite = getCallSite
-    logInfo("Starting job: " + callSite.shortForm)
+    safeLogInfo("Starting job", UnsafeArg.of("callSite", callSite.shortForm))
     val start = System.nanoTime
     val cleanedFunc = clean(func)
     val result = dagScheduler.runApproximateJob(rdd, cleanedFunc, evaluator, callSite, timeout,
       localProperties.get)
-    logInfo(
-      "Job finished: " + callSite.shortForm + ", took " + (System.nanoTime - start) / 1e9 + " s")
+    safeLogInfo(
+      "Job finished",
+      UnsafeArg.of("callSite", callSite.shortForm),
+      SafeArg.of("durationInSeconds", (System.nanoTime - start) / 1e9))
     result
   }
 
@@ -2383,9 +2396,10 @@ class SparkContext(config: SparkConf) extends Logging {
     // its own local file system, which is incorrect because the checkpoint files
     // are actually on the executor machines.
     if (!isLocal && Utils.nonLocalPaths(directory).isEmpty) {
-      logWarning("Spark is not running in local mode, therefore the checkpoint directory " +
-        s"must not be on the local filesystem. Directory '$directory' " +
-        "appears to be on the local filesystem.")
+      safeLogWarning("Spark is not running in local mode, therefore the checkpoint directory " +
+        "must not be on the local filesystem. Directory " +
+        "appears to be on the local filesystem.",
+        UnsafeArg.of("directory", directory))
     }
 
     checkpointDir = Option(directory).map { dir =>
@@ -2431,7 +2445,8 @@ class SparkContext(config: SparkConf) extends Logging {
         val listeners = Utils.loadExtensions(classOf[SparkListenerInterface], classNames, conf)
         listeners.foreach { listener =>
           listenerBus.addToSharedQueue(listener)
-          logInfo(s"Registered listener ${listener.getClass().getName()}")
+          safeLogInfo("Registered listener",
+            SafeArg.of("ListenerName", listener.getClass().getName()))
         }
       }
     } catch {
@@ -2491,7 +2506,7 @@ class SparkContext(config: SparkConf) extends Logging {
  * The SparkContext object contains a number of implicit conversions and parameters for use with
  * various Spark features.
  */
-object SparkContext extends Logging {
+object SparkContext extends SafeLogging {
   private val VALID_LOG_LEVELS =
     Set("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN")
 
@@ -2534,7 +2549,7 @@ object SparkContext extends Logging {
             s"The currently running SparkContext was created at:\n${ctx.creationSite.longForm}"
           val exception = new SparkException(errMsg)
           if (allowMultipleContexts) {
-            logWarning("Multiple running SparkContexts detected in the same JVM!", exception)
+            safeLogWarning("Multiple running SparkContexts detected in the same JVM!", exception)
           } else {
             throw exception
           }
@@ -2545,11 +2560,10 @@ object SparkContext extends Logging {
         // its creationSite field being null:
         val otherContextCreationSite =
           Option(otherContext.creationSite).map(_.longForm).getOrElse("unknown location")
-        val warnMsg = "Another SparkContext is being constructed (or threw an exception in its" +
+        safeLogWarning("Another SparkContext is being constructed (or threw an exception in its" +
           " constructor).  This may indicate an error, since only one SparkContext may be" +
-          " running in this JVM (see SPARK-2243)." +
-          s" The other SparkContext was created at:\n$otherContextCreationSite"
-        logWarning(warnMsg)
+          " running in this JVM (see SPARK-2243).",
+          UnsafeArg.of("otherContextCreationSite", otherContextCreationSite))
       }
     }
   }
@@ -2572,7 +2586,7 @@ object SparkContext extends Logging {
         setActiveContext(new SparkContext(config), allowMultipleContexts = false)
       } else {
         if (config.getAll.nonEmpty) {
-          logWarning("Using an existing SparkContext; some configuration may not take effect.")
+          safeLogWarning("Using an existing SparkContext; some configuration may not take effect.")
         }
       }
       activeContext.get()

--- a/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
@@ -19,10 +19,11 @@ package org.apache.spark.broadcast
 
 import java.io.Serializable
 
-import scala.reflect.ClassTag
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
 
+import scala.reflect.ClassTag
 import org.apache.spark.SparkException
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.util.Utils
 
 /**
@@ -54,7 +55,7 @@ import org.apache.spark.util.Utils
  * @param id A unique identifier for the broadcast variable.
  * @tparam T Type of the data contained in the broadcast variable.
  */
-abstract class Broadcast[T: ClassTag](val id: Long) extends Serializable with Logging {
+abstract class Broadcast[T: ClassTag](val id: Long) extends Serializable with SafeLogging {
 
   /**
    * Flag signifying whether the broadcast variable is valid
@@ -107,7 +108,10 @@ abstract class Broadcast[T: ClassTag](val id: Long) extends Serializable with Lo
     assertValid()
     _isValid = false
     _destroySite = Utils.getCallSite().shortForm
-    logInfo("Destroying %s (from %s)".format(toString, _destroySite))
+    safeLogInfo("Destroying",
+      SafeArg.of("id", id),
+      UnsafeArg.of("stringRepr", toString),
+      UnsafeArg.of("destroySite", _destroySite))
     doDestroy(blocking)
   }
 

--- a/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
@@ -19,9 +19,10 @@ package org.apache.spark.broadcast
 
 import java.io.Serializable
 
+import scala.reflect.ClassTag
+
 import com.palantir.logsafe.{SafeArg, UnsafeArg}
 
-import scala.reflect.ClassTag
 import org.apache.spark.SparkException
 import org.apache.spark.internal.SafeLogging
 import org.apache.spark.util.Utils

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -21,11 +21,12 @@ import java.io._
 import java.nio.ByteBuffer
 import java.util.zip.Adler32
 
-import com.palantir.logsafe.SafeArg
-
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.Random
+
+import com.palantir.logsafe.SafeArg
+
 import org.apache.spark._
 import org.apache.spark.internal.SafeLogging
 import org.apache.spark.io.CompressionCodec

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -153,7 +153,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
       val pieceId = BroadcastBlockId(id, "piece" + pid)
       safeLogDebug("Reading piece",
         SafeArg.of("pieceId", pieceId),
-        SafeArg.of("broadCastId", broadcastId))
+        SafeArg.of("broadcastId", broadcastId))
       // First try getLocalBytes because there is a chance that previous attempts to fetch the
       // broadcast blocks have already fetched some of the blocks. In that case, some blocks
       // would be available locally (on this executor).
@@ -229,10 +229,13 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
               throw new SparkException(s"Failed to get locally stored broadcast data: $broadcastId")
             }
           case None =>
-            logInfo("Started reading broadcast variable " + id)
+            safeLogInfo("Started reading broadcast variable",
+              SafeArg.of("id", id))
             val startTimeMs = System.currentTimeMillis()
             val blocks = readBlocks()
-            logInfo("Reading broadcast variable " + id + " took" + Utils.getUsedTimeMs(startTimeMs))
+            safeLogInfo("Reading broadcast variable finished",
+              SafeArg.of("id", id),
+              SafeArg.of("timeUsed", Utils.getUsedTimeMs(startTimeMs)))
 
             try {
               val obj = TorrentBroadcast.unBlockifyObject[T](

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -22,11 +22,12 @@ import java.nio.ByteBuffer
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.palantir.logsafe.{SafeArg, UnsafeArg}
-
 import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
+
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
+
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -22,15 +22,16 @@ import java.nio.ByteBuffer
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
+
 import scala.collection.mutable
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
-
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.worker.WorkerWatcher
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, SafeLogging}
 import org.apache.spark.rpc._
 import org.apache.spark.scheduler.{ExecutorLossReason, TaskDescription}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
@@ -45,7 +46,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     cores: Int,
     userClassPath: Seq[URL],
     env: SparkEnv)
-  extends ThreadSafeRpcEndpoint with ExecutorBackend with Logging {
+  extends ThreadSafeRpcEndpoint with ExecutorBackend with SafeLogging {
 
   private[this] val stopping = new AtomicBoolean(false)
   var executor: Executor = null
@@ -56,7 +57,7 @@ private[spark] class CoarseGrainedExecutorBackend(
   private[this] val ser: SerializerInstance = env.closureSerializer.newInstance()
 
   override def onStart() {
-    logInfo("Connecting to driver: " + driverUrl)
+    safeLogInfo("Connecting to driver", UnsafeArg.of("driverUrl", driverUrl))
     rpcEnv.asyncSetupEndpointRefByURI(driverUrl).flatMap { ref =>
       // This is a very fast action so we can use "ThreadUtils.sameThread"
       driver = Some(ref)
@@ -78,7 +79,7 @@ private[spark] class CoarseGrainedExecutorBackend(
 
   override def receive: PartialFunction[Any, Unit] = {
     case RegisteredExecutor =>
-      logInfo("Successfully registered with driver")
+      safeLogInfo("Successfully registered with driver")
       try {
         executor = new Executor(executorId, hostname, env, userClassPath, isLocal = false)
       } catch {
@@ -94,7 +95,7 @@ private[spark] class CoarseGrainedExecutorBackend(
         exitExecutor(1, "Received LaunchTask command but executor was null")
       } else {
         val taskDesc = TaskDescription.decode(data.value)
-        logInfo("Got assigned task " + taskDesc.taskId)
+        safeLogInfo("Got assigned task", SafeArg.of("taskId", taskDesc.taskId))
         executor.launchTask(this, taskDesc)
       }
 
@@ -107,7 +108,7 @@ private[spark] class CoarseGrainedExecutorBackend(
 
     case StopExecutor =>
       stopping.set(true)
-      logInfo("Driver commanded a shutdown")
+      safeLogInfo("Driver commanded a shutdown")
       // Cannot shutdown here because an ack may need to be sent back to the caller. So send
       // a message to self to actually do the shutdown.
       self.send(Shutdown)
@@ -125,18 +126,20 @@ private[spark] class CoarseGrainedExecutorBackend(
       }.start()
 
     case UpdateDelegationTokens(tokenBytes) =>
-      logInfo(s"Received tokens of ${tokenBytes.length} bytes")
+      safeLogInfo("Received tokens", UnsafeArg.of("tokenBytesLength", tokenBytes.length))
       SparkHadoopUtil.get.addDelegationTokens(tokenBytes, env.conf)
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {
     if (stopping.get()) {
-      logInfo(s"Driver from $remoteAddress disconnected during shutdown")
+      safeLogInfo("Driver disconnected during shutdown",
+        UnsafeArg.of("remoteAddress", remoteAddress))
     } else if (driver.exists(_.address == remoteAddress)) {
       exitExecutor(1, s"Driver $remoteAddress disassociated! Shutting down.", null,
         notifyDriver = false)
     } else {
-      logWarning(s"An unknown ($remoteAddress) driver disconnected.")
+      safeLogWarning("An unknown driver disconnected.",
+        UnsafeArg.of("remoteAddress", remoteAddress))
     }
   }
 
@@ -144,7 +147,8 @@ private[spark] class CoarseGrainedExecutorBackend(
     val msg = StatusUpdate(executorId, taskId, state, data)
     driver match {
       case Some(driverRef) => driverRef.send(msg)
-      case None => logWarning(s"Drop $msg because has not yet connected to driver")
+      case None => safeLogWarning("Drop message because has not yet connected to driver",
+        UnsafeArg.of("msg", msg))
     }
   }
 
@@ -157,11 +161,11 @@ private[spark] class CoarseGrainedExecutorBackend(
                              reason: String,
                              throwable: Throwable = null,
                              notifyDriver: Boolean = true) = {
-    val message = "Executor self-exiting due to : " + reason
+    val message = "Executor self-exiting"
     if (throwable != null) {
-      logError(message, throwable)
+      safeLogError(message, throwable, UnsafeArg.of("reason", reason))
     } else {
-      logError(message)
+      safeLogError(message, UnsafeArg.of("reason", reason))
     }
 
     if (notifyDriver && driver.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -470,7 +470,8 @@ private[spark] class Executor(
           // unlikely).  So we will log an error and keep going.
           safeLogError("Task completed successfully though internally it encountered " +
             "unrecoverable fetch failures!  Most likely this means user code is incorrectly " +
-            "swallowing Spark's internal exception", fetchFailure,
+            "swallowing Spark's internal exception",
+            fetchFailure,
             SafeArg.of("taskId", taskId),
             SafeArg.of("internalExceptionName", classOf[FetchFailedException]))
         }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -24,18 +24,18 @@ import java.net.{URI, URL}
 import java.nio.ByteBuffer
 import java.util.Properties
 import java.util.concurrent._
+
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap, Map}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.internal.config._
 import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager}
 import org.apache.spark.rpc.RpcTimeout
@@ -59,9 +59,11 @@ private[spark] class Executor(
     userClassPath: Seq[URL] = Nil,
     isLocal: Boolean = false,
     uncaughtExceptionHandler: UncaughtExceptionHandler = new SparkUncaughtExceptionHandler)
-  extends Logging {
+  extends SafeLogging {
 
-  logInfo(s"Starting executor ID $executorId on host $executorHostname")
+  safeLogInfo("Starting executor on host",
+    SafeArg.of("executorId", executorId),
+    UnsafeArg.of("host",executorHostname))
 
   // Application dependencies (added through SparkContext) that we've fetched so far on this node.
   // Each map holds the master's timestamp for the version of that file or JAR we got.
@@ -140,7 +142,8 @@ private[spark] class Executor(
   private val executorPlugins: Seq[ExecutorPlugin] = {
     val pluginNames = conf.get(EXECUTOR_PLUGINS)
     if (pluginNames.nonEmpty) {
-      logDebug(s"Initializing the following plugins: ${pluginNames.mkString(", ")}")
+      safeLogDebug("Initializing the following plugins",
+        UnsafeArg.of("pluginNames", pluginNames.mkString(", ")))
 
       // Plugins need to load using a class loader that includes the executor's user classpath
       val pluginList: Seq[ExecutorPlugin] =
@@ -148,12 +151,13 @@ private[spark] class Executor(
           val plugins = Utils.loadExtensions(classOf[ExecutorPlugin], pluginNames, conf)
           plugins.foreach { plugin =>
             plugin.init()
-            logDebug(s"Successfully loaded plugin " + plugin.getClass().getCanonicalName())
+            safeLogDebug("Successfully loaded plugin",
+              UnsafeArg.of("pluginName", plugin.getClass().getCanonicalName()))
           }
           plugins
         }
 
-      logDebug("Finished initializing plugins")
+      safeLogDebug("Finished initializing plugins")
       pluginList
     } else {
       Nil
@@ -256,7 +260,7 @@ private[spark] class Executor(
       heartbeater.stop()
     } catch {
       case NonFatal(e) =>
-        logWarning("Unable to stop heartbeater", e)
+        safeLogWarning("Unable to stop heartbeater", e)
      }
     threadPool.shutdown()
 
@@ -267,7 +271,8 @@ private[spark] class Executor(
           plugin.shutdown()
         } catch {
           case e: Exception =>
-            logWarning("Plugin " + plugin.getClass().getCanonicalName() + " shutdown failed", e)
+            safeLogWarning("Plugin shutdown failed", e,
+              SafeArg.of("pluginName", plugin.getClass().getCanonicalName()))
         }
       }
     }
@@ -313,7 +318,10 @@ private[spark] class Executor(
     @volatile var task: Task[Any] = _
 
     def kill(interruptThread: Boolean, reason: String): Unit = {
-      logInfo(s"Executor is trying to kill $taskName (TID $taskId), reason: $reason")
+      safeLogInfo("Executor is trying to kill task",
+        UnsafeArg.of("taskName", taskName),
+        SafeArg.of("taskId", taskId),
+        UnsafeArg.of("reason", reason))
       reasonIfKilled = Some(reason)
       if (task != null) {
         synchronized {
@@ -372,7 +380,9 @@ private[spark] class Executor(
       } else 0L
       Thread.currentThread.setContextClassLoader(replClassLoader)
       val ser = env.closureSerializer.newInstance()
-      logInfo(s"Running $taskName (TID $taskId)")
+      safeLogInfo("Running task",
+        UnsafeArg.of("taskName", taskName),
+        SafeArg.of("taskId", taskId))
       execBackend.statusUpdate(taskId, TaskState.RUNNING, EMPTY_BYTE_BUFFER)
       var taskStartTime: Long = 0
       var taskStartCpu: Long = 0
@@ -405,7 +415,9 @@ private[spark] class Executor(
         // MapOutputTrackerMaster and its cache invalidation is not based on epoch numbers so
         // we don't need to make any special calls here.
         if (!isLocal) {
-          logDebug("Task " + taskId + "'s epoch is " + task.epoch)
+          safeLogDebug("Task's epoch",
+            SafeArg.of("taskId", taskId),
+            SafeArg.of("epoch", task.epoch))
           env.mapOutputTracker.asInstanceOf[MapOutputTrackerWorker].updateEpoch(task.epoch)
         }
 
@@ -431,7 +443,9 @@ private[spark] class Executor(
             if (conf.getBoolean("spark.unsafe.exceptionOnMemoryLeak", false)) {
               throw new SparkException(errMsg)
             } else {
-              logWarning(errMsg)
+              safeLogWarning("Managed memory leak detected",
+                SafeArg.of("sizeInBytes", freedMemory),
+                SafeArg.of("taskId", taskId))
             }
           }
 
@@ -442,7 +456,10 @@ private[spark] class Executor(
             if (conf.getBoolean("spark.storage.exceptionOnPinLeak", false)) {
               throw new SparkException(errMsg)
             } else {
-              logInfo(errMsg)
+              safeLogInfo("block locks were not released by task",
+                SafeArg.of("numBlockLocks", releasedLocks.size),
+                SafeArg.of("taskId", taskId),
+                SafeArg.of("locks", releasedLocks.mkString("[", ", ", "]")))
             }
           }
         }
@@ -450,9 +467,11 @@ private[spark] class Executor(
           // uh-oh.  it appears the user code has caught the fetch-failure without throwing any
           // other exceptions.  Its *possible* this is what the user meant to do (though highly
           // unlikely).  So we will log an error and keep going.
-          logError(s"TID ${taskId} completed successfully though internally it encountered " +
+          safeLogError("Task completed successfully though internally it encountered " +
             s"unrecoverable fetch failures!  Most likely this means user code is incorrectly " +
-            s"swallowing Spark's internal ${classOf[FetchFailedException]}", fetchFailure)
+            s"swallowing Spark's internal exception", fetchFailure,
+            SafeArg.of("taskId", taskId),
+            SafeArg.of("internalExceptionName", classOf[FetchFailedException]))
         }
         val taskFinish = System.currentTimeMillis()
         val taskFinishCpu = if (threadMXBean.isCurrentThreadCpuTimeSupported) {
@@ -531,9 +550,12 @@ private[spark] class Executor(
         // directSend = sending directly back to the driver
         val serializedResult: ByteBuffer = {
           if (maxResultSize > 0 && resultSize > maxResultSize) {
-            logWarning(s"Finished $taskName (TID $taskId). Result is larger than maxResultSize " +
-              s"(${Utils.bytesToString(resultSize)} > ${Utils.bytesToString(maxResultSize)}), " +
-              s"dropping it.")
+            safeLogWarning("Finished task. Result is larger than maxResultSize " +
+              "dropping it.",
+              UnsafeArg.of("taskName", taskName),
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("resultSize", Utils.bytesToString(resultSize)),
+              SafeArg.of("maxResultSize", Utils.bytesToString(maxResultSize)))
             ser.serialize(new IndirectTaskResult[Any](TaskResultBlockId(taskId), resultSize))
           } else if (resultSize > maxDirectResultSize) {
             val blockId = TaskResultBlockId(taskId)
@@ -541,11 +563,17 @@ private[spark] class Executor(
               blockId,
               new ChunkedByteBuffer(serializedDirectResult.duplicate()),
               StorageLevel.MEMORY_AND_DISK_SER)
-            logInfo(
-              s"Finished $taskName (TID $taskId). $resultSize bytes result sent via BlockManager)")
+            safeLogInfo(
+              "Finished task. result sent via BlockManager)",
+              UnsafeArg.of("taskName", taskName),
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("resultSizeInBytes", resultSize))
             ser.serialize(new IndirectTaskResult[Any](blockId, resultSize))
           } else {
-            logInfo(s"Finished $taskName (TID $taskId). $resultSize bytes result sent to driver")
+            safeLogInfo("Finished task. result sent to driver",
+              UnsafeArg.of("taskName", taskName),
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("resultSizeInBytes", resultSize))
             serializedDirectResult
           }
         }
@@ -555,7 +583,10 @@ private[spark] class Executor(
 
       } catch {
         case t: TaskKilledException =>
-          logInfo(s"Executor killed $taskName (TID $taskId), reason: ${t.reason}")
+          safeLogInfo("Executor killed task",
+            UnsafeArg.of("taskName", taskName),
+            SafeArg.of("taskId", taskId),
+            UnsafeArg.of("reason", t.reason))
 
           val (accums, accUpdates) = collectAccumulatorsAndResetStatusOnFailure(taskStartTime)
           val serializedTK = ser.serialize(TaskKilled(t.reason, accUpdates, accums))
@@ -564,7 +595,10 @@ private[spark] class Executor(
         case _: InterruptedException | NonFatal(_) if
             task != null && task.reasonIfKilled.isDefined =>
           val killReason = task.reasonIfKilled.getOrElse("unknown reason")
-          logInfo(s"Executor interrupted and killed $taskName (TID $taskId), reason: $killReason")
+          safeLogInfo("Executor interrupted and killed task",
+            UnsafeArg.of("taskName", taskName),
+            SafeArg.of("taskId", taskId),
+            UnsafeArg.of("reason", killReason))
 
           val (accums, accUpdates) = collectAccumulatorsAndResetStatusOnFailure(taskStartTime)
           val serializedTK = ser.serialize(TaskKilled(killReason, accUpdates, accums))
@@ -576,10 +610,12 @@ private[spark] class Executor(
             // there was a fetch failure in the task, but some user code wrapped that exception
             // and threw something else.  Regardless, we treat it as a fetch failure.
             val fetchFailedCls = classOf[FetchFailedException].getName
-            logWarning(s"TID ${taskId} encountered a ${fetchFailedCls} and " +
-              s"failed, but the ${fetchFailedCls} was hidden by another " +
+            safeLogWarning(s"Task encountered a fetch failure exception and " +
+              s"failed, but the fetch failure exception was hidden by another " +
               s"exception.  Spark is handling this like a fetch failure and ignoring the " +
-              s"other exception: $t")
+              s"other exception: $t",
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("fetchFailedExceptionClass", fetchFailedCls))
           }
           setTaskFinishedAndClearInterruptStatus()
           execBackend.statusUpdate(taskId, TaskState.FAILED, ser.serialize(reason))
@@ -593,7 +629,9 @@ private[spark] class Executor(
           // Attempt to exit cleanly by informing the driver of our failure.
           // If anything goes wrong (or this was a fatal exception), we will delegate to
           // the default uncaught exception handler, which will terminate the Executor.
-          logError(s"Exception in $taskName (TID $taskId)", t)
+          safeLogError("Exception in task", t,
+            UnsafeArg.of("taskName", taskName),
+            SafeArg.of("taskId", taskId))
 
           // SPARK-20904: Do not report failure to driver if if happened during shut down. Because
           // libraries may set up shutdown hooks that race with running tasks during shutdown,
@@ -615,7 +653,7 @@ private[spark] class Executor(
             setTaskFinishedAndClearInterruptStatus()
             execBackend.statusUpdate(taskId, TaskState.FAILED, serializedTaskEndReason)
           } else {
-            logInfo("Not reporting error to driver during JVM shutdown.")
+            safeLogInfo("Not reporting error to driver during JVM shutdown.")
           }
 
           // Don't forcibly exit unless the exception was inherently fatal, to avoid
@@ -700,17 +738,21 @@ private[spark] class Executor(
           if (taskRunner.isFinished) {
             finished = true
           } else {
-            logWarning(s"Killed task $taskId is still running after $elapsedTimeMs ms")
+            safeLogWarning("Killed task is still running",
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("stillRunningAfterMs", elapsedTimeMs))
             if (takeThreadDump) {
               try {
                 Utils.getThreadDumpForThread(taskRunner.getThreadId).foreach { thread =>
                   if (thread.threadName == taskRunner.threadName) {
-                    logWarning(s"Thread dump from task $taskId:\n${thread.stackTrace}")
+                    safeLogWarning("Thread dump from task",
+                      SafeArg.of("taskId", taskId),
+                      UnsafeArg.of("stacktrace", thread.stackTrace))
                   }
                 }
               } catch {
                 case NonFatal(e) =>
-                  logWarning("Exception thrown while obtaining thread dump: ", e)
+                  safeLogWarning("Exception thrown while obtaining thread dump: ", e)
               }
             }
           }
@@ -718,8 +760,10 @@ private[spark] class Executor(
 
         if (!taskRunner.isFinished && timeoutExceeded()) {
           if (isLocal) {
-            logError(s"Killed task $taskId could not be stopped within $killTimeoutMs ms; " +
-              "not killing JVM because we are running in local mode.")
+            safeLogError(s"Killed task could not be stopped; " +
+              "not killing JVM because we are running in local mode.",
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("notStoppedWithinMs", killTimeoutMs))
           } else {
             // In non-local-mode, the exception thrown here will bubble up to the uncaught exception
             // handler and cause the executor JVM to exit.
@@ -777,7 +821,7 @@ private[spark] class Executor(
   private def addReplClassLoaderIfNeeded(parent: ClassLoader): ClassLoader = {
     val classUri = conf.get("spark.repl.class.uri", null)
     if (classUri != null) {
-      logInfo("Using REPL class URI: " + classUri)
+      safeLogInfo("Using REPL class URI", UnsafeArg.of("uri", classUri))
       try {
         val _userClassPathFirst: java.lang.Boolean = userClassPathFirst
         val klass = Utils.classForName("org.apache.spark.repl.ExecutorClassLoader")
@@ -787,7 +831,7 @@ private[spark] class Executor(
         constructor.newInstance(conf, env, classUri, parent, _userClassPathFirst)
       } catch {
         case _: ClassNotFoundException =>
-          logError("Could not find org.apache.spark.repl.ExecutorClassLoader on classpath!")
+          safeLogError("Could not find org.apache.spark.repl.ExecutorClassLoader on classpath!")
           System.exit(1)
           null
       }
@@ -805,7 +849,9 @@ private[spark] class Executor(
     synchronized {
       // Fetch missing dependencies
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
-        logInfo("Fetching " + name + " with timestamp " + timestamp)
+        safeLogInfo("Fetching",
+          UnsafeArg.of("name", name),
+          SafeArg.of("timestamp", timestamp))
         // Fetch file with useCache mode, close cache for local mode.
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
           env.securityManager, hadoopConf, timestamp, useCache = !isLocal)
@@ -817,7 +863,9 @@ private[spark] class Executor(
           .orElse(currentJars.get(localName))
           .getOrElse(-1L)
         if (currentTimeStamp < timestamp) {
-          logInfo("Fetching " + name + " with timestamp " + timestamp)
+          safeLogInfo("Fetching",
+            UnsafeArg.of("name", name),
+            SafeArg.of("timestamp", timestamp))
           // Fetch file with useCache mode, close cache for local mode.
           Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
             env.securityManager, hadoopConf, timestamp, useCache = !isLocal)
@@ -825,7 +873,7 @@ private[spark] class Executor(
           // Add it to our class loader
           val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
           if (!urlClassLoader.getURLs().contains(url)) {
-            logInfo("Adding " + url + " to class loader")
+            safeLogInfo("Adding url to class loader", UnsafeArg.of("url", url))
             urlClassLoader.addURL(url)
           }
         }
@@ -862,17 +910,18 @@ private[spark] class Executor(
       val response = heartbeatReceiverRef.askSync[HeartbeatResponse](
         message, new RpcTimeout(HEARTBEAT_INTERVAL_MS.millis, EXECUTOR_HEARTBEAT_INTERVAL.key))
       if (response.reregisterBlockManager) {
-        logInfo("Told to re-register on heartbeat")
+        safeLogInfo("Told to re-register on heartbeat")
         env.blockManager.reregister()
       }
       heartbeatFailures = 0
     } catch {
       case NonFatal(e) =>
-        logWarning("Issue communicating with driver in heartbeater", e)
+        safeLogWarning("Issue communicating with driver in heartbeater", e)
         heartbeatFailures += 1
         if (heartbeatFailures >= HEARTBEAT_MAX_FAILURES) {
-          logError(s"Exit as unable to send heartbeats to driver " +
-            s"more than $HEARTBEAT_MAX_FAILURES times")
+          safeLogError("Exit as unable to send heartbeats to driver " +
+            "more than the maximum allowed number of times",
+            SafeArg.of("maxHearbeatFailures", HEARTBEAT_MAX_FAILURES))
           System.exit(ExecutorExitCode.HEARTBEAT_FAILURE)
         }
     }

--- a/core/src/main/scala/org/apache/spark/internal/SafeLogging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/SafeLogging.scala
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory
 trait SafeLogging {
   private[this] val log_ = LoggerFactory.getLogger(this.getClass.getName)
 
+  def safeLogIsInfoEnabled: Boolean = log_.isInfoEnabled
+
   def safeLogInfo(message: String, args: Arg[_]*): Unit = {
     if (log_.isInfoEnabled) log_.info(message, args: _*)
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -705,7 +705,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * @return whether the kill request is acknowledged.
    */
   final override def killExecutorsOnHost(host: String): Boolean = {
-    safeLogInfo(s"Requesting to kill any and all executors on host",
+    safeLogInfo("Requesting to kill any and all executors on host",
       UnsafeArg.of("host", host))
     // A potential race exists if a new executor attempts to register on a host
     // that is on the blacklist and is no no longer valid. To avoid this race,

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -130,8 +130,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               makeOffers(executorId)
             case None =>
               // Ignoring the update since we don't know about the executor.
-              safeLogWarning("Ignored task status update ($taskId state $state) " +
-                "from unknown executor with ID $executorId",
+              safeLogWarning("Ignored task status update from unknown executor",
                 SafeArg.of("taskId", taskId),
                 SafeArg.of("state", state),
                 SafeArg.of("executorId", executorId))
@@ -388,8 +387,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       }
 
       if (shouldDisable) {
-        safeLogInfo("Disabling executor.",
-          SafeArg.of("executorId", executorId))
+        safeLogInfo("Disabling executor.", SafeArg.of("executorId", executorId))
         scheduler.executorLost(executorId, LossReasonPending)
       }
 
@@ -498,12 +496,13 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   override def isReady(): Boolean = {
     if (sufficientResourcesRegistered) {
       safeLogInfo("SchedulerBackend is ready for scheduling beginning after " +
-        s"reached minRegisteredResourcesRatio",
+        "reached minRegisteredResourcesRatio",
         SafeArg.of("minRegisteredRatio", minRegisteredRatio))
       return true
     }
     if ((System.currentTimeMillis() - createTime) >= maxRegisteredWaitingTimeMs) {
-      safeLogInfo("SchedulerBackend is ready for scheduling beginning after waiting",
+      safeLogInfo("SchedulerBackend is ready for scheduling beginning after " +
+        "waiting maxRegisteredResourcesWaitingTime",
         SafeArg.of("maxRegisteredResourcesWaitingTimeInMs", maxRegisteredWaitingTimeMs))
       return true
     }
@@ -705,8 +704,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * @return whether the kill request is acknowledged.
    */
   final override def killExecutorsOnHost(host: String): Boolean = {
-    safeLogInfo("Requesting to kill any and all executors on host",
-      UnsafeArg.of("host", host))
+    safeLogInfo("Requesting to kill any and all executors on host", UnsafeArg.of("host", host))
     // A potential race exists if a new executor attempts to register on a host
     // that is on the blacklist and is no no longer valid. To avoid this race,
     // all executor registration and killing happens in the event loop. This way, either

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -24,8 +24,11 @@ import javax.annotation.concurrent.GuardedBy
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.Future
 
+import com.palantir.logsafe.SafeArg
+import com.palantir.logsafe.UnsafeArg
+
 import org.apache.spark.{ExecutorAllocationClient, SparkEnv, SparkException, TaskState}
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.rpc._
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
@@ -42,7 +45,7 @@ import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils, Utils}
  */
 private[spark]
 class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: RpcEnv)
-  extends ExecutorAllocationClient with SchedulerBackend with Logging {
+  extends ExecutorAllocationClient with SchedulerBackend with SafeLogging {
 
   // Use an atomic variable to track total number of cores in the cluster for simplicity and speed
   protected val totalCoreCount = new AtomicInteger(0)
@@ -99,7 +102,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-revive-thread")
 
   class DriverEndpoint(override val rpcEnv: RpcEnv, sparkProperties: Seq[(String, String)])
-    extends ThreadSafeRpcEndpoint with Logging {
+    extends ThreadSafeRpcEndpoint with SafeLogging {
 
     // Executors that have been lost, but for which we don't yet know the real exit reason.
     protected val executorsPendingLossReason = new HashSet[String]
@@ -127,8 +130,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               makeOffers(executorId)
             case None =>
               // Ignoring the update since we don't know about the executor.
-              logWarning(s"Ignored task status update ($taskId state $state) " +
-                s"from unknown executor with ID $executorId")
+              safeLogWarning("Ignored task status update ($taskId state $state) " +
+                "from unknown executor with ID $executorId",
+                SafeArg.of("taskId", taskId),
+                SafeArg.of("state", state),
+                SafeArg.of("executorId", executorId))
           }
         }
 
@@ -142,7 +148,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               KillTask(taskId, executorId, interruptThread, reason))
           case None =>
             // Ignoring the task kill since the executor is not registered.
-            logWarning(s"Attempted to kill task $taskId for unknown executor $executorId.")
+            safeLogWarning("Attempted to kill task for unknown executor.",
+              SafeArg.of("taskId", taskId),
+              SafeArg.of("executorId", executorId))
         }
 
       case KillExecutorsOnHost(host) =>
@@ -174,7 +182,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // If the cluster manager gives us an executor on a blacklisted node (because it
           // already started allocating those resources before we informed it of our blacklist,
           // or if it ignored our blacklist), then we reject that executor immediately.
-          logInfo(s"Rejecting $executorId as it has been blacklisted.")
+          safeLogInfo("Rejecting executorId as it has been blacklisted.",
+            SafeArg.of("executorId", executorId))
           executorRef.send(RegisterExecutorFailed(s"Executor is blacklisted: $executorId"))
           context.reply(true)
         } else {
@@ -185,7 +194,10 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             } else {
               context.senderAddress
             }
-          logInfo(s"Registered executor $executorRef ($executorAddress) with ID $executorId")
+          safeLogInfo("Registered executor",
+            UnsafeArg.of("executorRef", executorRef),
+            UnsafeArg.of("executorAddress", executorAddress),
+            SafeArg.of("executorId", executorId))
           addressToExecutorId(executorAddress) = executorId
           totalCoreCount.addAndGet(cores)
           totalRegisteredExecutors.addAndGet(1)
@@ -200,7 +212,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             }
             if (numPendingExecutors > 0) {
               numPendingExecutors -= 1
-              logDebug(s"Decremented number of pending executors ($numPendingExecutors left)")
+              safeLogDebug("Decremented number of pending executors",
+                SafeArg.of("numPendingExecutorsLeft", numPendingExecutors))
             }
           }
           executorRef.send(RegisteredExecutor)
@@ -216,7 +229,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         stop()
 
       case StopExecutors =>
-        logInfo("Asking each executor to shut down")
+        safeLogInfo("Asking each executor to shut down")
         for ((_, executorData) <- executorDataMap) {
           executorData.executorEndpoint.send(StopExecutor)
         }
@@ -298,7 +311,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               msg = msg.format(task.taskId, task.index, serializedTask.limit(), maxRpcMessageSize)
               taskSetMgr.abort(msg)
             } catch {
-              case e: Exception => logError("Exception in error callback", e)
+              case e: Exception => safeLogError("Exception in error callback", e)
             }
           }
         }
@@ -306,8 +319,10 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           val executorData = executorDataMap(task.executorId)
           executorData.freeCores -= scheduler.CPUS_PER_TASK
 
-          logDebug(s"Launching task ${task.taskId} on executor id: ${task.executorId} hostname: " +
-            s"${executorData.executorHost}.")
+          safeLogDebug("Launching task on executor.",
+            SafeArg.of("taskId", task.taskId),
+            SafeArg.of("executorId", task.executorId),
+            UnsafeArg.of("executorHostname", executorData.executorHost))
 
           executorData.executorEndpoint.send(LaunchTask(new SerializableBuffer(serializedTask)))
         }
@@ -316,7 +331,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Remove a disconnected slave from the cluster
     private def removeExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
-      logDebug(s"Asked to remove executor $executorId with reason $reason")
+      safeLogDebug("Asked to remove executor",
+        SafeArg.of("executorId", executorId),
+        UnsafeArg.of("reason", reason))
       executorDataMap.get(executorId) match {
         case Some(executorInfo) =>
           // This must be synchronized because variables mutated
@@ -339,13 +356,16 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // about the executor, but the scheduler will not. Therefore, we should remove the
           // executor from the block manager when we hit this case.
           scheduler.sc.env.blockManager.master.removeExecutorAsync(executorId)
-          logInfo(s"Asked to remove non-existent executor $executorId")
+          safeLogInfo("Asked to remove non-existent executor",
+            SafeArg.of("executorId", executorId))
       }
     }
 
     // Remove a lost worker from the cluster
     private def removeWorker(workerId: String, host: String, message: String): Unit = {
-      logDebug(s"Asked to remove worker $workerId with reason $message")
+      safeLogDebug("Asked to remove worker",
+        SafeArg.of("workerId", workerId),
+        UnsafeArg.of("reason", message))
       scheduler.workerRemoved(workerId, host, message)
     }
 
@@ -368,7 +388,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       }
 
       if (shouldDisable) {
-        logInfo(s"Disabling executor $executorId.")
+        safeLogInfo("Disabling executor.",
+          SafeArg.of("executorId", executorId))
         scheduler.executorLost(executorId, LossReasonPending)
       }
 
@@ -404,7 +425,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   def stopExecutors() {
     try {
       if (driverEndpoint != null) {
-        logInfo("Shutting down all executors")
+        safeLogInfo("Shutting down all executors")
         driverEndpoint.askSync[Boolean](StopExecutors)
       }
     } catch {
@@ -468,20 +489,22 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   protected def removeWorker(workerId: String, host: String, message: String): Unit = {
     driverEndpoint.ask[Boolean](RemoveWorker(workerId, host, message)).failed.foreach(t =>
-      logError(t.getMessage, t))(ThreadUtils.sameThread)
+      safeLogError("Error removing worker", t, UnsafeArg.of("message", t.getMessage))
+    )(ThreadUtils.sameThread)
   }
 
   def sufficientResourcesRegistered(): Boolean = true
 
   override def isReady(): Boolean = {
     if (sufficientResourcesRegistered) {
-      logInfo("SchedulerBackend is ready for scheduling beginning after " +
-        s"reached minRegisteredResourcesRatio: $minRegisteredRatio")
+      safeLogInfo("SchedulerBackend is ready for scheduling beginning after " +
+        s"reached minRegisteredResourcesRatio",
+        SafeArg.of("minRegisteredRatio", minRegisteredRatio))
       return true
     }
     if ((System.currentTimeMillis() - createTime) >= maxRegisteredWaitingTimeMs) {
-      logInfo("SchedulerBackend is ready for scheduling beginning after waiting " +
-        s"maxRegisteredResourcesWaitingTime: $maxRegisteredWaitingTimeMs(ms)")
+      safeLogInfo("SchedulerBackend is ready for scheduling beginning after waiting",
+        SafeArg.of("maxRegisteredResourcesWaitingTimeInMs", maxRegisteredWaitingTimeMs))
       return true
     }
     false
@@ -512,20 +535,23 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         "Attempted to request a negative number of additional executor(s) " +
         s"$numAdditionalExecutors from the cluster manager. Please specify a positive number!")
     }
-    logInfo(s"Requesting $numAdditionalExecutors additional executor(s) from the cluster manager")
+    safeLogInfo("Requesting additional executor(s) from the cluster manager",
+      SafeArg.of("numAdditionalExecutors", numAdditionalExecutors))
 
     val response = synchronized {
       requestedTotalExecutors += numAdditionalExecutors
       numPendingExecutors += numAdditionalExecutors
-      logDebug(s"Number of pending executors is now $numPendingExecutors")
+      safeLogDebug("Number of pending executors is now",
+        SafeArg.of("numPendingExecutors", numPendingExecutors))
       if (requestedTotalExecutors !=
           (numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)) {
-        logDebug(
-          s"""requestExecutors($numAdditionalExecutors): Executor request doesn't match:
-             |requestedTotalExecutors  = $requestedTotalExecutors
-             |numExistingExecutors     = $numExistingExecutors
-             |numPendingExecutors      = $numPendingExecutors
-             |executorsPendingToRemove = ${executorsPendingToRemove.size}""".stripMargin)
+        safeLogDebug(
+          "requestExecutors: Executor request doesn't match.",
+        SafeArg.of("numAdditionalExecutors", numAdditionalExecutors),
+        SafeArg.of("requestedTotalExecutors", requestedTotalExecutors),
+        SafeArg.of("numExistingExecutors", numExistingExecutors),
+        SafeArg.of("numPendingExecutors", numPendingExecutors),
+        SafeArg.of("executorsPendingToRemove", executorsPendingToRemove.size))
       }
 
       // Account for executors pending to be added or removed
@@ -605,12 +631,14 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       adjustTargetNumExecutors: Boolean,
       countFailures: Boolean,
       force: Boolean): Seq[String] = {
-    logInfo(s"Requesting to kill executor(s) ${executorIds.mkString(", ")}")
+    safeLogInfo("Requesting to kill executor(s)",
+      SafeArg.of("executorIds", executorIds.mkString(", ")))
 
     val response = synchronized {
       val (knownExecutors, unknownExecutors) = executorIds.partition(executorDataMap.contains)
       unknownExecutors.foreach { id =>
-        logWarning(s"Executor to kill $id does not exist!")
+        safeLogWarning("Executor to kill does not exist!",
+          SafeArg.of("executorId", id))
       }
 
       // If an executor is already pending to be removed, do not kill it again (SPARK-9795)
@@ -620,7 +648,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         .filter { id => force || !scheduler.isExecutorBusy(id) }
       executorsToKill.foreach { id => executorsPendingToRemove(id) = !countFailures }
 
-      logInfo(s"Actual list of executor(s) to be killed is ${executorsToKill.mkString(", ")}")
+      safeLogInfo("Actual list of executor(s) to be killed",
+        SafeArg.of("executorIds", executorsToKill.mkString(", ")))
 
       // If we do not wish to replace the executors we kill, sync the target number of executors
       // with the cluster manager to avoid allocating new ones. When computing the new target,
@@ -630,13 +659,16 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           requestedTotalExecutors = math.max(requestedTotalExecutors - executorsToKill.size, 0)
           if (requestedTotalExecutors !=
               (numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)) {
-            logDebug(
-              s"""killExecutors($executorIds, $adjustTargetNumExecutors, $countFailures, $force):
-                 |Executor counts do not match:
-                 |requestedTotalExecutors  = $requestedTotalExecutors
-                 |numExistingExecutors     = $numExistingExecutors
-                 |numPendingExecutors      = $numPendingExecutors
-                 |executorsPendingToRemove = ${executorsPendingToRemove.size}""".stripMargin)
+            safeLogDebug(
+              "killExecutors: Executor counts do not match.",
+              SafeArg.of("executorIds", executorIds),
+              SafeArg.of("adjustTargetNumExecutors", adjustTargetNumExecutors),
+              SafeArg.of("countFailures", countFailures),
+              SafeArg.of("force", force),
+              SafeArg.of("requestedTotalExecutors", requestedTotalExecutors),
+              SafeArg.of("numExistingExecutors", numExistingExecutors),
+              SafeArg.of("numPendingExecutors", numPendingExecutors),
+              SafeArg.of("executorsPendingToRemove", executorsPendingToRemove.size))
           }
           doRequestTotalExecutors(requestedTotalExecutors)
         } else {
@@ -673,7 +705,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * @return whether the kill request is acknowledged.
    */
   final override def killExecutorsOnHost(host: String): Boolean = {
-    logInfo(s"Requesting to kill any and all executors on host ${host}")
+    safeLogInfo(s"Requesting to kill any and all executors on host",
+      UnsafeArg.of("host", host))
     // A potential race exists if a new executor attempts to register on a host
     // that is on the blacklist and is no no longer valid. To avoid this race,
     // all executor registration and killing happens in the event loop. This way, either

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -157,7 +157,7 @@ private[spark] class MemoryStore(
       entries.synchronized {
         entries.put(blockId, entry)
       }
-      safeLogInfo("Block %s stored as bytes in memory (estimated size %s, free %s)",
+      safeLogInfo("Block %stored as bytes in memory",
         SafeArg.of("blockId", blockId),
         SafeArg.of("estimatedSize", Utils.bytesToString(size)),
         SafeArg.of("freeMemory", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
@@ -627,7 +627,7 @@ private[spark] class MemoryStore(
    */
   private def logMemoryUsage(): Unit = {
     safeLogInfo(
-      s"Memory use",
+      "Memory use",
       SafeArg.of("blocksMemoryUsed", Utils.bytesToString(blocksMemoryUsed)),
       SafeArg.of("scratchSpaceShared", Utils.bytesToString(currentUnrollMemory)),
       SafeArg.of("numTasksSharingScratchSpace", numTasksUnrolling),
@@ -650,7 +650,7 @@ private[spark] class MemoryStore(
     )
     logMemoryUsage()
   }
-}ScratchSpaceShared
+}
 
 private trait MemoryEntryBuilder[T] {
   def preciseSize: Long

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -24,8 +24,10 @@ import java.util.LinkedHashMap
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
+
 import com.google.common.io.ByteStreams
 import com.palantir.logsafe.SafeArg
+
 import org.apache.spark.{SparkConf, TaskContext}
 import org.apache.spark.internal.{Logging, SafeLogging}
 import org.apache.spark.internal.config.{UNROLL_MEMORY_CHECK_PERIOD, UNROLL_MEMORY_GROWTH_FACTOR}
@@ -158,7 +160,7 @@ private[spark] class MemoryStore(
       safeLogInfo("Block %s stored as bytes in memory (estimated size %s, free %s)",
         SafeArg.of("blockId", blockId),
         SafeArg.of("estimatedSize", Utils.bytesToString(size)),
-        SafeArg.of("free", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
+        SafeArg.of("freeMemory", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
       true
     } else {
       false
@@ -272,7 +274,7 @@ private[spark] class MemoryStore(
         safeLogInfo("Block stored as values in memory",
           SafeArg.of("blockId", blockId),
           SafeArg.of("estimatedSize", Utils.bytesToString(entry.size)),
-          SafeArg.of("free", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
+          SafeArg.of("freeMemory", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
         Right(entry.size)
       } else {
         // We ran out of space while unrolling the values for this block
@@ -345,7 +347,7 @@ private[spark] class MemoryStore(
       safeLogWarning("Initial memory threshold " +
         "is too large to be set as chunk size. Chunk size has been capped",
         SafeArg.of("threshold", Utils.bytesToString(initialMemoryThreshold)),
-        SafeArg.of("capped", Utils.bytesToString(Int.MaxValue)))
+        SafeArg.of("cappedChunkSize", Utils.bytesToString(Int.MaxValue)))
       Int.MaxValue
     } else {
       initialMemoryThreshold.toInt
@@ -403,10 +405,10 @@ private[spark] class MemoryStore(
         case _ =>
       }
       memoryManager.releaseStorageMemory(entry.size, entry.memoryMode)
-      safeLogDebug("Block of size dropped from memory",
+      safeLogDebug("Block dropped from memory",
         SafeArg.of("blockId", blockId),
         SafeArg.of("size", entry.size),
-        SafeArg.of("free", maxMemory - blocksMemoryUsed))
+        SafeArg.of("freeMemory", maxMemory - blocksMemoryUsed))
       true
     } else {
       false
@@ -627,7 +629,7 @@ private[spark] class MemoryStore(
     safeLogInfo(
       s"Memory use",
       SafeArg.of("blocksMemoryUsed", Utils.bytesToString(blocksMemoryUsed)),
-      SafeArg.of("ScratchSpaceShared", Utils.bytesToString(currentUnrollMemory)),
+      SafeArg.of("scratchSpaceShared", Utils.bytesToString(currentUnrollMemory)),
       SafeArg.of("numTasksSharingScratchSpace", numTasksUnrolling),
       SafeArg.of("memoryUsed", Utils.bytesToString(memoryUsed)),
       SafeArg.of("stogrageLimit", Utils.bytesToString(maxMemory))
@@ -648,7 +650,7 @@ private[spark] class MemoryStore(
     )
     logMemoryUsage()
   }
-}
+}ScratchSpaceShared
 
 private trait MemoryEntryBuilder[T] {
   def preciseSize: Long

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -24,11 +24,10 @@ import java.util.LinkedHashMap
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
-
 import com.google.common.io.ByteStreams
-
+import com.palantir.logsafe.SafeArg
 import org.apache.spark.{SparkConf, TaskContext}
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, SafeLogging}
 import org.apache.spark.internal.config.{UNROLL_MEMORY_CHECK_PERIOD, UNROLL_MEMORY_GROWTH_FACTOR}
 import org.apache.spark.memory.{MemoryManager, MemoryMode}
 import org.apache.spark.serializer.{SerializationStream, SerializerManager}
@@ -83,7 +82,7 @@ private[spark] class MemoryStore(
     serializerManager: SerializerManager,
     memoryManager: MemoryManager,
     blockEvictionHandler: BlockEvictionHandler)
-  extends Logging {
+  extends SafeLogging {
 
   // Note: all changes to memory allocations, notably putting blocks, evicting blocks, and
   // acquiring or releasing unroll memory, must be synchronized on `memoryManager`!
@@ -107,12 +106,15 @@ private[spark] class MemoryStore(
   }
 
   if (maxMemory < unrollMemoryThreshold) {
-    logWarning(s"Max memory ${Utils.bytesToString(maxMemory)} is less than the initial memory " +
-      s"threshold ${Utils.bytesToString(unrollMemoryThreshold)} needed to store a block in " +
-      s"memory. Please configure Spark with more memory.")
+    safeLogWarning("Max memory is less than the initial memory " +
+      "threshold needed to store a block in " +
+      "memory. Please configure Spark with more memory.",
+      SafeArg.of("maxMemory", Utils.bytesToString(maxMemory)),
+      SafeArg.of("threshold", Utils.bytesToString(unrollMemoryThreshold)))
   }
 
-  logInfo("MemoryStore started with capacity %s".format(Utils.bytesToString(maxMemory)))
+  safeLogInfo("MemoryStore started with capacity",
+    SafeArg.of("capacity", Utils.bytesToString(maxMemory)))
 
   /** Total storage memory used including unroll memory, in bytes. */
   private def memoryUsed: Long = memoryManager.storageMemoryUsed
@@ -153,8 +155,10 @@ private[spark] class MemoryStore(
       entries.synchronized {
         entries.put(blockId, entry)
       }
-      logInfo("Block %s stored as bytes in memory (estimated size %s, free %s)".format(
-        blockId, Utils.bytesToString(size), Utils.bytesToString(maxMemory - blocksMemoryUsed)))
+      safeLogInfo("Block %s stored as bytes in memory (estimated size %s, free %s)",
+        SafeArg.of("blockId", blockId),
+        SafeArg.of("estimatedSize", Utils.bytesToString(size)),
+        SafeArg.of("free", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
       true
     } else {
       false
@@ -210,8 +214,10 @@ private[spark] class MemoryStore(
       reserveUnrollMemoryForThisTask(blockId, initialMemoryThreshold, memoryMode)
 
     if (!keepUnrolling) {
-      logWarning(s"Failed to reserve initial memory threshold of " +
-        s"${Utils.bytesToString(initialMemoryThreshold)} for computing block $blockId in memory.")
+      safeLogWarning("Failed to reserve initial memory threshold " +
+        "for computing block in memory.",
+        SafeArg.of("initialThreshold", Utils.bytesToString(initialMemoryThreshold)),
+        SafeArg.of("blockId", blockId))
     } else {
       unrollMemoryUsedByThisBlock += initialMemoryThreshold
     }
@@ -263,8 +269,10 @@ private[spark] class MemoryStore(
           entries.put(blockId, entry)
         }
 
-        logInfo("Block %s stored as values in memory (estimated size %s, free %s)".format(blockId,
-          Utils.bytesToString(entry.size), Utils.bytesToString(maxMemory - blocksMemoryUsed)))
+        safeLogInfo("Block stored as values in memory",
+          SafeArg.of("blockId", blockId),
+          SafeArg.of("estimatedSize", Utils.bytesToString(entry.size)),
+          SafeArg.of("free", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
         Right(entry.size)
       } else {
         // We ran out of space while unrolling the values for this block
@@ -334,9 +342,10 @@ private[spark] class MemoryStore(
     // Initial per-task memory to request for unrolling blocks (bytes).
     val initialMemoryThreshold = unrollMemoryThreshold
     val chunkSize = if (initialMemoryThreshold > Int.MaxValue) {
-      logWarning(s"Initial memory threshold of ${Utils.bytesToString(initialMemoryThreshold)} " +
-        s"is too large to be set as chunk size. Chunk size has been capped to " +
-        s"${Utils.bytesToString(Int.MaxValue)}")
+      safeLogWarning("Initial memory threshold " +
+        "is too large to be set as chunk size. Chunk size has been capped",
+        SafeArg.of("threshold", Utils.bytesToString(initialMemoryThreshold)),
+        SafeArg.of("capped", Utils.bytesToString(Int.MaxValue)))
       Int.MaxValue
     } else {
       initialMemoryThreshold.toInt
@@ -394,8 +403,10 @@ private[spark] class MemoryStore(
         case _ =>
       }
       memoryManager.releaseStorageMemory(entry.size, entry.memoryMode)
-      logDebug(s"Block $blockId of size ${entry.size} dropped " +
-        s"from memory (free ${maxMemory - blocksMemoryUsed})")
+      safeLogDebug("Block of size dropped from memory",
+        SafeArg.of("blockId", blockId),
+        SafeArg.of("size", entry.size),
+        SafeArg.of("free", maxMemory - blocksMemoryUsed))
       true
     } else {
       false
@@ -409,7 +420,7 @@ private[spark] class MemoryStore(
     onHeapUnrollMemoryMap.clear()
     offHeapUnrollMemoryMap.clear()
     memoryManager.releaseAllStorageMemory()
-    logInfo("MemoryStore cleared")
+    safeLogInfo("MemoryStore cleared")
   }
 
   /**
@@ -484,8 +495,9 @@ private[spark] class MemoryStore(
       if (freedMemory >= space) {
         var lastSuccessfulBlock = -1
         try {
-          logInfo(s"${selectedBlocks.size} blocks selected for dropping " +
-            s"(${Utils.bytesToString(freedMemory)} bytes)")
+          safeLogInfo("blocks selected for dropping",
+            SafeArg.of("numBlocksSelected", selectedBlocks.size),
+            SafeArg.of("freedMemoryInBytes", Utils.bytesToString(freedMemory)))
           (0 until selectedBlocks.size).foreach { idx =>
             val blockId = selectedBlocks(idx)
             val entry = entries.synchronized {
@@ -500,8 +512,9 @@ private[spark] class MemoryStore(
             }
             lastSuccessfulBlock = idx
           }
-          logInfo(s"After dropping ${selectedBlocks.size} blocks, " +
-            s"free memory is ${Utils.bytesToString(maxMemory - blocksMemoryUsed)}")
+          safeLogInfo("After dropping blocks",
+            SafeArg.of("numBlocksDropped", selectedBlocks.size),
+            SafeArg.of("freeMemory", Utils.bytesToString(maxMemory - blocksMemoryUsed)))
           freedMemory
         } finally {
           // like BlockManager.doPut, we use a finally rather than a catch to avoid having to deal
@@ -516,7 +529,7 @@ private[spark] class MemoryStore(
         }
       } else {
         blockId.foreach { id =>
-          logInfo(s"Will not store $id")
+          safeLogInfo("Will not store", SafeArg.of("blockId", id))
         }
         selectedBlocks.foreach { id =>
           blockInfoManager.unlock(id)
@@ -611,11 +624,13 @@ private[spark] class MemoryStore(
    * Log information about current memory usage.
    */
   private def logMemoryUsage(): Unit = {
-    logInfo(
-      s"Memory use = ${Utils.bytesToString(blocksMemoryUsed)} (blocks) + " +
-      s"${Utils.bytesToString(currentUnrollMemory)} (scratch space shared across " +
-      s"$numTasksUnrolling tasks(s)) = ${Utils.bytesToString(memoryUsed)}. " +
-      s"Storage limit = ${Utils.bytesToString(maxMemory)}."
+    safeLogInfo(
+      s"Memory use",
+      SafeArg.of("blocksMemoryUsed", Utils.bytesToString(blocksMemoryUsed)),
+      SafeArg.of("ScratchSpaceShared", Utils.bytesToString(currentUnrollMemory)),
+      SafeArg.of("numTasksSharingScratchSpace", numTasksUnrolling),
+      SafeArg.of("memoryUsed", Utils.bytesToString(memoryUsed)),
+      SafeArg.of("stogrageLimit", Utils.bytesToString(maxMemory))
     )
   }
 
@@ -626,9 +641,10 @@ private[spark] class MemoryStore(
    * @param finalVectorSize Final size of the vector before unrolling failed.
    */
   private def logUnrollFailureMessage(blockId: BlockId, finalVectorSize: Long): Unit = {
-    logWarning(
-      s"Not enough space to cache $blockId in memory! " +
-      s"(computed ${Utils.bytesToString(finalVectorSize)} so far)"
+    safeLogWarning(
+      "Not enough space to cache block in memory!",
+      SafeArg.of("blockId", blockId),
+      SafeArg.of("soFarComputed", Utils.bytesToString(finalVectorSize))
     )
     logMemoryUsage()
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
@@ -41,7 +41,7 @@ private[spark] class ExecutorPodsPollingSnapshotSource(
   def start(applicationId: String): Unit = {
     require(pollingFuture == null, "Cannot start polling more than once.")
     safeLogDebug("Starting to check for executor pod state",
-      SafeArg.of("pollingIntervalInMs",  pollingInterval))
+      SafeArg.of("pollingIntervalInMs", pollingInterval))
     pollingFuture = pollingExecutor.scheduleWithFixedDelay(
       new PollRunnable(applicationId), pollingInterval, pollingInterval, TimeUnit.MILLISECONDS)
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
@@ -18,20 +18,21 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.concurrent.{Future, ScheduledExecutorService, TimeUnit}
 
+import com.palantir.logsafe.SafeArg
 import io.fabric8.kubernetes.client.KubernetesClient
 import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.util.ThreadUtils
 
 private[spark] class ExecutorPodsPollingSnapshotSource(
     conf: SparkConf,
     kubernetesClient: KubernetesClient,
     snapshotsStore: ExecutorPodsSnapshotsStore,
-    pollingExecutor: ScheduledExecutorService) extends Logging {
+    pollingExecutor: ScheduledExecutorService) extends SafeLogging {
 
   private val pollingInterval = conf.get(KUBERNETES_EXECUTOR_API_POLLING_INTERVAL)
 
@@ -39,7 +40,8 @@ private[spark] class ExecutorPodsPollingSnapshotSource(
 
   def start(applicationId: String): Unit = {
     require(pollingFuture == null, "Cannot start polling more than once.")
-    logDebug(s"Starting to check for executor pod state every $pollingInterval ms.")
+    safeLogDebug("Starting to check for executor pod state",
+      SafeArg.of("pollingIntervalInMs",  pollingInterval))
     pollingFuture = pollingExecutor.scheduleWithFixedDelay(
       new PollRunnable(applicationId), pollingInterval, pollingInterval, TimeUnit.MILLISECONDS)
   }
@@ -54,7 +56,7 @@ private[spark] class ExecutorPodsPollingSnapshotSource(
 
   private class PollRunnable(applicationId: String) extends Runnable {
     override def run(): Unit = {
-      logDebug(s"Resynchronizing full executor pod state from Kubernetes.")
+      safeLogDebug("Resynchronizing full executor pod state from Kubernetes.")
       snapshotsStore.replaceSnapshot(kubernetesClient
         .pods()
         .withLabel(SPARK_APP_ID_LABEL, applicationId)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -18,10 +18,11 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.Locale
 
+import com.palantir.logsafe.SafeArg
 import io.fabric8.kubernetes.api.model.Pod
 
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 
 /**
  * An immutable view of the current executor pods that are running in the cluster.
@@ -36,7 +37,7 @@ private[spark] case class ExecutorPodsSnapshot(executorPods: Map[Long, ExecutorP
   }
 }
 
-object ExecutorPodsSnapshot extends Logging {
+object ExecutorPodsSnapshot extends SafeLogging {
 
   def apply(executorPods: Seq[Pod]): ExecutorPodsSnapshot = {
     ExecutorPodsSnapshot(toStatesByExecutorId(executorPods))
@@ -65,8 +66,10 @@ object ExecutorPodsSnapshot extends Logging {
         case "succeeded" =>
           PodSucceeded(pod)
         case _ =>
-          logWarning(s"Received unknown phase $phase for executor pod with name" +
-            s" ${pod.getMetadata.getName} in namespace ${pod.getMetadata.getNamespace}")
+          safeLogWarning("Received unknown phase for executor pod with name",
+            SafeArg.of("phase", phase),
+            SafeArg.of("podName", pod.getMetadata.getName),
+            SafeArg.of("namespace", pod.getMetadata.getNamespace))
           PodUnknown(pod)
       }
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
@@ -35,7 +35,7 @@ private[spark] class ExecutorPodsWatchSnapshotSource(
 
   def start(applicationId: String): Unit = {
     require(watchConnection == null, "Cannot start the watcher twice.")
-    safeLogDebug("Starting watch for pods with labels.",
+    safeLogDebug("Starting watch for pods.",
       SafeArg.of("applicationId", applicationId))
     watchConnection = kubernetesClient.pods()
       .withLabel(SPARK_APP_ID_LABEL, applicationId)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
@@ -18,24 +18,25 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.io.Closeable
 
+import com.palantir.logsafe.SafeArg
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientException, Watcher}
 import io.fabric8.kubernetes.client.Watcher.Action
 
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.SafeLogging
 import org.apache.spark.util.Utils
 
 private[spark] class ExecutorPodsWatchSnapshotSource(
     snapshotsStore: ExecutorPodsSnapshotsStore,
-    kubernetesClient: KubernetesClient) extends Logging {
+    kubernetesClient: KubernetesClient) extends SafeLogging {
 
   private var watchConnection: Closeable = _
 
   def start(applicationId: String): Unit = {
     require(watchConnection == null, "Cannot start the watcher twice.")
-    logDebug(s"Starting watch for pods with labels $SPARK_APP_ID_LABEL=$applicationId," +
-      s" $SPARK_ROLE_LABEL=$SPARK_POD_EXECUTOR_ROLE.")
+    safeLogDebug("Starting watch for pods with labels.",
+      SafeArg.of("applicationId", applicationId))
     watchConnection = kubernetesClient.pods()
       .withLabel(SPARK_APP_ID_LABEL, applicationId)
       .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
@@ -54,12 +55,14 @@ private[spark] class ExecutorPodsWatchSnapshotSource(
   private class ExecutorPodsWatcher extends Watcher[Pod] {
     override def eventReceived(action: Action, pod: Pod): Unit = {
       val podName = pod.getMetadata.getName
-      logDebug(s"Received executor pod update for pod named $podName, action $action")
+      safeLogDebug("Received executor pod update for pod",
+        SafeArg.of("podName", podName),
+        SafeArg.of("action", action))
       snapshotsStore.updatePod(pod)
     }
 
     override def onClose(e: KubernetesClientException): Unit = {
-      logWarning("Kubernetes client has been closed (this is expected if the application is" +
+      safeLogWarning("Kubernetes client has been closed (this is expected if the application is" +
         " shutting down.)", e)
     }
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -18,6 +18,7 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.concurrent.ExecutorService
 
+import com.palantir.logsafe.SafeArg
 import io.fabric8.kubernetes.client.KubernetesClient
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -134,6 +135,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
       // drive the rest of the lifecycle decisions
       // TODO what if we disconnect from a networking issue? Probably want to mark the executor
       // to be deleted eventually.
+      safeLogDebug("Executor disconnected",
+        SafeArg.of("executorId", addressToExecutorId.get(rpcAddress)))
       addressToExecutorId.get(rpcAddress).foreach(disableExecutor)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add SafeLogging (similar to https://github.com/palantir/spark/pull/425) to more classes that can be useful:
- k8s classes
- CoarseGrainedSchedulerBackend
- SparkContext
- MemoryStore
- Executor
- CoarseGrainedExecutorBackend
- TorrentBroadCast and Broadcast