### PR TITLE
[SPARK-27273] Compile break for UserDefinedType (DataType) subclasses with javac 8

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -107,6 +107,12 @@ abstract class DataType extends AbstractDataType {
   override private[sql] def acceptsType(other: DataType): Boolean = sameType(other)
 }
 
+private object JSortedObject {
+  def unapplySeq(value: JValue): Option[List[(String, JValue)]] = value match {
+    case JObject(seq) => Some(seq.toList.sortBy(_._1))
+    case _ => None
+  }
+}
 
 /**
  * @since 1.3.0
@@ -141,13 +147,6 @@ object DataType {
         other,
         throw new IllegalArgumentException(
           s"Failed to convert the JSON string '$name' to a data type."))
-    }
-  }
-
-  private object JSortedObject {
-    def unapplySeq(value: JValue): Option[List[(String, JValue)]] = value match {
-      case JObject(seq) => Some(seq.toList.sortBy(_._1))
-      case _ => None
     }
   }
 


### PR DESCRIPTION
Need to file an upstream ticket since the break is in DataType and that's considered Stable. The issue is that JSortedObject is an anonymous inner class of DataType but scala compiles it as a named `$JSortedObject` alias. Before https://github.com/palantir/spark/commit/630e25e35506c02a0b1e202ef82b1b0f69e50966 the inner classes had names but after this one doesn't