### PR TITLE
Use packed conda env from driver to initialize executor conda environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
           name: Run all tests
           command: ./dev/run-scala-tests.py \
               | tee -a "/tmp/run-scala-tests.log"
-          no_output_timeout: 15m
+          no_output_timeout: 25m
 
       - store_artifacts:
           path: /tmp/run-scala-tests.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
   run-scala-tests:
     <<: *test-defaults
     # project/CirclePlugin.scala does its own test splitting in SBT based on CIRCLE_NODE_INDEX, CIRCLE_NODE_TOTAL
-    parallelism: 12
+    parallelism: 13
     # Spark runs a lot of tests in parallel, we need 16 GB of RAM for this
     resource_class: xlarge
     steps:
@@ -404,7 +404,7 @@ jobs:
           name: Run all tests
           command: ./dev/run-scala-tests.py \
               | tee -a "/tmp/run-scala-tests.log"
-          no_output_timeout: 25m
+          no_output_timeout: 15m
 
       - store_artifacts:
           path: /tmp/run-scala-tests.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
   run-scala-tests:
     <<: *test-defaults
     # project/CirclePlugin.scala does its own test splitting in SBT based on CIRCLE_NODE_INDEX, CIRCLE_NODE_TOTAL
-    parallelism: 13
+    parallelism: 12
     # Spark runs a lot of tests in parallel, we need 16 GB of RAM for this
     resource_class: xlarge
     steps:
@@ -404,7 +404,7 @@ jobs:
           name: Run all tests
           command: ./dev/run-scala-tests.py \
               | tee -a "/tmp/run-scala-tests.log"
-          no_output_timeout: 15m
+          no_output_timeout: 25m
 
       - store_artifacts:
           path: /tmp/run-scala-tests.log

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -39,7 +39,8 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
                              bootstrapPackages: Seq[String],
                              bootstrapChannels: Seq[String],
                              extraArgs: Seq[String] = Nil,
-                             envVars: Map[String, String] = Map.empty) extends Logging {
+                             envVars: Map[String, String] = Map.empty,
+                             condaPackConfig: Option[CondaPackConfig]) extends Logging {
 
   import CondaEnvironment._
 
@@ -98,7 +99,7 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
    * This is for sending the instructions to the executors so they can replicate the same steps.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    CondaSetupInstructions(packages.toList, channels.toList, extraArgs, envVars)
+    CondaSetupInstructions(packages.toList, channels.toList, extraArgs, envVars, condaPackConfig)
   }
 }
 
@@ -158,7 +159,8 @@ object CondaEnvironment {
          packages: Seq[String],
          unauthenticatedChannels: Seq[UnauthenticatedChannel],
          extraArgs: Seq[String],
-         envVars: Map[String, String])
+         envVars: Map[String, String],
+         condaPackConfig: Option[CondaPackConfig])
         (userInfos: Map[UnauthenticatedChannel, String]) {
     require(unauthenticatedChannels.nonEmpty)
     require(packages.nonEmpty)
@@ -171,10 +173,10 @@ object CondaEnvironment {
 
   object CondaSetupInstructions {
     def apply(packages: Seq[String], channels: Seq[AuthenticatedChannel], extraArgs: Seq[String],
-              envVars: Map[String, String])
+              envVars: Map[String, String], condaPackConfig: Option[CondaPackConfig])
         : CondaSetupInstructions = {
       val ChannelsWithCreds(unauthed, userInfos) = unauthenticateChannels(channels)
-      CondaSetupInstructions(packages, unauthed, extraArgs, envVars)(userInfos)
+      CondaSetupInstructions(packages, unauthed, extraArgs, envVars, condaPackConfig)(userInfos)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -40,7 +40,7 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
                              bootstrapChannels: Seq[String],
                              extraArgs: Seq[String] = Nil,
                              envVars: Map[String, String] = Map.empty,
-                             condaPackConfig: Option[CondaPackConfig]) extends Logging {
+                             condaPackLocation: Option[String]) extends Logging {
 
   import CondaEnvironment._
 
@@ -99,7 +99,7 @@ final class CondaEnvironment(val manager: CondaEnvironmentManager,
    * This is for sending the instructions to the executors so they can replicate the same steps.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    CondaSetupInstructions(packages.toList, channels.toList, extraArgs, envVars, condaPackConfig)
+    CondaSetupInstructions(packages.toList, channels.toList, extraArgs, envVars, condaPackLocation)
   }
 }
 
@@ -160,7 +160,7 @@ object CondaEnvironment {
          unauthenticatedChannels: Seq[UnauthenticatedChannel],
          extraArgs: Seq[String],
          envVars: Map[String, String],
-         condaPackConfig: Option[CondaPackConfig])
+         maybeCondaPackLocation: Option[String])
         (userInfos: Map[UnauthenticatedChannel, String]) {
     require(unauthenticatedChannels.nonEmpty)
     require(packages.nonEmpty)
@@ -173,10 +173,11 @@ object CondaEnvironment {
 
   object CondaSetupInstructions {
     def apply(packages: Seq[String], channels: Seq[AuthenticatedChannel], extraArgs: Seq[String],
-              envVars: Map[String, String], condaPackConfig: Option[CondaPackConfig])
+              envVars: Map[String, String], maybeCondaPackLocation: Option[String])
         : CondaSetupInstructions = {
       val ChannelsWithCreds(unauthed, userInfos) = unauthenticateChannels(channels)
-      CondaSetupInstructions(packages, unauthed, extraArgs, envVars, condaPackConfig)(userInfos)
+      CondaSetupInstructions(packages, unauthed, extraArgs, envVars,
+        maybeCondaPackLocation)(userInfos)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -29,12 +29,14 @@ import scala.sys.process.BasicIO
 import scala.sys.process.Process
 import scala.sys.process.ProcessBuilder
 import scala.sys.process.ProcessIO
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.google.common.collect.ImmutableSet
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.Json4sScalaModule
 import org.json4s.jackson.JsonMethods
+
 import org.apache.spark._
 import org.apache.spark.api.conda.CondaEnvironment.CondaSetupInstructions
 import org.apache.spark.internal.Logging
@@ -99,14 +101,16 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
         channels = condaChannelUrls.toList,
         envVars = condaEnvVars
       )
+
+      val packedEnvPath = s"$baseDir/$envName.tar.gz"
       runCondaProcess(
         linkedBaseDir,
-        List("pack", "-n", envName, "--directory", s"$baseDir"),
+        List("pack", "-n", envName, "--output", packedEnvPath),
         description = "Packing conda env",
         channels = condaChannelUrls.toList,
         envVars = condaEnvVars
       )
-      SparkContext.getOrCreate().addFile(s"$baseDir/$envName.tar.gz")
+      SparkContext.getOrCreate().addFile(packedEnvPath)
   } else {
       unpack(baseDir, envName)
   }

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaPackConfig.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaPackConfig.scala
@@ -18,20 +18,23 @@
 package org.apache.spark.api.conda
 
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.config.{CONDA_PACK_COMPRESS_LEVEL, CONDA_PACK_FORMAT, CONDA_PACK_NUM_THREADS, CONDA_USE_PACK}
+import org.apache.spark.internal.config.{CONDA_PACK_COMPRESS_LEVEL, CONDA_PACK_ENABLED, CONDA_PACK_FALLBACK_ENABLED,
+  CONDA_PACK_FORMAT, CONDA_PACK_NUM_THREADS}
 
-final case class CondaPackConfig(format: String, compressLevel: Int, numThreads: Int) {
+final case class CondaPackConfig(format: String, compressLevel: Int, numThreads: Int,
+                                 fallbackEnabled: Boolean) {
 }
 
 object CondaPackConfig {
   def fromConf(sparkConf: SparkConf): Option[CondaPackConfig] = {
 
-    if (!sparkConf.get(CONDA_USE_PACK)) {
-      return Option.empty
+    if (!sparkConf.get(CONDA_PACK_ENABLED)) {
+      return None
     }
     val format = sparkConf.get(CONDA_PACK_FORMAT)
     val compressLevel = sparkConf.get(CONDA_PACK_COMPRESS_LEVEL)
     val numThreads = sparkConf.get(CONDA_PACK_NUM_THREADS)
-    Option(new CondaPackConfig(format, compressLevel, numThreads))
+    val fallbackEnabled = sparkConf.get(CONDA_PACK_FALLBACK_ENABLED)
+    Option(new CondaPackConfig(format, compressLevel, numThreads, fallbackEnabled))
   }
 }

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaPackConfig.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaPackConfig.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.conda
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.{CONDA_PACK_COMPRESS_LEVEL, CONDA_PACK_FORMAT, CONDA_PACK_NUM_THREADS, CONDA_USE_PACK}
+
+final case class CondaPackConfig(format: String, compressLevel: Int, numThreads: Int) {
+}
+
+object CondaPackConfig {
+  def fromConf(sparkConf: SparkConf): Option[CondaPackConfig] = {
+
+    if (!sparkConf.get(CONDA_USE_PACK)) {
+      return Option.empty
+    }
+    val format = sparkConf.get(CONDA_PACK_FORMAT)
+    val compressLevel = sparkConf.get(CONDA_PACK_COMPRESS_LEVEL)
+    val numThreads = sparkConf.get(CONDA_PACK_NUM_THREADS)
+    Option(new CondaPackConfig(format, compressLevel, numThreads))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/CondaRunner.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.api.conda.CondaEnvironment
 import org.apache.spark.api.conda.CondaEnvironmentManager
+import org.apache.spark.api.conda.CondaPackConfig
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
@@ -57,13 +58,16 @@ object CondaRunner {
       val condaEnvVariables = extractEnvVariables(sparkConf)
       val condaBaseDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), "conda").getAbsolutePath
       val condaEnvironmentManager = CondaEnvironmentManager.fromConf(sparkConf)
+      val condaPackConfig = CondaPackConfig.fromConf(sparkConf)
       val environment =
         condaEnvironmentManager.create(
           condaBaseDir,
           condaBootstrapDeps,
           condaChannelUrls,
           condaExtraArgs,
-          condaEnvVariables)
+          condaEnvVariables,
+          condaPackConfig
+        )
       setCondaEnvironment(environment)
       Some(environment)
     } else {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -327,6 +327,26 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val CONDA_USE_PACK = ConfigBuilder("spark.conda.pack")
+    .doc("Use conda-pack to initialize environment on executors")
+    .booleanConf
+    .createWithDefault(false)
+
+  private[spark] val CONDA_PACK_FORMAT = ConfigBuilder("spark.conda.pack.format")
+    .doc("Archival format to use for conda-pack. Supports .tar, .tar.gz")
+    .stringConf
+    .createWithDefault("tar.gz")
+
+  private[spark] val CONDA_PACK_COMPRESS_LEVEL = ConfigBuilder("spark.conda.pack.compressLevel")
+    .doc("Compression level to use for conda-pack")
+    .intConf
+    .createWithDefault(4)
+
+  private[spark] val CONDA_PACK_NUM_THREADS = ConfigBuilder("spark.conda.pack.numThreads")
+    .doc("Number of threads to use for conda-pack. -1 will use the number of cpus on the machine")
+    .intConf
+    .createWithDefault(1)
+
   // To limit how many applications are shown in the History Server summary ui
   private[spark] val HISTORY_UI_MAX_APPS =
     ConfigBuilder("spark.history.ui.maxApplications").intConf.createWithDefault(Integer.MAX_VALUE)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -341,6 +341,7 @@ package object config {
   private[spark] val CONDA_PACK_FORMAT = ConfigBuilder("spark.conda.pack.format")
     .doc("Archival format to use for conda-pack. Supports .tar, .tar.gz")
     .stringConf
+    .checkValues(Set("tar.gz", "tar"))
     .createWithDefault("tar.gz")
 
   private[spark] val CONDA_PACK_COMPRESS_LEVEL = ConfigBuilder("spark.conda.pack.compressLevel")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -327,10 +327,16 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
-  private[spark] val CONDA_USE_PACK = ConfigBuilder("spark.conda.pack")
-    .doc("Use conda-pack to initialize environment on executors")
+  private[spark] val CONDA_PACK_ENABLED = ConfigBuilder("spark.conda.pack.enabled")
+    .doc("When true will use conda-pack to initialize environemnts on ")
     .booleanConf
     .createWithDefault(false)
+
+  private[spark] val CONDA_PACK_FALLBACK_ENABLED =
+    ConfigBuilder("spark.conda.pack.fallback.enabled")
+    .doc("Initialize environment from scratch if unpacking fails")
+    .booleanConf
+    .createWithDefault(true)
 
   private[spark] val CONDA_PACK_FORMAT = ConfigBuilder("spark.conda.pack.format")
     .doc("Archival format to use for conda-pack. Supports .tar, .tar.gz")

--- a/dev/docker-images/base/Dockerfile
+++ b/dev/docker-images/base/Dockerfile
@@ -112,6 +112,7 @@ RUN curl -sO https://repo.continuum.io/miniconda/Miniconda2-${MINICONDA2_VERSION
   && bash Miniconda2-${MINICONDA2_VERSION}-Linux-x86_64.sh -b -p ${CONDA_ROOT} \
   && $CONDA_BIN clean --all \
   && sudo mkdir -m 777 /home/.conda \
+  && $CONDA_BIN install conda-pack -c conda-forge
   && rm -f Miniconda2-${MINICONDA2_VERSION}-Linux-x86_64.sh
 
 # END IMAGE CUSTOMIZATIONS

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -229,12 +229,14 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   test("run Python application within Conda using conda-pack in yarn-client mode") {
     testCondaPySpark(true, Map(
-      "spark.conda.pack.enabled" -> "true"))
+      "spark.conda.pack.enabled" -> "true",
+      "spark.conda.pack.fallback.enabled" -> "false"))
   }
 
   test("run Python application within Conda using conda-pack in yarn-cluster mode") {
     testCondaPySpark(false, Map(
-      "spark.conda.pack.enabled" -> "true"))
+      "spark.conda.pack.enabled" -> "true",
+      "spark.conda.pack.fallback.enabled" -> "false"))
   }
 
   test("run Python application in yarn-cluster mode using " +


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
Conda support hasn't been merged upstream
## What changes were proposed in this pull request?
Exposes an option to use [conda-pack](https://conda.github.io/conda-pack/spark.html) to use the initialized driver env to create the executor env instead of re-initializing it again. Creating a vanilla conda env is expensive because of slow conda resolution and extracting pkgs.

## How was this patch tested?
- Added tests to run conda-pack in client and cluster mode