### PR TITLE
[SPARK-27773][SHUFFLE] add metrics for number of exceptions caught in ExternalShuffleBlockHandler

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -122,6 +122,11 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     }
   }
 
+  @Override
+  public void exceptionCaught(Throwable cause, TransportClient client) {
+    metrics.caughtExceptions.inc();
+  }
+
   public MetricSet getAllMetrics() {
     return metrics;
   }
@@ -187,6 +192,8 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     private Counter activeConnections = new Counter();
     // Number of registered connections to the shuffle service
     private Counter registeredConnections = new Counter();
+    // Number of exceptions caught in connections to the shuffle service
+    private Counter caughtExceptions = new Counter();
 
     public ShuffleMetrics() {
       allMetrics = new HashMap<>();
@@ -197,6 +204,7 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
                      (Gauge<Integer>) () -> blockManager.getRegisteredExecutorsSize());
       allMetrics.put("numActiveConnections", activeConnections);
       allMetrics.put("numRegisteredConnections", registeredConnections);
+      allMetrics.put("numCaughtExceptions", caughtExceptions);
     }
 
     @Override

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -106,13 +106,13 @@ class YarnShuffleServiceMetrics implements MetricsSource {
     } else if (metric instanceof Gauge) {
       final Object gaugeValue = ((Gauge) metric).getValue();
       if (gaugeValue instanceof Integer) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfo(name), (Integer) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Integer) gaugeValue);
       } else if (gaugeValue instanceof Long) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfo(name), (Long) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Long) gaugeValue);
       } else if (gaugeValue instanceof Float) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfo(name), (Float) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Float) gaugeValue);
       } else if (gaugeValue instanceof Double) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfo(name), (Double) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Double) gaugeValue);
       } else {
         throw new IllegalStateException(
                 "Not supported class type of metric[" + name + "] for value " + gaugeValue);
@@ -120,13 +120,16 @@ class YarnShuffleServiceMetrics implements MetricsSource {
     } else if (metric instanceof Counter) {
       Counter c = (Counter) metric;
       long counterValue = c.getCount();
-      metricsRecordBuilder.addGauge(new ShuffleServiceMetricsInfo(name, "Number of " +
-          "connections to shuffle service " + name), counterValue);
+      metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForCounter(name), counterValue);
     }
   }
 
-  private static MetricsInfo getShuffleServiceMetricsInfo(String name) {
+  private static MetricsInfo getShuffleServiceMetricsInfoForGauge(String name) {
     return new ShuffleServiceMetricsInfo(name, "Value of gauge " + name);
+  }
+
+  private static ShuffleServiceMetricsInfo getShuffleServiceMetricsInfoForCounter(String name) {
+    return new ShuffleServiceMetricsInfo(name, "Value of counter " + name);
   }
 
   private static class ShuffleServiceMetricsInfo implements MetricsInfo {

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -106,13 +106,17 @@ class YarnShuffleServiceMetrics implements MetricsSource {
     } else if (metric instanceof Gauge) {
       final Object gaugeValue = ((Gauge) metric).getValue();
       if (gaugeValue instanceof Integer) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Integer) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name),
+                (Integer) gaugeValue);
       } else if (gaugeValue instanceof Long) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Long) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name),
+                (Long) gaugeValue);
       } else if (gaugeValue instanceof Float) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Float) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name),
+                (Float) gaugeValue);
       } else if (gaugeValue instanceof Double) {
-        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name), (Double) gaugeValue);
+        metricsRecordBuilder.addGauge(getShuffleServiceMetricsInfoForGauge(name),
+                (Double) gaugeValue);
       } else {
         throw new IllegalStateException(
                 "Not supported class type of metric[" + name + "] for value " + gaugeValue);

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -39,7 +39,7 @@ class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
     val allMetrics = Set(
       "openBlockRequestLatencyMillis", "registerExecutorRequestLatencyMillis",
       "blockTransferRateBytes", "registeredExecutorsSize", "numActiveConnections",
-      "numRegisteredConnections")
+      "numRegisteredConnections", "numCaughtExceptions")
 
     metrics.getMetrics.keySet().asScala should be (allMetrics)
   }


### PR DESCRIPTION
More context on https://issues.apache.org/jira/browse/SPARK-27773. Basically gives us a rough indicator of health of the external shuffle service / metric that we can monitor and alert on.