### PR TITLE
Allow configuring conda env variables

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -73,7 +73,8 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
               baseDir: String,
               condaPackages: Seq[String],
               condaChannelUrls: Seq[String],
-              condaExtraArgs: Seq[String] = Nil): CondaEnvironment = {
+              condaExtraArgs: Seq[String] = Nil,
+              condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
     require(condaPackages.nonEmpty, "Expected at least one conda package.")
     require(condaChannelUrls.nonEmpty, "Can't have an empty list of conda channel URLs")
     val name = "conda-env"
@@ -95,7 +96,8 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
         ::: verbosityFlags
         ::: "--" :: condaPackages.toList,
       description = "create conda env",
-      channels = condaChannelUrls.toList
+      channels = condaChannelUrls.toList,
+      envVars = condaEnvVars
     )
 
     new CondaEnvironment(this, linkedBaseDir, name, condaPackages, condaChannelUrls, condaExtraArgs)
@@ -139,7 +141,8 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
   private[conda] def runCondaProcess(baseRoot: Path,
                                      args: List[String],
                                      channels: List[String],
-                                     description: String): Unit = {
+                                     description: String,
+                                     envVars: Map[String, String]): Unit = {
     val condarc = generateCondarc(baseRoot, channels)
     val fakeHomeDir = baseRoot.resolve("home")
     // Attempt to create fake home dir
@@ -148,7 +151,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     val extraEnv = List(
       "CONDARC" -> condarc.toString,
       "HOME" -> fakeHomeDir.toString
-    )
+    ) ++ envVars
 
     val command = Process(
       condaBinaryPath :: args,

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -326,6 +326,11 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val CONDA_ENVIRONMENT_VARIABLES = ConfigBuilder("spark.conda.envVars")
+    .doc("Environment variables to use while running conda")
+    .stringConf
+    .createWithDefault("")
+
   // To limit how many applications are shown in the History Server summary ui
   private[spark] val HISTORY_UI_MAX_APPS =
     ConfigBuilder("spark.history.ui.maxApplications").intConf.createWithDefault(Integer.MAX_VALUE)

--- a/core/src/test/java/org/apache/spark/deploy/CondaRunnerTest.java
+++ b/core/src/test/java/org/apache/spark/deploy/CondaRunnerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy;
+
+
+import org.apache.spark.SparkConf;
+import org.junit.Test;
+import scala.collection.immutable.Map;
+
+import java.io.IOException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class CondaRunnerTest {
+
+    @Test
+    public void testReadingEnvVariables() throws IOException {
+        SparkConf conf = new SparkConf();
+        conf.set("spark.conda.envVars", "key1=value1,key2=value2");
+        Map.Map2 expected = new Map.Map2<>("key1", "value1", "key2", "value2");
+        assertThat(CondaRunner.extractEnvVariables(conf), is(expected));
+    }
+}


### PR DESCRIPTION
Allow passing env variables for conda so that we can enable instrumentation/other flags when required.