### PR TITLE
Publish DS v2 branch as snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ deployable-branches-and-tags: &deployable-branches-and-tags
     tags:
       only: /[0-9]+(?:\.[0-9]+){2,}-palantir\.[0-9]+(?:\.[0-9]+)*/
     branches:
-      only: master
+      only:
+        - master
+        - ds-v2-base
 
 
 # Step templates


### PR DESCRIPTION
Makes the ds-v2-base branch releasable as bintray snapshots for internal testing. Specifically required to update the Spark version in https://github.com/palantir/incubator-iceberg.