### PR TITLE
Revert soft dynamic allocation for SPARK-25299.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,9 +357,9 @@ jobs:
       - *restore-home-sbt-cache
       - restore_cache:
           keys:
-            - v1-test-results-{{ .Branch }}-{{ .BuildNum }}
-            - v1-test-results-{{ .Branch }}-
-            - v1-test-results-master-
+            - v2-test-results-{{ .Branch }}-{{ .BuildNum }}
+            - v2-test-results-{{ .Branch }}-
+            - v2-test-results-master-
       - run:
           name: Merge cached test results with results provided by circle (if any)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,9 +357,9 @@ jobs:
       - *restore-home-sbt-cache
       - restore_cache:
           keys:
-            - v2-test-results-{{ .Branch }}-{{ .BuildNum }}
-            - v2-test-results-{{ .Branch }}-
-            - v2-test-results-master-
+            - v1-test-results-{{ .Branch }}-{{ .BuildNum }}
+            - v1-test-results-{{ .Branch }}-
+            - v1-test-results-master-
       - run:
           name: Merge cached test results with results provided by circle (if any)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,22 +40,22 @@ step_templates:
   restore-ivy-cache: &restore-ivy-cache
     restore_cache:
       keys:
-        - v9-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
+        - v7-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
         # if cache for exact version of `pom.xml` is not present then load any most recent one
-        - v9-ivy-dependency-cache-{{ .Branch }}-
-        - v9-ivy-dependency-cache-master-{{ checksum "pom.xml" }}
-        - v9-ivy-dependency-cache-master-
+        - v7-ivy-dependency-cache-{{ .Branch }}-
+        - v7-ivy-dependency-cache-master-{{ checksum "pom.xml" }}
+        - v7-ivy-dependency-cache-master-
   restore-gradle-wrapper-cache: &restore-gradle-wrapper-cache
-    restore_cache: { key: 'gradle-wrapper-v3-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+    restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
   restore-gradle-cache: &restore-gradle-cache
-    restore_cache: { key: 'gradle-cache-v3-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+    restore_cache: { key: 'gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
   restore-home-sbt-cache: &restore-home-sbt-cache
     restore_cache:
       keys:
-        - v4-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+        - v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
   restore-build-sbt-cache: &restore-build-sbt-cache
     restore_cache:
-      key: v4-build-sbt-{{ .Branch }}-{{ .Revision }}
+      key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
   link-in-build-sbt-cache: &link-in-build-sbt-cache
     run:
       name: Hard link cache contents into current build directory
@@ -135,34 +135,34 @@ jobs:
       # Saves us from recompiling every time...
       - restore_cache:
           keys:
-            - build-maven-v1-{{ .Branch }}-{{ .BuildNum }}
-            - build-maven-v1-{{ .Branch }}-
-            - build-maven-v1-master-
+            - build-maven-{{ .Branch }}-{{ .BuildNum }}
+            - build-maven-{{ .Branch }}-
+            - build-maven-master-
       - *checkout-code
       - restore_cache:
           keys:
-            - maven-dependency-cache-v1-{{ checksum "pom.xml" }}
+            - maven-dependency-cache-{{ checksum "pom.xml" }}
             # Fallback - see https://circleci.com/docs/2.0/configuration-reference/#example-2
-            - maven-dependency-cache-v1
+            - maven-dependency-cache-
       # Given the build-maven cache, this is superfluous, but leave it in in case we will want to remove the former
       - restore_cache:
           keys:
-            - build-binaries-v1-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
-            - build-binaries-v1
+            - build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+            - build-binaries-
       - run: ./build/mvn -DskipTests -Psparkr install
       # Get sbt to run trivially, ensures its launcher is downloaded under build/
       - run: ./build/sbt -h || true
       - save_cache:
-          key: build-binaries-v1-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+          key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
           paths:
             - "build"
       - save_cache:
-          key: maven-dependency-cache-v1-{{ checksum "pom.xml" }}
+          key: maven-dependency-cache-{{ checksum "pom.xml" }}
           paths:
             - "~/.m2"
       # And finally save the whole project directory
       - save_cache:
-          key: build-maven-v1-{{ .Branch }}-{{ .BuildNum }}
+          key: build-maven-{{ .Branch }}-{{ .BuildNum }}
           paths: .
   build-spark-docker-gradle-plugin:
     <<: *defaults
@@ -172,10 +172,10 @@ jobs:
       - *restore-gradle-cache
       - run: ./gradlew --info --stacktrace check -x test
       - save_cache:
-          key: 'gradle-wrapper-v3-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
+          key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
       - save_cache:
-          key: 'gradle-cache-v3-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          key: 'gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
           paths: [ ~/.gradle/caches ]
 
   run-style-tests:
@@ -238,14 +238,14 @@ jobs:
       - store_artifacts:
           path: /tmp/heap.bin
       - save_cache:
-          key: v9-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: v7-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - "~/.ivy2"
       - store_artifacts:
           path: /tmp/build-apache-spark.log
           destination: build-apache-spark.log
       - save_cache:
-          key: v4-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+          key: v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
           paths: ~/.sbt
       # Also hard link all the things so we can save it as a cache and restore it in future builds
       - run:
@@ -255,7 +255,7 @@ jobs:
             --exclude '***/*.jar' --include 'target/***'
             --include '**/' --exclude '*' . "$BUILD_SBT_CACHE/"
       - save_cache:
-          key: v4-build-sbt-{{ .Branch }}-{{ .Revision }}
+          key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
           paths:
             - "~/build-sbt-cache"
       # Also save all the assembly jars directories to the workspace - need them for spark submitting
@@ -357,9 +357,9 @@ jobs:
       - *restore-home-sbt-cache
       - restore_cache:
           keys:
-            - v3-test-results-{{ .Branch }}-{{ .BuildNum }}
-            - v3-test-results-{{ .Branch }}-
-            - v3-test-results-master-
+            - v2-test-results-{{ .Branch }}-{{ .BuildNum }}
+            - v2-test-results-{{ .Branch }}-
+            - v2-test-results-master-
       - run:
           name: Merge cached test results with results provided by circle (if any)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,22 +40,22 @@ step_templates:
   restore-ivy-cache: &restore-ivy-cache
     restore_cache:
       keys:
-        - v7-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
+        - v9-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
         # if cache for exact version of `pom.xml` is not present then load any most recent one
-        - v7-ivy-dependency-cache-{{ .Branch }}-
-        - v7-ivy-dependency-cache-master-{{ checksum "pom.xml" }}
-        - v7-ivy-dependency-cache-master-
+        - v9-ivy-dependency-cache-{{ .Branch }}-
+        - v9-ivy-dependency-cache-master-{{ checksum "pom.xml" }}
+        - v9-ivy-dependency-cache-master-
   restore-gradle-wrapper-cache: &restore-gradle-wrapper-cache
-    restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+    restore_cache: { key: 'gradle-wrapper-v3-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
   restore-gradle-cache: &restore-gradle-cache
-    restore_cache: { key: 'gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+    restore_cache: { key: 'gradle-cache-v3-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
   restore-home-sbt-cache: &restore-home-sbt-cache
     restore_cache:
       keys:
-        - v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+        - v4-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
   restore-build-sbt-cache: &restore-build-sbt-cache
     restore_cache:
-      key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
+      key: v4-build-sbt-{{ .Branch }}-{{ .Revision }}
   link-in-build-sbt-cache: &link-in-build-sbt-cache
     run:
       name: Hard link cache contents into current build directory
@@ -135,34 +135,34 @@ jobs:
       # Saves us from recompiling every time...
       - restore_cache:
           keys:
-            - build-maven-{{ .Branch }}-{{ .BuildNum }}
-            - build-maven-{{ .Branch }}-
-            - build-maven-master-
+            - build-maven-v1-{{ .Branch }}-{{ .BuildNum }}
+            - build-maven-v1-{{ .Branch }}-
+            - build-maven-v1-master-
       - *checkout-code
       - restore_cache:
           keys:
-            - maven-dependency-cache-{{ checksum "pom.xml" }}
+            - maven-dependency-cache-v1-{{ checksum "pom.xml" }}
             # Fallback - see https://circleci.com/docs/2.0/configuration-reference/#example-2
-            - maven-dependency-cache-
+            - maven-dependency-cache-v1
       # Given the build-maven cache, this is superfluous, but leave it in in case we will want to remove the former
       - restore_cache:
           keys:
-            - build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
-            - build-binaries-
+            - build-binaries-v1-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+            - build-binaries-v1
       - run: ./build/mvn -DskipTests -Psparkr install
       # Get sbt to run trivially, ensures its launcher is downloaded under build/
       - run: ./build/sbt -h || true
       - save_cache:
-          key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+          key: build-binaries-v1-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
           paths:
             - "build"
       - save_cache:
-          key: maven-dependency-cache-{{ checksum "pom.xml" }}
+          key: maven-dependency-cache-v1-{{ checksum "pom.xml" }}
           paths:
             - "~/.m2"
       # And finally save the whole project directory
       - save_cache:
-          key: build-maven-{{ .Branch }}-{{ .BuildNum }}
+          key: build-maven-v1-{{ .Branch }}-{{ .BuildNum }}
           paths: .
   build-spark-docker-gradle-plugin:
     <<: *defaults
@@ -172,10 +172,10 @@ jobs:
       - *restore-gradle-cache
       - run: ./gradlew --info --stacktrace check -x test
       - save_cache:
-          key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
+          key: 'gradle-wrapper-v3-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
       - save_cache:
-          key: 'gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          key: 'gradle-cache-v3-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
           paths: [ ~/.gradle/caches ]
 
   run-style-tests:
@@ -238,14 +238,14 @@ jobs:
       - store_artifacts:
           path: /tmp/heap.bin
       - save_cache:
-          key: v7-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: v9-ivy-dependency-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - "~/.ivy2"
       - store_artifacts:
           path: /tmp/build-apache-spark.log
           destination: build-apache-spark.log
       - save_cache:
-          key: v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+          key: v4-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
           paths: ~/.sbt
       # Also hard link all the things so we can save it as a cache and restore it in future builds
       - run:
@@ -255,7 +255,7 @@ jobs:
             --exclude '***/*.jar' --include 'target/***'
             --include '**/' --exclude '*' . "$BUILD_SBT_CACHE/"
       - save_cache:
-          key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
+          key: v4-build-sbt-{{ .Branch }}-{{ .Revision }}
           paths:
             - "~/build-sbt-cache"
       # Also save all the assembly jars directories to the workspace - need them for spark submitting
@@ -357,9 +357,9 @@ jobs:
       - *restore-home-sbt-cache
       - restore_cache:
           keys:
-            - v2-test-results-{{ .Branch }}-{{ .BuildNum }}
-            - v2-test-results-{{ .Branch }}-
-            - v2-test-results-master-
+            - v3-test-results-{{ .Branch }}-{{ .BuildNum }}
+            - v3-test-results-{{ .Branch }}-
+            - v3-test-results-master-
       - run:
           name: Merge cached test results with results provided by circle (if any)
           command: |

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -18,7 +18,7 @@
 package org.apache.spark
 
 import java.io._
-import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor}
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
 import scala.collection.JavaConverters._
@@ -28,7 +28,6 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import org.apache.spark.ExecutorShuffleStatus.ExecutorShuffleStatus
 import org.apache.spark.broadcast.{Broadcast, BroadcastManager}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
@@ -63,13 +62,6 @@ private class ShuffleStatus(numPartitions: Int) {
   val mapStatuses = new Array[MapStatus](numPartitions)
 
   /**
-   * Whether an active job in the [[org.apache.spark.scheduler.DAGScheduler]] depends on this.
-   * If dynamic allocation is enabled, then executors that do not contain active shuffles may
-   * eventually be surrendered by the [[ExecutorAllocationManager]].
-   */
-  var isActive = true
-
-  /**
    * The cached result of serializing the map statuses array. This cache is lazily populated when
    * [[serializedMapStatus]] is called. The cache is invalidated when map outputs are removed.
    */
@@ -88,16 +80,9 @@ private class ShuffleStatus(numPartitions: Int) {
   /**
    * Counter tracking the number of partitions that have output. This is a performance optimization
    * to avoid having to count the number of non-null entries in the `mapStatuses` array and should
-   * be equivalent to `mapStatuses.count(_ ne null)`.
+   * be equivalent to`mapStatuses.count(_ ne null)`.
    */
   private[this] var _numAvailableOutputs: Int = 0
-
-  /**
-   * Cached set of executorIds on which outputs exist. This is a performance optimization to avoid
-   * having to repeatedly iterate over ever element in the `mapStatuses` array and should be
-   * equivalent to `mapStatuses.map(_.location.executorId).groupBy(x => x).mapValues(_.length)`.
-   */
-  private[this] val _numOutputsPerExecutorId = HashMap[String, Int]().withDefaultValue(0)
 
   /**
    * Register a map output. If there is already a registered location for the map output then it
@@ -105,7 +90,7 @@ private class ShuffleStatus(numPartitions: Int) {
    */
   def addMapOutput(mapId: Int, status: MapStatus): Unit = synchronized {
     if (mapStatuses(mapId) == null) {
-      incrementNumAvailableOutputs(status.location)
+      _numAvailableOutputs += 1
       invalidateSerializedMapOutputStatusCache()
     }
     mapStatuses(mapId) = status
@@ -118,7 +103,7 @@ private class ShuffleStatus(numPartitions: Int) {
    */
   def removeMapOutput(mapId: Int, bmAddress: BlockManagerId): Unit = synchronized {
     if (mapStatuses(mapId) != null && mapStatuses(mapId).location == bmAddress) {
-      decrementNumAvailableOutputs(bmAddress)
+      _numAvailableOutputs -= 1
       mapStatuses(mapId) = null
       invalidateSerializedMapOutputStatusCache()
     }
@@ -148,19 +133,11 @@ private class ShuffleStatus(numPartitions: Int) {
   def removeOutputsByFilter(f: (BlockManagerId) => Boolean): Unit = synchronized {
     for (mapId <- 0 until mapStatuses.length) {
       if (mapStatuses(mapId) != null && f(mapStatuses(mapId).location)) {
-        decrementNumAvailableOutputs(mapStatuses(mapId).location)
+        _numAvailableOutputs -= 1
         mapStatuses(mapId) = null
         invalidateSerializedMapOutputStatusCache()
       }
     }
-  }
-
-  def hasOutputsOnExecutor(execId: String): Boolean = synchronized {
-    _numOutputsPerExecutorId(execId) > 0
-  }
-
-  def executorsWithOutputs(): Set[String] = synchronized {
-    _numOutputsPerExecutorId.keySet.toSet
   }
 
   /**
@@ -215,22 +192,6 @@ private class ShuffleStatus(numPartitions: Int) {
     f(mapStatuses)
   }
 
-  private[this] def incrementNumAvailableOutputs(bmAddress: BlockManagerId): Unit = synchronized {
-    _numOutputsPerExecutorId(bmAddress.executorId) += 1
-    _numAvailableOutputs += 1
-  }
-
-  private[this] def decrementNumAvailableOutputs(bmAddress: BlockManagerId): Unit = synchronized {
-    assert(_numOutputsPerExecutorId(bmAddress.executorId) >= 1,
-      s"Tried to remove non-existent output from ${bmAddress.executorId}")
-    if (_numOutputsPerExecutorId(bmAddress.executorId) == 1) {
-      _numOutputsPerExecutorId.remove(bmAddress.executorId)
-    } else {
-      _numOutputsPerExecutorId(bmAddress.executorId) -= 1
-    }
-    _numAvailableOutputs -= 1
-  }
-
   /**
    * Clears the cached serialized map output statuses.
    */
@@ -240,7 +201,7 @@ private class ShuffleStatus(numPartitions: Int) {
       Utils.tryLogNonFatalError {
         // Use `blocking = false` so that this operation doesn't hang while trying to send cleanup
         // RPCs to dead executors.
-        cachedSerializedBroadcast.destroy(blocking = false)
+        cachedSerializedBroadcast.destroy()
       }
       cachedSerializedBroadcast = null
     }
@@ -343,11 +304,6 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
   def unregisterShuffle(shuffleId: Int): Unit
 
   def stop() {}
-}
-
-private[spark] object ExecutorShuffleStatus extends Enumeration {
-  type ExecutorShuffleStatus = Value
-  val Active, Inactive, Unknown = Value
 }
 
 /**
@@ -496,26 +452,6 @@ private[spark] class MapOutputTrackerMaster(
     }
   }
 
-  def markShuffleInactive(shuffleId: Int): Unit = {
-    shuffleStatuses.get(shuffleId) match {
-      case Some(shuffleStatus) =>
-        shuffleStatus.isActive = false
-      case None =>
-        throw new SparkException(
-          s"markShuffleInactive called for nonexistent shuffle ID $shuffleId.")
-    }
-  }
-
-  def markShuffleActive(shuffleId: Int): Unit = {
-    shuffleStatuses.get(shuffleId) match {
-      case Some(shuffleStatus) =>
-        shuffleStatus.isActive = true
-      case None =>
-        throw new SparkException(
-          s"markShuffleActive called for nonexistent shuffle ID $shuffleId.")
-    }
-  }
-
   /**
    * Removes all shuffle outputs associated with this host. Note that this will also remove
    * outputs which are served by an external shuffle server (if one exists).
@@ -533,12 +469,6 @@ private[spark] class MapOutputTrackerMaster(
   def removeOutputsOnExecutor(execId: String): Unit = {
     shuffleStatuses.valuesIterator.foreach { _.removeOutputsOnExecutor(execId) }
     incrementEpoch()
-  }
-
-  def hasOutputsOnExecutor(execId: String, activeOnly: Boolean = false): Boolean = {
-    shuffleStatuses.valuesIterator.exists { status =>
-      status.hasOutputsOnExecutor(execId) && (!activeOnly || status.isActive)
-    }
   }
 
   /** Check if the given shuffle is being tracked */
@@ -644,20 +574,6 @@ private[spark] class MapOutputTrackerMaster(
     } else {
       Nil
     }
-  }
-
-  /**
-   * Return the set of executors that contain tracked shuffle files, with a status of
-   * [[ExecutorShuffleStatus.Inactive]] iff all shuffle files on that executor are marked inactive.
-   *
-   * @return a map of executor IDs to their corresponding [[ExecutorShuffleStatus]]
-   */
-  def getExecutorShuffleStatus: scala.collection.Map[String, ExecutorShuffleStatus] = {
-    shuffleStatuses.values
-      .flatMap(status => status.executorsWithOutputs().map(_ -> status.isActive))
-      .groupBy(_._1) // group by executor ID
-      .mapValues(_.exists(_._2)) // true if any are Active
-      .mapValues(if (_) ExecutorShuffleStatus.Active else ExecutorShuffleStatus.Inactive)
   }
 
   /**
@@ -790,7 +706,7 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
     val statuses = mapStatuses.get(shuffleId).orNull
     if (statuses == null) {
       logInfo("Don't have map outputs for shuffle " + shuffleId + ", fetching them")
-      val startTime = System.currentTimeMillis
+      val startTimeNs = System.nanoTime()
       var fetchedStatuses: Array[MapStatus] = null
       fetching.synchronized {
         // Someone else is fetching it; wait for them to be done
@@ -828,7 +744,7 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
         }
       }
       logDebug(s"Fetching map output statuses for shuffle $shuffleId took " +
-        s"${System.currentTimeMillis - startTime} ms")
+        s"${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)} ms")
 
       if (fetchedStatuses != null) {
         fetchedStatuses

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -549,7 +549,7 @@ class SparkContext(config: SparkConf) extends SafeLogging {
           case b: ExecutorAllocationClient =>
             Some(new ExecutorAllocationManager(
               schedulerBackend.asInstanceOf[ExecutorAllocationClient], listenerBus, _conf,
-              _env.blockManager.asInstanceOf[BlockManagerMaster]))
+              _env.blockManager.master))
           case _ =>
             None
         }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -549,8 +549,7 @@ class SparkContext(config: SparkConf) extends SafeLogging {
           case b: ExecutorAllocationClient =>
             Some(new ExecutorAllocationManager(
               schedulerBackend.asInstanceOf[ExecutorAllocationClient], listenerBus, _conf,
-              _env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster],
-              _env.blockManager.master))
+              _env.blockManager.asInstanceOf[BlockManagerMaster]))
           case _ =>
             None
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.Set
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
+import scala.collection.mutable.{ArrayBuffer, BitSet, HashMap, HashSet}
 import scala.util.Random
 
 import org.apache.spark._
@@ -51,7 +51,12 @@ import org.apache.spark.util.{AccumulatorV2, SystemClock, ThreadUtils, Utils}
  * threads, so it needs locks in public API methods to maintain its state. In addition, some
  * [[SchedulerBackend]]s synchronize on themselves when they want to send events here, and then
  * acquire a lock on us, so we need to make sure that we don't try to lock the backend while
- * we are holding a lock on ourselves.
+ * we are holding a lock on ourselves.  This class is called from many threads, notably:
+ *   * The DAGScheduler Event Loop
+ *   * The RPCHandler threads, responding to status updates from Executors
+ *   * Periodic revival of all offers from the CoarseGrainedSchedulerBackend, to accomodate delay
+ *      scheduling
+ *   * task-result-getter threads
  */
 private[spark] class TaskSchedulerImpl(
     val sc: SparkContext,
@@ -82,10 +87,6 @@ private[spark] class TaskSchedulerImpl(
   private val speculationScheduler =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("task-scheduler-speculation")
 
-  // whether to prefer assigning tasks to executors that contain shuffle files
-  val shuffleBiasedTaskSchedulingEnabled =
-    conf.getBoolean("spark.scheduler.shuffleBiasedTaskScheduling.enabled", false)
-
   // Threshold above which we warn user initial TaskSet may be starved
   val STARVATION_TIMEOUT_MS = conf.getTimeAsMs("spark.starvation.timeout", "15s")
 
@@ -93,12 +94,16 @@ private[spark] class TaskSchedulerImpl(
   val CPUS_PER_TASK = conf.get(config.CPUS_PER_TASK)
 
   // TaskSetManagers are not thread safe, so any access to one should be synchronized
-  // on this class.
+  // on this class.  Protected by `this`
   private val taskSetsByStageIdAndAttempt = new HashMap[Int, HashMap[Int, TaskSetManager]]
 
   // Protected by `this`
   private[scheduler] val taskIdToTaskSetManager = new ConcurrentHashMap[Long, TaskSetManager]
+  // Protected by `this`
   val taskIdToExecutorId = new HashMap[Long, String]
+
+  // Protected by `this`
+  private[scheduler] val stageIdToFinishedPartitions = new HashMap[Int, BitSet]
 
   @volatile private var hasReceivedTask = false
   @volatile private var hasLaunchedTask = false
@@ -210,14 +215,20 @@ private[spark] class TaskSchedulerImpl(
       val stage = taskSet.stageId
       val stageTaskSets =
         taskSetsByStageIdAndAttempt.getOrElseUpdate(stage, new HashMap[Int, TaskSetManager])
+
+      // Mark all the existing TaskSetManagers of this stage as zombie, as we are adding a new one.
+      // This is necessary to handle a corner case. Let's say a stage has 10 partitions and has 2
+      // TaskSetManagers: TSM1(zombie) and TSM2(active). TSM1 has a running task for partition 10
+      // and it completes. TSM2 finishes tasks for partition 1-9, and thinks he is still active
+      // because partition 10 is not completed yet. However, DAGScheduler gets task completion
+      // events for all the 10 partitions and thinks the stage is finished. If it's a shuffle stage
+      // and somehow it has missing map outputs, then DAGScheduler will resubmit it and create a
+      // TSM3 for it. As a stage can't have more than one active task set managers, we must mark
+      // TSM2 as zombie (it actually is).
+      stageTaskSets.foreach { case (_, ts) =>
+        ts.isZombie = true
+      }
       stageTaskSets(taskSet.stageAttemptId) = manager
-      val conflictingTaskSet = stageTaskSets.exists { case (_, ts) =>
-        ts.taskSet != taskSet && !ts.isZombie
-      }
-      if (conflictingTaskSet) {
-        throw new IllegalStateException(s"more than one active taskSet for stage $stage:" +
-          s" ${stageTaskSets.toSeq.map{_._2.taskSet.id}.mkString(",")}")
-      }
       schedulableBuilder.addTaskSetManager(manager, manager.taskSet.properties)
 
       if (!isLocal && !hasReceivedTask) {
@@ -242,7 +253,20 @@ private[spark] class TaskSchedulerImpl(
   private[scheduler] def createTaskSetManager(
       taskSet: TaskSet,
       maxTaskFailures: Int): TaskSetManager = {
-    new TaskSetManager(this, taskSet, maxTaskFailures, blacklistTrackerOpt)
+    // only create a BitSet once for a certain stage since we only remove
+    // that stage when an active TaskSetManager succeed.
+    stageIdToFinishedPartitions.getOrElseUpdate(taskSet.stageId, new BitSet)
+    val tsm = new TaskSetManager(this, taskSet, maxTaskFailures, blacklistTrackerOpt)
+    // TaskSet got submitted by DAGScheduler may have some already completed
+    // tasks since DAGScheduler does not always know all the tasks that have
+    // been completed by other tasksets when completing a stage, so we mark
+    // those tasks as finished here to avoid launching duplicate tasks, while
+    // holding the TaskSchedulerImpl lock.
+    // See SPARK-25250 and `markPartitionCompletedInAllTaskSets()`
+    stageIdToFinishedPartitions.get(taskSet.stageId).foreach {
+      finishedPartitions => finishedPartitions.foreach(tsm.markPartitionCompleted(_, None))
+    }
+    tsm
   }
 
   override def cancelTasks(stageId: Int, interruptThread: Boolean): Unit = synchronized {
@@ -258,7 +282,10 @@ private[spark] class TaskSchedulerImpl(
     }
   }
 
-  override def killTaskAttempt(taskId: Long, interruptThread: Boolean, reason: String): Boolean = {
+  override def killTaskAttempt(
+      taskId: Long,
+      interruptThread: Boolean,
+      reason: String): Boolean = synchronized {
     logInfo(s"Killing task $taskId: $reason")
     val execId = taskIdToExecutorId.get(taskId)
     if (execId.isDefined) {
@@ -387,7 +414,11 @@ private[spark] class TaskSchedulerImpl(
       }
     }.getOrElse(offers)
 
-    var tasks: Seq[Seq[TaskDescription]] = Nil
+    val shuffledOffers = shuffleOffers(filteredOffers)
+    // Build a list of tasks to assign to each worker.
+    val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
+    val availableCpus = shuffledOffers.map(o => o.cores).toArray
+    val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
     val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
@@ -397,36 +428,11 @@ private[spark] class TaskSchedulerImpl(
       }
     }
 
-    // If shuffle-biased task scheduling is enabled, then first assign as many tasks as possible to
-    // executors containing active shuffle files, followed by assigning to executors with inactive
-    // shuffle files, and then finally to those without shuffle files. This bin packing allows for
-    // more efficient dynamic allocation in the absence of an external shuffle service.
-    val partitionedAndShuffledOffers = partitionAndShuffleOffers(filteredOffers)
-    for (shuffledOffers <- partitionedAndShuffledOffers.map(_._2)) {
-      tasks ++= doResourceOffers(shuffledOffers, sortedTaskSets)
-    }
-
-    // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get
-    // launched within a configured time.
-    if (tasks.size > 0) {
-      hasLaunchedTask = true
-    }
-    return tasks
-  }
-
-  private def doResourceOffers(
-      shuffledOffers: IndexedSeq[WorkerOffer],
-      sortedTaskSets: IndexedSeq[TaskSetManager]): Seq[Seq[TaskDescription]] = {
-    // Build a list of tasks to assign to each worker.
-    val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores / CPUS_PER_TASK))
-    val availableCpus = shuffledOffers.map(o => o.cores).toArray
-    val availableSlots = shuffledOffers.map(o => o.cores / CPUS_PER_TASK).sum
-
     // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
     // of locality levels so that it gets a chance to launch local tasks on all of them.
     // NOTE: the preferredLocality order: PROCESS_LOCAL, NODE_LOCAL, NO_PREF, RACK_LOCAL, ANY
     for (taskSet <- sortedTaskSets) {
-      // Skip the barrier taskSet if the available slots are less than the number of pending tasks
+      // Skip the barrier taskSet if the available slots are less than the number of pending tasks.
       if (taskSet.isBarrier && availableSlots < taskSet.numTasks) {
         // Skip the launch process.
         // TODO SPARK-24819 If the job requires more slots than available (both busy and free
@@ -514,33 +520,18 @@ private[spark] class TaskSchedulerImpl(
             .mkString(",")
           addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
 
-          logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for " +
-            s"barrier stage ${taskSet.stageId}.")
+          logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
+            s"stage ${taskSet.stageId}.")
         }
       }
     }
-    tasks
-  }
 
-  /**
-   * Shuffle offers around to avoid always placing tasks on the same workers.
-   * If shuffle-biased task scheduling is enabled, this function partitions the offers based on
-   * whether they have active/inactive/no shuffle files present.
-   */
-  def partitionAndShuffleOffers(offers: IndexedSeq[WorkerOffer])
-  : IndexedSeq[(ExecutorShuffleStatus.Value, IndexedSeq[WorkerOffer])] = {
-    if (shuffleBiasedTaskSchedulingEnabled && offers.length > 1) {
-      // bias towards executors that have active shuffle outputs
-      val execShuffles = mapOutputTracker.getExecutorShuffleStatus
-      offers
-        .groupBy(offer => execShuffles.getOrElse(offer.executorId, ExecutorShuffleStatus.Unknown))
-        .mapValues(doShuffleOffers)
-        .toStream
-        .sortBy(_._1) // order: Active, Inactive, Unknown
-        .toIndexedSeq
-    } else {
-      IndexedSeq((ExecutorShuffleStatus.Unknown, doShuffleOffers(offers)))
+    // TODO SPARK-24823 Cancel a job that contains barrier stage(s) if the barrier tasks don't get
+    // launched within a configured time.
+    if (tasks.size > 0) {
+      hasLaunchedTask = true
     }
+    return tasks
   }
 
   private def createUnschedulableTaskSetAbortTimer(
@@ -561,10 +552,10 @@ private[spark] class TaskSchedulerImpl(
   }
 
   /**
-   * Does the shuffling for [[partitionAndShuffleOffers()]]. Exposed to allow overriding in tests,
-   * so that it can be deterministic.
+   * Shuffle offers around to avoid always placing tasks on the same workers.  Exposed to allow
+   * overriding in tests, so it can be deterministic.
    */
-  protected def doShuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
+  protected def shuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
     Random.shuffle(offers)
   }
 
@@ -865,9 +856,10 @@ private[spark] class TaskSchedulerImpl(
 
   override def applicationAttemptId(): Option[String] = backend.applicationAttemptId()
 
+  // exposed for testing
   private[scheduler] def taskSetManagerForAttempt(
       stageId: Int,
-      stageAttemptId: Int): Option[TaskSetManager] = {
+      stageAttemptId: Int): Option[TaskSetManager] = synchronized {
     for {
       attempts <- taskSetsByStageIdAndAttempt.get(stageId)
       manager <- attempts.get(stageAttemptId)
@@ -877,19 +869,31 @@ private[spark] class TaskSchedulerImpl(
   }
 
   /**
-   * Marks the task has completed in all TaskSetManagers for the given stage.
+   * Marks the task has completed in all TaskSetManagers(active / zombie) for the given stage.
    *
    * After stage failure and retry, there may be multiple TaskSetManagers for the stage.
    * If an earlier attempt of a stage completes a task, we should ensure that the later attempts
    * do not also submit those same tasks.  That also means that a task completion from an earlier
    * attempt can lead to the entire stage getting marked as successful.
+   * And there is also the possibility that the DAGScheduler submits another taskset at the same
+   * time as we're marking a task completed here -- that taskset would have a task for a partition
+   * that was already completed. We maintain the set of finished partitions in
+   * stageIdToFinishedPartitions, protected by this, so we can detect those tasks when the taskset
+   * is submitted. See SPARK-25250 for more details.
+   *
+   * note: this method must be called with a lock on this.
    */
   private[scheduler] def markPartitionCompletedInAllTaskSets(
       stageId: Int,
       partitionId: Int,
       taskInfo: TaskInfo) = {
+    // if we do not find a BitSet for this stage, which means an active TaskSetManager
+    // has already succeeded and removed the stage.
+    stageIdToFinishedPartitions.get(stageId).foreach{
+      finishedPartitions => finishedPartitions += partitionId
+    }
     taskSetsByStageIdAndAttempt.getOrElse(stageId, Map()).values.foreach { tsm =>
-      tsm.markPartitionCompleted(partitionId, taskInfo)
+      tsm.markPartitionCompleted(partitionId, Some(taskInfo))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -21,7 +21,7 @@ import java.io.NotSerializableException
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
+import scala.collection.mutable.{ArrayBuffer, BitSet, HashMap, HashSet}
 import scala.math.max
 import scala.util.control.NonFatal
 
@@ -38,7 +38,8 @@ import org.apache.spark.util.collection.MedianHeap
  * each task, retries tasks if they fail (up to a limited number of times), and
  * handles locality-aware scheduling for this TaskSet via delay scheduling. The main interfaces
  * to it are resourceOffer, which asks the TaskSet whether it wants to run a task on one node,
- * and statusUpdate, which tells it that one of its tasks changed state (e.g. finished).
+ * and handleSuccessfulTask/handleFailedTask, which tells it that one of its tasks changed state
+ *  (e.g. finished/failed).
  *
  * THREADING: This class is designed to only be called from code with a lock on the
  * TaskScheduler (e.g. its event handlers). It should not be called from other threads.
@@ -257,7 +258,7 @@ private[spark] class TaskSetManager(
    * Return the pending tasks list for a given host, or an empty list if
    * there is no map entry for that host
    */
-  protected def getPendingTasksForHost(host: String): ArrayBuffer[Int] = {
+  private def getPendingTasksForHost(host: String): ArrayBuffer[Int] = {
     pendingTasksForHost.getOrElse(host, ArrayBuffer())
   }
 
@@ -778,7 +779,11 @@ private[spark] class TaskSetManager(
       // Mark successful and stop if all the tasks have succeeded.
       successful(index) = true
       if (tasksSuccessful == numTasks) {
-        isZombie = true
+        // clean up finished partitions for the stage when the active TaskSetManager succeed
+        if (!isZombie) {
+          sched.stageIdToFinishedPartitions -= stageId
+          isZombie = true
+        }
       }
     } else {
       logInfo("Ignoring task-finished event for " + info.id + " in stage " + taskSet.id +
@@ -797,16 +802,21 @@ private[spark] class TaskSetManager(
     maybeFinishTaskSet()
   }
 
-  private[scheduler] def markPartitionCompleted(partitionId: Int, taskInfo: TaskInfo): Unit = {
+  private[scheduler] def markPartitionCompleted(
+      partitionId: Int,
+      taskInfo: Option[TaskInfo]): Unit = {
     partitionToIndex.get(partitionId).foreach { index =>
       if (!successful(index)) {
         if (speculationEnabled && !isZombie) {
-          successfulTaskDurations.insert(taskInfo.duration)
+          taskInfo.foreach { info => successfulTaskDurations.insert(info.duration) }
         }
         tasksSuccessful += 1
         successful(index) = true
         if (tasksSuccessful == numTasks) {
-          isZombie = true
+          if (!isZombie) {
+            sched.stageIdToFinishedPartitions -= stageId
+            isZombie = true
+          }
         }
         maybeFinishTaskSet()
       }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -329,31 +329,4 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     rpcEnv.shutdown()
   }
 
-  test("correctly track executors and ExecutorShuffleStatus") {
-    val tracker = newTrackerMaster()
-    val bmId1 = BlockManagerId("exec1", "host1", 1000)
-    val bmId2 = BlockManagerId("exec2", "host2", 1000)
-    tracker.registerShuffle(11, 3)
-    tracker.registerMapOutput(11, 0, MapStatus(bmId1, Array(10)))
-    tracker.registerMapOutput(11, 1, MapStatus(bmId1, Array(100)))
-    tracker.registerMapOutput(11, 2, MapStatus(bmId2, Array(1000)))
-
-    assert(tracker.hasOutputsOnExecutor("exec1"))
-    assert(tracker.getExecutorShuffleStatus.keySet.equals(Set("exec1", "exec2")))
-    assert(!tracker.hasOutputsOnExecutor("exec3"))
-
-    tracker.unregisterMapOutput(11, 0, bmId1)
-    assert(tracker.hasOutputsOnExecutor("exec1"))
-    tracker.unregisterMapOutput(11, 1, bmId1)
-    assert(!tracker.hasOutputsOnExecutor("exec1"))
-
-    tracker.markShuffleInactive(11)
-    assert(tracker.hasOutputsOnExecutor("exec2"))
-    assert(!tracker.hasOutputsOnExecutor("exec2", activeOnly = true))
-
-    assert(tracker.getExecutorShuffleStatus == Map("exec2" -> ExecutorShuffleStatus.Inactive))
-    tracker.markShuffleActive(11)
-    assert(tracker.getExecutorShuffleStatus == Map("exec2" -> ExecutorShuffleStatus.Active))
-  }
-
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.rdd.{DeterministicLevel, RDD}
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
 import org.apache.spark.shuffle.{FetchFailedException, MetadataFetchFailedException}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockManagerMaster}
-import org.apache.spark.util._
+import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, CallSite, LongAccumulator, Utils}
 
 class DAGSchedulerEventProcessLoopTester(dagScheduler: DAGScheduler)
   extends DAGSchedulerEventProcessLoop(dagScheduler) {
@@ -890,7 +890,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Confirm job finished successfully
     sc.listenerBus.waitUntilEmpty(1000)
-    assert(ended === true)
+    assert(ended)
     assert(results === (0 until parts).map { idx => idx -> 42 }.toMap)
     assertDataStructuresEmpty()
   }
@@ -1049,7 +1049,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     assertDataStructuresEmpty()
     sc.listenerBus.waitUntilEmpty(1000)
-    assert(ended === true)
+    assert(ended)
     assert(results === Map(0 -> 42))
   }
 
@@ -2192,102 +2192,6 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Check that if we submit the map stage again, no tasks run
     submitMapStage(shuffleDep)
     assert(results.size === 1)
-    assertDataStructuresEmpty()
-  }
-
-  test("stage level active shuffle tracking") {
-    // We will have 3 stages depending on each other.
-    // The second stage is composed of 2 RDDs to check we're tracking shuffle up the chain.
-    val shuffleMapRdd1 = new MyRDD(sc, 2, Nil)
-    val shuffleDep1 = new ShuffleDependency(shuffleMapRdd1, new HashPartitioner(1))
-    val shuffleId1 = shuffleDep1.shuffleId
-    val shuffleMapRdd2 = new MyRDD(sc, 2, List(shuffleDep1), tracker = mapOutputTracker)
-    val shuffleDep2 = new ShuffleDependency(shuffleMapRdd2, new HashPartitioner(1))
-    val shuffleId2 = shuffleDep2.shuffleId
-    val intermediateRdd = new MyRDD(sc, 1, List(shuffleDep2), tracker = mapOutputTracker)
-    val intermediateDep = new OneToOneDependency(intermediateRdd)
-    val reduceRdd = new MyRDD(sc, 1, List(intermediateDep), tracker = mapOutputTracker)
-
-    // Submit the job.
-    // Both shuffles should become active.
-    submit(reduceRdd, Array(0))
-    assert(mapOutputTracker.shuffleStatuses(shuffleId1).isActive === true)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId2).isActive === true)
-
-    // Complete the first stage.
-    // Both shuffles remain active.
-    completeShuffleMapStageSuccessfully(0, 0, 2)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId1).isActive === true)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId2).isActive === true)
-
-    // Complete the second stage.
-    // Shuffle 1 is no longer needed and should become inactive.
-    completeShuffleMapStageSuccessfully(1, 0, 1)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId1).isActive === false)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId2).isActive === true)
-
-    // Complete the results stage.
-    // Both shuffles are no longer needed and should become inactive.
-    completeNextResultStageWithSuccess(2, 0)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId1).isActive === false)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId2).isActive === false)
-
-    // Double check results.
-    assert(results === Map(0 -> 42))
-    results.clear()
-    assertDataStructuresEmpty()
-  }
-
-  test("stage level active shuffle tracking with multiple dependents") {
-    // We will have a diamond shape dependency.
-    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
-    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(1))
-    val shuffleId = shuffleDep.shuffleId
-    val intermediateRdd1 = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
-    val intermediateRdd2 = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
-    val intermediateDep1 = new ShuffleDependency(intermediateRdd1, new HashPartitioner(1))
-    val intermediateDep2 = new ShuffleDependency(intermediateRdd2, new HashPartitioner(1))
-    val reduceRdd =
-      new MyRDD(sc, 1, List(intermediateDep1, intermediateDep2), tracker = mapOutputTracker)
-
-    // Submit the job.
-    // Shuffle becomes active.
-    submit(reduceRdd, Array(0))
-    assert(mapOutputTracker.shuffleStatuses(shuffleId).isActive === true)
-
-    // Complete the shuffle stage.
-    // Shuffle remains active.
-    completeShuffleMapStageSuccessfully(0, 0, 2)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId).isActive === true)
-
-    // Complete first intermediate stage.
-    // Shuffle is still active.
-    val stageAttempt = taskSets(1)
-    checkStageId(1, 0, stageAttempt)
-    complete(stageAttempt, stageAttempt.tasks.zipWithIndex.map {
-      case (task, idx) =>
-        (Success, makeMapStatus("host" + ('A' + idx).toChar, 1))
-    }.toSeq)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId).isActive === true)
-
-    // Complete second intermediate stage.
-    // Shuffle is no longer active.
-    val stageAttempt2 = taskSets(2)
-    checkStageId(2, 0, stageAttempt2)
-    complete(stageAttempt2, stageAttempt2.tasks.zipWithIndex.map {
-      case (task, idx) =>
-        (Success, makeMapStatus("host" + ('A' + idx).toChar, 1))
-    }.toSeq)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId).isActive === false)
-
-    // Complete the results stage.
-    // Shuffle is still inactive.
-    completeNextResultStageWithSuccess(3, 0)
-    assert(mapOutputTracker.shuffleStatuses(shuffleId).isActive === false)
-
-    // Double check results.
-    assert(results === Map(0 -> 42))
-    results.clear()
     assertDataStructuresEmpty()
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -29,10 +29,8 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 
 import org.apache.spark._
-import org.apache.spark.ExecutorShuffleStatus._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
-import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.ManualClock
 
 class FakeSchedulerBackend extends SchedulerBackend {
@@ -203,28 +201,39 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // Even if one of the task sets has not-serializable tasks, the other task set should
     // still be processed without error
     taskScheduler.submitTasks(FakeTask.createTaskSet(1))
-    taskScheduler.submitTasks(taskSet)
+    val taskSet2 = new TaskSet(
+      Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)), 1, 0, 0, null)
+    taskScheduler.submitTasks(taskSet2)
     taskDescriptions = taskScheduler.resourceOffers(multiCoreWorkerOffers).flatten
     assert(taskDescriptions.map(_.executorId) === Seq("executor0"))
   }
 
-  test("refuse to schedule concurrent attempts for the same stage (SPARK-8103)") {
+  test("concurrent attempts for the same stage only have one active taskset") {
     val taskScheduler = setupScheduler()
-    val attempt1 = FakeTask.createTaskSet(1, 0)
-    val attempt2 = FakeTask.createTaskSet(1, 1)
-    taskScheduler.submitTasks(attempt1)
-    intercept[IllegalStateException] { taskScheduler.submitTasks(attempt2) }
+    def isTasksetZombie(taskset: TaskSet): Boolean = {
+      taskScheduler.taskSetManagerForAttempt(taskset.stageId, taskset.stageAttemptId).get.isZombie
+    }
 
-    // OK to submit multiple if previous attempts are all zombie
-    taskScheduler.taskSetManagerForAttempt(attempt1.stageId, attempt1.stageAttemptId)
-      .get.isZombie = true
+    val attempt1 = FakeTask.createTaskSet(1, 0)
+    taskScheduler.submitTasks(attempt1)
+    // The first submitted taskset is active
+    assert(!isTasksetZombie(attempt1))
+
+    val attempt2 = FakeTask.createTaskSet(1, 1)
     taskScheduler.submitTasks(attempt2)
+    // The first submitted taskset is zombie now
+    assert(isTasksetZombie(attempt1))
+    // The newly submitted taskset is active
+    assert(!isTasksetZombie(attempt2))
+
     val attempt3 = FakeTask.createTaskSet(1, 2)
-    intercept[IllegalStateException] { taskScheduler.submitTasks(attempt3) }
-    taskScheduler.taskSetManagerForAttempt(attempt2.stageId, attempt2.stageAttemptId)
-      .get.isZombie = true
     taskScheduler.submitTasks(attempt3)
-    assert(!failedTaskSet)
+    // The first submitted taskset remains zombie
+    assert(isTasksetZombie(attempt1))
+    // The second submitted taskset is zombie now
+    assert(isTasksetZombie(attempt2))
+    // The newly submitted taskset is active
+    assert(!isTasksetZombie(attempt3))
   }
 
   test("don't schedule more tasks after a taskset is zombie") {
@@ -1021,7 +1030,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // We customize the task scheduler just to let us control the way offers are shuffled, so we
     // can be sure we try both permutations, and to control the clock on the tasksetmanager.
     val taskScheduler = new TaskSchedulerImpl(sc) {
-      override def doShuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
+      override def shuffleOffers(offers: IndexedSeq[WorkerOffer]): IndexedSeq[WorkerOffer] = {
         // Don't shuffle the offers around for this test.  Instead, we'll just pass in all
         // the permutations we care about directly.
         offers
@@ -1056,40 +1065,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
         assert(taskDescs.head.executorId === "exec1")
       }
     }
-  }
-
-  test("Shuffle-biased task scheduling enabled should lead to non-random offer shuffling") {
-    setupScheduler("spark.scheduler.shuffleBiasedTaskScheduling.enabled" -> "true")
-
-    // Make offers in different executors, so they can be a mix of active, inactive, unknown
-    val offers = IndexedSeq(
-      WorkerOffer("exec1", "host1", 2), // inactive
-      WorkerOffer("exec2", "host2", 2), // active
-      WorkerOffer("exec3", "host3", 2) // unknown
-    )
-    val makeMapStatus = (offer: WorkerOffer) =>
-      MapStatus(BlockManagerId(offer.executorId, offer.host, 1), Array(10))
-    val mapOutputTracker = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
-    mapOutputTracker.registerShuffle(0, 2)
-    mapOutputTracker.registerShuffle(1, 1)
-    mapOutputTracker.registerMapOutput(0, 0, makeMapStatus(offers(0)))
-    mapOutputTracker.registerMapOutput(0, 1, makeMapStatus(offers(1)))
-    mapOutputTracker.registerMapOutput(1, 0, makeMapStatus(offers(1)))
-    mapOutputTracker.markShuffleInactive(0)
-
-    val execStatus = mapOutputTracker.getExecutorShuffleStatus
-    assert(execStatus.equals(Map("exec1" -> Inactive, "exec2" -> Active)))
-
-    assert(taskScheduler.partitionAndShuffleOffers(offers).map(_._1)
-      .equals(IndexedSeq(Active, Inactive, Unknown)))
-    assert(taskScheduler.partitionAndShuffleOffers(offers).flatMap(_._2).map(offers.indexOf(_))
-      .equals(IndexedSeq(1, 0, 2)))
-
-    taskScheduler.submitTasks(FakeTask.createTaskSet(3, stageId = 1, stageAttemptId = 0))
-    // should go to active first, then inactive
-    val taskDescs = taskScheduler.resourceOffers(offers).flatten
-    assert(taskDescs.size === 3)
-    assert(taskDescs.map(_.executorId).equals(Seq("exec2", "exec2", "exec1")))
   }
 
   test("With delay scheduling off, tasks can be run at any locality level immediately") {
@@ -1138,7 +1113,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     }
   }
 
-  test("Completions in zombie tasksets update status of non-zombie taskset") {
+  test("SPARK-23433/25250 Completions in zombie tasksets update status of non-zombie taskset") {
     val taskScheduler = setupSchedulerWithMockTaskSetBlacklist()
     val valueSer = SparkEnv.get.serializer.newInstance()
 
@@ -1150,9 +1125,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     }
 
     // Submit a task set, have it fail with a fetch failed, and then re-submit the task attempt,
-    // two times, so we have three active task sets for one stage.  (For this to really happen,
-    // you'd need the previous stage to also get restarted, and then succeed, in between each
-    // attempt, but that happens outside what we're mocking here.)
+    // two times, so we have three TaskSetManagers(2 zombie, 1 active) for one stage.  (For this
+    // to really happen, you'd need the previous stage to also get restarted, and then succeed,
+    // in between each attempt, but that happens outside what we're mocking here.)
     val zombieAttempts = (0 until 2).map { stageAttempt =>
       val attempt = FakeTask.createTaskSet(10, stageAttemptId = stageAttempt)
       taskScheduler.submitTasks(attempt)
@@ -1169,13 +1144,33 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       assert(tsm.runningTasks === 9)
       tsm
     }
+    // we've now got 2 zombie attempts, each with 9 tasks still running. And there's no active
+    // attempt exists in taskScheduler by now.
 
-    // we've now got 2 zombie attempts, each with 9 tasks still active.  Submit the 3rd attempt for
-    // the stage, but this time with insufficient resources so not all tasks are active.
+    // finish partition 1,2 by completing the tasks before a new attempt for the same stage submit.
+    // This is possible since the behaviour of submitting new attempt and handling successful task
+    // is from two different threads, which are "task-result-getter" and "dag-scheduler-event-loop"
+    // separately.
+    (0 until 2).foreach { i =>
+      completeTaskSuccessfully(zombieAttempts(i), i + 1)
+      assert(taskScheduler.stageIdToFinishedPartitions(0).contains(i + 1))
+    }
 
+    // Submit the 3rd attempt still with 10 tasks, this happens due to the race between thread
+    // "task-result-getter" and "dag-scheduler-event-loop", where a TaskSet gets submitted with
+    // already completed tasks. And this time with insufficient resources so not all tasks are
+    // active.
     val finalAttempt = FakeTask.createTaskSet(10, stageAttemptId = 2)
     taskScheduler.submitTasks(finalAttempt)
     val finalTsm = taskScheduler.taskSetManagerForAttempt(0, 2).get
+    // Though finalTSM gets submitted with 10 tasks, the call to taskScheduler.submitTasks should
+    // realize that 2 tasks have already completed, and mark them appropriately, so it won't launch
+    // any duplicate tasks later (SPARK-25250).
+    (0 until 2).map(_ + 1).foreach { partitionId =>
+      val index = finalTsm.partitionToIndex(partitionId)
+      assert(finalTsm.successful(index))
+    }
+
     val offers = (0 until 5).map{ idx => WorkerOffer(s"exec-$idx", s"host-$idx", 1) }
     val finalAttemptLaunchedPartitions = taskScheduler.resourceOffers(offers).flatten.map { task =>
       finalAttempt.tasks(task.index).partitionId
@@ -1183,16 +1178,17 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(finalTsm.runningTasks === 5)
     assert(!finalTsm.isZombie)
 
-    // We simulate late completions from our zombie tasksets, corresponding to all the pending
-    // partitions in our final attempt.  This means we're only waiting on the tasks we've already
-    // launched.
+    // We continually simulate late completions from our zombie tasksets(but this time, there's one
+    // active attempt exists in taskScheduler), corresponding to all the pending partitions in our
+    // final attempt. This means we're only waiting on the tasks we've already launched.
     val finalAttemptPendingPartitions = (0 until 10).toSet.diff(finalAttemptLaunchedPartitions)
     finalAttemptPendingPartitions.foreach { partition =>
       completeTaskSuccessfully(zombieAttempts(0), partition)
+      assert(taskScheduler.stageIdToFinishedPartitions(0).contains(partition))
     }
 
     // If there is another resource offer, we shouldn't run anything.  Though our final attempt
-    // used to have pending tasks, now those tasks have been completed by zombie attempts.  The
+    // used to have pending tasks, now those tasks have been completed by zombie attempts. The
     // remaining tasks to compute are already active in the non-zombie attempt.
     assert(
       taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec-1", "host-1", 1))).flatten.isEmpty)
@@ -1240,6 +1236,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       // perspective, as the failures weren't from a problem w/ the tasks themselves.
       verify(blacklist).updateBlacklistForSuccessfulTaskSet(meq(0), meq(stageAttempt), any())
     }
+    assert(taskScheduler.stageIdToFinishedPartitions.isEmpty)
   }
 
   test("don't schedule for a barrier taskSet if available slots are less than pending tasks") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.File
+import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.{HashMap => JHashMap}
 
@@ -77,43 +78,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    sc.stop()
     """.stripMargin
 
-  private val TEST_CONDA_PYFILE = """
-    |import mod1, mod2
-    |import sys
-    |from operator import add
-    |
-    |from pyspark import SparkConf , SparkContext
-    |if __name__ == "__main__":
-    |    if len(sys.argv) != 2:
-    |        print >> sys.stderr, "Usage: test.py [result file]"
-    |        exit(-1)
-    |    sc = SparkContext(conf=SparkConf())
-    |
-    |    sc.addCondaPackages('numpy=1.14.0')
-    |    import numpy
-    |
-    |    status = open(sys.argv[1],'w')
-    |
-    |    # Addict exists only in external-conda-forge, not anaconda
-    |    sc.addCondaChannel("https://conda.anaconda.org/conda-forge")
-    |    sc.addCondaPackages('addict=2.2.0')
-    |
-    |    def numpy_multiply(x):
-    |        # Ensure package from non-base channel is installed
-    |        import addict
-    |        numpy.multiply(x, mod1.func() * mod2.func())
-    |
-    |    rdd = sc.parallelize(range(10)).map(numpy_multiply)
-    |    cnt = rdd.count()
-    |    if cnt == 10:
-    |        result = "success"
-    |    else:
-    |        result = "failure"
-    |    status.write(result)
-    |    status.close()
-    |    sc.stop()
-  """.stripMargin
-
   private val TEST_PYMODULE = """
     |def func():
     |    return 42
@@ -158,26 +122,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       ))
   }
 
-  test("run Spark in yarn-client mode with dynamic allocation") {
-    testBasicYarnApp(true,
-      Map(
-        "spark.dynamicAllocation.enabled" -> "true",
-        // Start with 0 executors to at least test that we will request more to run the job.
-        "spark.dynamicAllocation.initialExecutors" -> "0",
-        "spark.dynamicAllocation.maxExecutors" -> "1"
-      ))
-  }
-
-  test("run Spark in yarn-cluster mode with dynamic allocation") {
-    testBasicYarnApp(false,
-      Map(
-        "spark.dynamicAllocation.enabled" -> "true",
-        // Start with 0 executors to at least test that we will request more to run the job.
-        "spark.dynamicAllocation.initialExecutors" -> "0",
-        "spark.dynamicAllocation.maxExecutors" -> "1"
-      ))
-  }
-
   test("yarn-cluster should respect conf overrides in SparkHadoopUtil (SPARK-16414, SPARK-23630)") {
     // Create a custom hadoop config file, to make sure it's contents are propagated to the driver.
     val customConf = Utils.createTempDir()
@@ -195,9 +139,8 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     val finalState = runSpark(false,
       mainClassName(YarnClusterDriverUseSparkHadoopUtilConf.getClass),
       appArgs = Seq("key=value", "spark.test.key=testvalue", result.getAbsolutePath()),
-      extraConf = Map(
-        "spark.hadoop.key" -> "value",
-        "spark.yarn.conf.dir" -> customConf.getAbsolutePath))
+      extraConf = Map("spark.hadoop.key" -> "value"),
+      extraEnv = Map("SPARK_TEST_HADOOP_CONF_DIR" -> customConf.getAbsolutePath()))
     checkResult(finalState, result)
   }
 
@@ -226,14 +169,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   test("run Python application in yarn-cluster mode") {
     testPySpark(false)
-  }
-
-  test("run Python application within Conda in yarn-client mode") {
-    testCondaPySpark(true)
-  }
-
-  test("run Python application within Conda in yarn-cluster mode") {
-    testCondaPySpark(false)
   }
 
   test("run Python application in yarn-cluster mode using " +
@@ -364,55 +299,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       extraConf = extraConf,
       outFile = outFile)
     checkResult(finalState, result, outFile = outFile)
-  }
-
-  private def testCondaPySpark(
-      clientMode: Boolean,
-      extraEnv: Map[String, String] = Map()): Unit = {
-    val primaryPyFile = new File(tempDir, "test.py")
-    Files.write(TEST_CONDA_PYFILE, primaryPyFile, StandardCharsets.UTF_8)
-
-    // When running tests, let's not assume the user has built the assembly module, which also
-    // creates the pyspark archive. Instead, let's use PYSPARK_ARCHIVES_PATH to point at the
-    // needed locations.
-    val sparkHome = sys.props("spark.test.home")
-    val pythonPath = Seq(
-      s"$sparkHome/python/lib/py4j-0.10.8.1-src.zip",
-      s"$sparkHome/python")
-    val extraEnvVars = Map(
-      "PYSPARK_ARCHIVES_PATH" -> pythonPath.map("local:" + _).mkString(File.pathSeparator),
-      "PYTHONPATH" -> pythonPath.mkString(File.pathSeparator)) ++ extraEnv
-
-    val extraConf: Map[String, String] = Map(
-      "spark.conda.binaryPath" -> sys.env("CONDA_BIN"),
-      "spark.conda.channelUrls" -> "https://repo.continuum.io/pkgs/main",
-      "spark.conda.bootstrapPackages" -> "python=3.6"
-    )
-
-    val moduleDir =
-      if (clientMode) {
-        // In client-mode, .py files added with --py-files are not visible in the driver.
-        // This is something that the launcher library would have to handle.
-        tempDir
-      } else {
-        val subdir = new File(tempDir, "pyModules")
-        subdir.mkdir()
-        subdir
-      }
-    val pyModule = new File(moduleDir, "mod1.py")
-    Files.write(TEST_PYMODULE, pyModule, StandardCharsets.UTF_8)
-
-    val mod2Archive = TestUtils.createJarWithFiles(Map("mod2.py" -> TEST_PYMODULE), moduleDir)
-    val pyFiles = Seq(pyModule.getAbsolutePath(), mod2Archive.getPath()).mkString(",")
-    val result = File.createTempFile("result", null, tempDir)
-
-    val finalState = runSpark(clientMode, primaryPyFile.getAbsolutePath(),
-      sparkArgs = Seq("--py-files" -> pyFiles),
-      appArgs = Seq(result.getAbsolutePath()),
-      extraEnv = extraEnvVars,
-      extraConf = extraConf,
-      timeoutDuration = 4.minutes) // give it a bit longer
-    checkResult(finalState, result)
   }
 
   private def testUseClassPathFirst(clientMode: Boolean): Unit = {
@@ -591,6 +477,9 @@ private object YarnClusterDriver extends Logging with Matchers {
         val driverAttributes = listener.driverAttributes.get
         val expectationAttributes = Map(
           "HTTP_SCHEME" -> YarnContainerInfoHelper.getYarnHttpScheme(yarnConf),
+          "NM_HOST" -> YarnContainerInfoHelper.getNodeManagerHost(container = None),
+          "NM_PORT" -> YarnContainerInfoHelper.getNodeManagerPort(container = None),
+          "NM_HTTP_PORT" -> YarnContainerInfoHelper.getNodeManagerHttpPort(container = None),
           "NM_HTTP_ADDRESS" -> YarnContainerInfoHelper.getNodeManagerHttpAddress(container = None),
           "CLUSTER_ID" -> YarnContainerInfoHelper.getClusterId(yarnConf).getOrElse(""),
           "CONTAINER_ID" -> ConverterUtils.toString(containerId),

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -158,26 +158,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       ))
   }
 
-  test("run Spark in yarn-client mode with dynamic allocation") {
-    testBasicYarnApp(true,
-      Map(
-        "spark.dynamicAllocation.enabled" -> "true",
-        // Start with 0 executors to at least test that we will request more to run the job.
-        "spark.dynamicAllocation.initialExecutors" -> "0",
-        "spark.dynamicAllocation.maxExecutors" -> "1"
-      ))
-  }
-
-  test("run Spark in yarn-cluster mode with dynamic allocation") {
-    testBasicYarnApp(false,
-      Map(
-        "spark.dynamicAllocation.enabled" -> "true",
-        // Start with 0 executors to at least test that we will request more to run the job.
-        "spark.dynamicAllocation.initialExecutors" -> "0",
-        "spark.dynamicAllocation.maxExecutors" -> "1"
-      ))
-  }
-
   test("yarn-cluster should respect conf overrides in SparkHadoopUtil (SPARK-16414, SPARK-23630)") {
     // Create a custom hadoop config file, to make sure it's contents are propagated to the driver.
     val customConf = Utils.createTempDir()


### PR DESCRIPTION
When working on SPARK-25299 specifically, we want to work off of the master branch's version of various parts of the code that soft dynamic allocation changed.

Due to the way the code diverged, and due to the way conflict resolution was performed when merging from upstream, simply reverting the commits that introduced the feature was not trivial. We instead followed a more manual approach:

1. git checkout the upstream master version of `MapOutputTracker`
2. Find all compilation errors in dependent classes
3. git checkout the upstream master version of all broken classes
4. Repeat 2-3 until no compilation errors are left