### PR TITLE
Revert "Use SMART resolver strategy when parsing timestamps and dates"

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -19,7 +19,6 @@
     * yarn: YarnClusterSchedulerBackend, YarnSchedulerBackend
 
 * [SPARK-26626](https://issues.apache.org/jira/browse/SPARK-26626) - Limited the maximum size of repeatedly substituted aliases
-* [SPARK-26178](https://issues.apache.org/jira/browse/SPARK-26178) (partial) - Do not use STRICT strategy when parsing timestamps
 
 # Added
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -73,6 +73,6 @@ private object DateTimeFormatterHelper {
       .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
       .toFormatter(locale)
       .withChronology(IsoChronology.INSTANCE)
-      .withResolverStyle(ResolverStyle.SMART)
+      .withResolverStyle(ResolverStyle.STRICT)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -568,10 +568,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     val y1 = "2016-02-29"
     val y2 = "2017-02-29"
     val ts5 = Timestamp.valueOf("2016-02-29 00:00:00")
-    val ts6 = Timestamp.valueOf("2017-02-28 00:00:00")
     val df2 = Seq(y1, y2).toDF("y")
     checkAnswer(df2.select(unix_timestamp(col("y"), "yyyy-MM-dd")), Seq(
-      Row(ts5.getTime / 1000L), Row(ts6.getTime / 1000L)))
+      Row(ts5.getTime / 1000L), Row(null)))
 
     val now = sql("select unix_timestamp()").collect().head.getLong(0)
     checkAnswer(sql(s"select cast ($now as timestamp)"), Row(new java.util.Date(now * 1000)))
@@ -614,10 +613,9 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
     val y1 = "2016-02-29"
     val y2 = "2017-02-29"
     val ts5 = Timestamp.valueOf("2016-02-29 00:00:00")
-    val ts6 = Timestamp.valueOf("2017-02-28 00:00:00")
     val df2 = Seq(y1, y2).toDF("y")
     checkAnswer(df2.select(unix_timestamp(col("y"), "yyyy-MM-dd")), Seq(
-      Row(ts5.getTime / 1000L), Row(ts6.getTime / 1000L)))
+      Row(ts5.getTime / 1000L), Row(null)))
 
     // invalid format
     checkAnswer(df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd bb:HH:ss')"), Seq(


### PR DESCRIPTION
Reverts palantir/spark#504

This pr is not necessary. After more debugging it looks like it's not possible to replicate `yyyy-MM-dd HH:mm:ss.S` SDF format in java.time.