### PR TITLE
[SPARK-27267][CORE] Update snappy to avoid error when decompressing empty serialized data

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -192,7 +192,7 @@ shapeless_2.11-2.3.2.jar
 slf4j-api-1.7.25.jar
 slf4j-log4j12-1.7.25.jar
 snakeyaml-1.23.jar
-snappy-java-1.1.7.2.jar
+snappy-java-1.1.7.3.jar
 spire-macros_2.11-0.13.0.jar
 spire_2.11-0.13.0.jar
 stax-api-1.0-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.9.7</fasterxml.jackson.version>
-    <snappy.version>1.1.7.2</snappy.version>
+    <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.11</commons-codec.version>


### PR DESCRIPTION
- Fixes https://issues.apache.org/jira/browse/SPARK-27267
- Upstream PR: https://github.com/apache/spark/pull/24242/files