### PR TITLE
log conda output

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -177,12 +177,15 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       BasicIO.processFully((redactCredentials _).andThen(line => {
         out.append(line)
         out.append(BasicIO.Newline)
+        if (verbosity > 0) {
+          logInfo(s"<conda> $line")
+        }
         ()
       })),
       BasicIO.processFully((redactCredentials _).andThen(line => {
         err.append(line)
         err.append(BasicIO.Newline)
-        log.info(s"<conda> $line")
+        logInfo(s"<conda> $line")
       })))
     val exitCode = command.run(collectErrOutToBuffer).exitValue()
     if (exitCode != 0) {


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
When running verbose conda commands, outputs via `log.info` are not being logged, but outputs with `logInfo` are. We also want to log the conda command in the case the verbosity flag is on (>0).
## What changes were proposed in this pull request?

Change the logging of the conda command to `logInfo` and log the command when the verbosity flag is on.

## How was this patch tested?

N/A.
