### PR TITLE
Empty commit to retag 2.5.0-palantir.8 as 3.0.0-palantir.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Palantir distribution of Apache Spark
+# Palantir distribution of Apache Spark 
 
 [ ![Download](https://api.bintray.com/packages/palantir/releases/spark/images/download.svg) ](https://bintray.com/palantir/releases/spark/_latestVersion)
 


### PR DESCRIPTION
Releasing 2.5.0-palantir.8 from this branch as 3.0.0-palantir.26 

@rahij @vinooganesh @gatesn 