### PR TITLE
Use a null BlockManagerId instead of Option[BlockManagerId] in MapStatus

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -137,8 +137,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       if (!records.hasNext()) {
         partitionLengths = new long[numPartitions];
         Optional<BlockManagerId> location = mapOutputWriter.commitAllPartitions();
-        mapStatus = MapStatus$.MODULE$.apply(
-            Option.apply(location.orNull()), partitionLengths, attemptId);
+        mapStatus = MapStatus$.MODULE$.apply(location.orNull(), partitionLengths, attemptId);
         return;
       }
       final SerializerInstance serInstance = serializer.newInstance();
@@ -172,8 +171,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
 
       partitionLengths = writePartitionedData(mapOutputWriter);
       Optional<BlockManagerId> location = mapOutputWriter.commitAllPartitions();
-      mapStatus = MapStatus$.MODULE$.apply(
-          Option.apply(location.orNull()), partitionLengths, attemptId);
+      mapStatus = MapStatus$.MODULE$.apply(location.orNull(), partitionLengths, attemptId);
     } catch (Exception e) {
       try {
         mapOutputWriter.abort(e);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -243,7 +243,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       throw e;
     }
     mapStatus = MapStatus$.MODULE$.apply(
-        Option.apply(location.orNull()), partitionLengths, taskContext.attemptNumber());
+        location.orNull(), partitionLengths, taskContext.attemptNumber());
   }
 
   @VisibleForTesting

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -102,7 +102,7 @@ private class ShuffleStatus(numPartitions: Int) {
    * different block manager.
    */
   def removeMapOutput(mapId: Int, bmAddress: BlockManagerId): Unit = synchronized {
-    if (mapStatuses(mapId) != null && mapStatuses(mapId).location.orNull == bmAddress) {
+    if (mapStatuses(mapId) != null && mapStatuses(mapId).location == bmAddress) {
       _numAvailableOutputs -= 1
       mapStatuses(mapId) = null
       invalidateSerializedMapOutputStatusCache()
@@ -132,8 +132,8 @@ private class ShuffleStatus(numPartitions: Int) {
    */
   def removeOutputsByFilter(f: (BlockManagerId) => Boolean): Unit = synchronized {
     for (mapId <- 0 until mapStatuses.length) {
-      if (mapStatuses(mapId) != null && mapStatuses(mapId).location.isDefined
-        && f(mapStatuses(mapId).location.get)) {
+      if (mapStatuses(mapId) != null && mapStatuses(mapId).location != null
+        && f(mapStatuses(mapId).location)) {
         _numAvailableOutputs -= 1
         mapStatuses(mapId) = null
         invalidateSerializedMapOutputStatusCache()
@@ -609,11 +609,10 @@ private[spark] class MapOutputTrackerMaster(
             // with valid status entries. This is possible if one thread schedules a job which
             // depends on an RDD which is currently being computed by another thread.
             // This also ignores locations that are not on executors.
-            if (status != null && status.location.isDefined
-              && status.location.get.executorId != null) {
+            if (status != null && status.location != null && status.location.executorId != null) {
               val blockSize = status.getSizeForBlock(reducerId)
               if (blockSize > 0) {
-                locs(status.location.get) = locs.getOrElse(status.location.get, 0L) + blockSize
+                locs(status.location) = locs.getOrElse(status.location, 0L) + blockSize
                 totalOutputSize += blockSize
               }
             }
@@ -886,8 +885,13 @@ private[spark] object MapOutputTracker extends Logging {
         for (part <- startPartition until endPartition) {
           val size = status.getSizeForBlock(part)
           if (size != 0) {
-            splitsByAddress.getOrElseUpdate(status.location, ListBuffer()) +=
-              ((ShuffleBlockAttemptId(shuffleId, mapId, part, status.attemptId), size))
+            if (status.location != null) {
+              splitsByAddress.getOrElseUpdate(Option.apply(status.location), ListBuffer()) +=
+                ((ShuffleBlockAttemptId(shuffleId, mapId, part, status.attemptId), size))
+            } else {
+              splitsByAddress.getOrElseUpdate(Option.empty, ListBuffer()) +=
+                ((ShuffleBlockAttemptId(shuffleId, mapId, part, status.attemptId), size))
+            }
           }
         }
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1436,8 +1436,8 @@ private[spark] class DAGScheduler(
             val shuffleStage = stage.asInstanceOf[ShuffleMapStage]
             shuffleStage.pendingPartitions -= task.partitionId
             val status = event.result.asInstanceOf[MapStatus]
-            if (status.location.isDefined && status.location.get.executorId != null) {
-              val execId = status.location.get.executorId
+            if (status.location != null && status.location.executorId != null) {
+              val execId = status.location.executorId
               if (execId != null) {
                 logDebug("ShuffleMapTask finished on " + execId)
                 if (failedEpoch.contains(execId) && smt.epoch <= failedEpoch(execId)) {

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -34,7 +34,7 @@ import org.apache.spark.util.Utils
  */
 private[spark] sealed trait MapStatus {
   /** Location where this task was run. */
-  def location: Option[BlockManagerId]
+  def location: BlockManagerId
 
   def attemptId: Long
 
@@ -58,12 +58,12 @@ private[spark] object MapStatus {
     .map(_.conf.get(config.SHUFFLE_MIN_NUM_PARTS_TO_HIGHLY_COMPRESS))
     .getOrElse(config.SHUFFLE_MIN_NUM_PARTS_TO_HIGHLY_COMPRESS.defaultValue.get)
 
-  def apply(maybeLoc: Option[BlockManagerId], uncompressedSizes: Array[Long], attemptId: Long)
+  def apply(loc: BlockManagerId, uncompressedSizes: Array[Long], attemptId: Long)
     : MapStatus = {
     if (uncompressedSizes.length > minPartitionsToUseHighlyCompressMapStatus) {
-      HighlyCompressedMapStatus(maybeLoc, uncompressedSizes, attemptId)
+      HighlyCompressedMapStatus(loc, uncompressedSizes, attemptId)
     } else {
-      new CompressedMapStatus(maybeLoc, uncompressedSizes, attemptId)
+      new CompressedMapStatus(loc, uncompressedSizes, attemptId)
     }
   }
 
@@ -105,7 +105,7 @@ private[spark] object MapStatus {
  * @param compressedSizes size of the blocks, indexed by reduce partition id.
  */
 private[spark] class CompressedMapStatus(
-    private[this] var loc: Option[BlockManagerId],
+    private[this] var loc: BlockManagerId,
     private[this] var compressedSizes: Array[Byte],
     private[this] var attemptNum: Long)
   extends MapStatus with Externalizable {
@@ -113,20 +113,20 @@ private[spark] class CompressedMapStatus(
   // For deserialization only
   protected def this() = this(null, null.asInstanceOf[Array[Byte]], -1)
 
-  def this(loc: Option[BlockManagerId], uncompressedSizes: Array[Long], attemptNumber: Long) {
+  def this(loc: BlockManagerId, uncompressedSizes: Array[Long], attemptNumber: Long) {
     this(loc, uncompressedSizes.map(MapStatus.compressSize), attemptNumber)
   }
 
-  override def location: Option[BlockManagerId] = loc
+  override def location: BlockManagerId = loc
 
   override def getSizeForBlock(reduceId: Int): Long = {
     MapStatus.decompressSize(compressedSizes(reduceId))
   }
 
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
-    if (loc.isDefined) {
+    if (loc != null) {
       out.writeBoolean(true)
-      loc.get.writeExternal(out)
+      loc.writeExternal(out)
     } else {
       out.writeBoolean(false)
     }
@@ -137,9 +137,9 @@ private[spark] class CompressedMapStatus(
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
     if (in.readBoolean()) {
-      loc = Some(BlockManagerId(in))
+      loc = BlockManagerId(in)
     } else {
-      loc = None
+      loc = null
     }
     val len = in.readInt()
     compressedSizes = new Array[Byte](len)
@@ -162,7 +162,7 @@ private[spark] class CompressedMapStatus(
  * @param hugeBlockSizes sizes of huge blocks by their reduceId.
  */
 private[spark] class HighlyCompressedMapStatus private (
-    private[this] var loc: Option[BlockManagerId],
+    private[this] var loc: BlockManagerId,
     private[this] var numNonEmptyBlocks: Int,
     private[this] var emptyBlocks: RoaringBitmap,
     private[this] var avgSize: Long,
@@ -176,7 +176,7 @@ private[spark] class HighlyCompressedMapStatus private (
 
   protected def this() = this(null, -1, null, -1, null, -1)  // For deserialization only
 
-  override def location: Option[BlockManagerId] = loc
+  override def location: BlockManagerId = loc
 
   override def getSizeForBlock(reduceId: Int): Long = {
     assert(hugeBlockSizes != null)
@@ -191,9 +191,9 @@ private[spark] class HighlyCompressedMapStatus private (
   }
 
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
-    if (loc.isDefined) {
+    if (loc != null) {
       out.writeBoolean(true)
-      loc.get.writeExternal(out)
+      loc.writeExternal(out)
     } else {
       out.writeBoolean(false)
     }
@@ -209,9 +209,9 @@ private[spark] class HighlyCompressedMapStatus private (
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
     if (in.readBoolean()) {
-      loc = Some(BlockManagerId(in))
+      loc = BlockManagerId(in)
     } else {
-      loc = None
+      loc = null
     }
     emptyBlocks = new RoaringBitmap()
     emptyBlocks.readExternal(in)
@@ -231,7 +231,7 @@ private[spark] class HighlyCompressedMapStatus private (
 }
 
 private[spark] object HighlyCompressedMapStatus {
-  def apply(loc: Option[BlockManagerId], uncompressedSizes: Array[Long], attemptNumber: Long)
+  def apply(loc: BlockManagerId, uncompressedSizes: Array[Long], attemptNumber: Long)
     : HighlyCompressedMapStatus = {
     // We must keep track of which blocks are empty so that we don't report a zero-sized
     // block as being non-empty (or vice-versa) when using the average block size.

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -68,7 +68,7 @@ private[spark] class SortShuffleWriter[K, V, C](
       dep.shuffleId, mapId, dep.partitioner.numPartitions, context.taskAttemptId())
     val partitionLengths = sorter.writePartitionedMapOutput(dep.shuffleId, mapId, mapOutputWriter)
     val location = mapOutputWriter.commitAllPartitions
-    mapStatus = MapStatus(Option.apply(location.orNull), partitionLengths, context.taskAttemptId())
+    mapStatus = MapStatus(location.orNull, partitionLengths, context.taskAttemptId())
   }
 
   /** Close this writer, passing along whether the map completed */

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -63,9 +63,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(tracker.containsShuffle(10))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
         Array(1000L, 10000L), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
         Array(10000L, 1000L), 0))
     val statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.map(status => (status._1.get, status._2)).toSet ===
@@ -87,9 +87,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerShuffle(10, 2)
     val compressedSize1000 = MapStatus.compressSize(1000L)
     val compressedSize10000 = MapStatus.compressSize(10000L)
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
       Array(compressedSize1000, compressedSize10000), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(compressedSize10000, compressedSize1000), 0))
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0).nonEmpty)
@@ -110,9 +110,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerShuffle(10, 2)
     val compressedSize1000 = MapStatus.compressSize(1000L)
     val compressedSize10000 = MapStatus.compressSize(10000L)
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
         Array(compressedSize1000, compressedSize1000, compressedSize1000), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
         Array(compressedSize10000, compressedSize1000, compressedSize1000), 0))
 
     assert(0 == tracker.getNumCachedSerializedBroadcast)
@@ -149,7 +149,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
 
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     masterTracker.registerMapOutput(10, 0, MapStatus(
-      Some(BlockManagerId("a", "hostA", 1000)), Array(1000L), 0))
+      BlockManagerId("a", "hostA", 1000), Array(1000L), 0))
     slaveTracker.updateEpoch(masterTracker.getEpoch)
     assert(slaveTracker.getMapSizesByExecutorId(10, 0)
       .map(status => (status._1.get, status._2)).toSeq ===
@@ -188,7 +188,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // Message size should be ~123B, and no exception should be thrown
     masterTracker.registerShuffle(10, 1)
     masterTracker.registerMapOutput(10, 0, MapStatus(
-      Some(BlockManagerId("88", "mph", 1000)), Array.fill[Long](10)(0), 0))
+      BlockManagerId("88", "mph", 1000), Array.fill[Long](10)(0), 0))
     val senderAddress = RpcAddress("localhost", 12345)
     val rpcCallContext = mock(classOf[RpcCallContext])
     when(rpcCallContext.senderAddress).thenReturn(senderAddress)
@@ -221,11 +221,11 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // on hostA with output size 2
     // on hostB with output size 3
     tracker.registerShuffle(10, 3)
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
         Array(2L), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("a", "hostA", 1000),
         Array(2L), 0))
-    tracker.registerMapOutput(10, 2, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 2, MapStatus(BlockManagerId("b", "hostB", 1000),
         Array(3L), 0))
 
     // When the threshold is 50%, only host A should be returned as a preferred location
@@ -266,7 +266,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
       masterTracker.registerShuffle(20, 100)
       (0 until 100).foreach { i =>
         masterTracker.registerMapOutput(20, i, new CompressedMapStatus(
-          Some(BlockManagerId("999", "mps", 1000)), Array.fill[Long](4000000)(0), 0))
+          BlockManagerId("999", "mps", 1000), Array.fill[Long](4000000)(0), 0))
       }
       val senderAddress = RpcAddress("localhost", 12345)
       val rpcCallContext = mock(classOf[RpcCallContext])
@@ -314,9 +314,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val size0 = MapStatus.decompressSize(MapStatus.compressSize(0L))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
       Array(size0, size1000, size0, size10000), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(size10000, size0, size1000, size0), 0))
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0, 4).toSeq ===
@@ -344,10 +344,10 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(tracker.containsShuffle(10))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("a", "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
       Array(1000L, 10000L), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(None, Array(10000L, 1000L), 0))
-    tracker.registerMapOutput(10, 2, MapStatus(None, Array(1000L, 10000L), 0))
+    tracker.registerMapOutput(10, 1, MapStatus(null, Array(10000L, 1000L), 0))
+    tracker.registerMapOutput(10, 2, MapStatus(null, Array(1000L, 10000L), 0))
     var statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
       Seq(
@@ -360,7 +360,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.removeOutputsOnHost("hostA")
 
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(1000L, 10000L), 0))
     statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
@@ -373,7 +373,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
         .toSet)
     tracker.unregisterMapOutput(10, 1, null)
 
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(1000L, 10000L), 0))
     statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
@@ -400,9 +400,9 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(tracker.containsShuffle(10))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId(null, "hostA", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId(null, "hostA", 1000),
       Array(1000L, 10000L), 0))
-    tracker.registerMapOutput(10, 1, MapStatus(Some(BlockManagerId(null, "hostB", 1000)),
+    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId(null, "hostB", 1000),
       Array(10000L, 1000L), 0))
     var statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
@@ -425,7 +425,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
         .toSet)
     tracker.unregisterMapOutput(10, 1, BlockManagerId(null, "hostA", 1000))
 
-    tracker.registerMapOutput(10, 0, MapStatus(Some(BlockManagerId("b", "hostB", 1000)),
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(1000L, 10000L), 0))
     statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerShufflePluginSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerShufflePluginSuite.scala
@@ -155,11 +155,11 @@ class DAGSchedulerShufflePluginSuite extends DAGSchedulerSuite {
   }
 
   def makeMapStatus(execId: String, host: String): MapStatus = {
-    MapStatus(Some(BlockManagerId(execId, host, 1234)), Array.fill[Long](2)(2), 0)
+    MapStatus(BlockManagerId(execId, host, 1234), Array.fill[Long](2)(2), 0)
   }
 
   def makeEmptyMapStatus(): MapStatus = {
-    MapStatus(None, Array.fill[Long](2)(2), 0)
+    MapStatus(null, Array.fill[Long](2)(2), 0)
   }
 
   def assertMapShuffleLocations(shuffleId: Int, set: Seq[MapStatus]): Unit = {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -445,30 +445,30 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // map stage1 completes successfully, with one task on each executor
     complete(taskSets(0), Seq(
       (Success,
-        MapStatus(Some(BlockManagerId("exec-hostA1", "hostA", 12345)), Array.fill[Long](1)(2), 0)),
+        MapStatus(BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), 0)),
       (Success,
-        MapStatus(Some(BlockManagerId("exec-hostA2", "hostA", 12345)), Array.fill[Long](1)(2), 0)),
+        MapStatus(BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), 0)),
       (Success, makeMapStatus("hostB", 1))
     ))
     // map stage2 completes successfully, with one task on each executor
     complete(taskSets(1), Seq(
       (Success,
-        MapStatus(Some(BlockManagerId("exec-hostA1", "hostA", 12345)), Array.fill[Long](1)(2), 0)),
+        MapStatus(BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), 0)),
       (Success,
-        MapStatus(Some(BlockManagerId("exec-hostA2", "hostA", 12345)), Array.fill[Long](1)(2), 0)),
+        MapStatus(BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), 0)),
       (Success, makeMapStatus("hostB", 1))
     ))
     // make sure our test setup is correct
     val initialMapStatus1 = mapOutputTracker.shuffleStatuses(firstShuffleId).mapStatuses
     //  val initialMapStatus1 = mapOutputTracker.mapStatuses.get(0).get
     assert(initialMapStatus1.count(_ != null) === 3)
-    assert(initialMapStatus1.map{_.location.get.executorId}.toSet ===
+    assert(initialMapStatus1.map{_.location.executorId}.toSet ===
       Set("exec-hostA1", "exec-hostA2", "exec-hostB"))
 
     val initialMapStatus2 = mapOutputTracker.shuffleStatuses(secondShuffleId).mapStatuses
     //  val initialMapStatus1 = mapOutputTracker.mapStatuses.get(0).get
     assert(initialMapStatus2.count(_ != null) === 3)
-    assert(initialMapStatus2.map{_.location.get.executorId}.toSet ===
+    assert(initialMapStatus2.map{_.location.executorId}.toSet ===
       Set("exec-hostA1", "exec-hostA2", "exec-hostB"))
 
     // reduce stage fails with a fetch failure from one host
@@ -482,13 +482,13 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     val mapStatus1 = mapOutputTracker.shuffleStatuses(firstShuffleId).mapStatuses
     assert(mapStatus1.count(_ != null) === 1)
-    assert(mapStatus1(2).location.get.executorId === "exec-hostB")
-    assert(mapStatus1(2).location.get.host === "hostB")
+    assert(mapStatus1(2).location.executorId === "exec-hostB")
+    assert(mapStatus1(2).location.host === "hostB")
 
     val mapStatus2 = mapOutputTracker.shuffleStatuses(secondShuffleId).mapStatuses
     assert(mapStatus2.count(_ != null) === 1)
-    assert(mapStatus2(2).location.get.executorId === "exec-hostB")
-    assert(mapStatus2(2).location.get.host === "hostB")
+    assert(mapStatus2(2).location.executorId === "exec-hostB")
+    assert(mapStatus2(2).location.host === "hostB")
   }
 
   test("zero split job") {
@@ -2904,7 +2904,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
 object DAGSchedulerSuite {
   def makeMapStatus(host: String, reduces: Int, sizes: Byte = 2): MapStatus =
-    MapStatus(Some(makeBlockManagerId(host)), Array.fill[Long](reduces)(sizes), 0)
+    MapStatus(makeBlockManagerId(host), Array.fill[Long](reduces)(sizes), 0)
 
   def makeBlockManagerId(host: String): BlockManagerId =
     BlockManagerId("exec-" + host, host, 12345)

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -61,7 +61,7 @@ class MapStatusSuite extends SparkFunSuite {
       stddev <- Seq(0.0, 0.01, 0.5, 1.0)
     ) {
       val sizes = Array.fill[Long](numSizes)(abs(round(Random.nextGaussian() * stddev)) + mean)
-      val status = MapStatus(Some(BlockManagerId("a", "b", 10)), sizes, 0)
+      val status = MapStatus(BlockManagerId("a", "b", 10), sizes, 0)
       val status1 = compressAndDecompressMapStatus(status)
       for (i <- 0 until numSizes) {
         if (sizes(i) != 0) {
@@ -87,10 +87,10 @@ class MapStatusSuite extends SparkFunSuite {
     val sizes = Array.tabulate[Long](3000) { i => i.toLong }
     val avg = sizes.sum / sizes.count(_ != 0)
     val loc = BlockManagerId("a", "b", 10)
-    val status = MapStatus(Some(loc), sizes, 0)
+    val status = MapStatus(loc, sizes, 0)
     val status1 = compressAndDecompressMapStatus(status)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
-    assert(status1.location.get == loc)
+    assert(status1.location == loc)
     for (i <- 0 until 3000) {
       val estimate = status1.getSizeForBlock(i)
       if (sizes(i) > 0) {
@@ -109,10 +109,10 @@ class MapStatusSuite extends SparkFunSuite {
     val smallBlockSizes = sizes.filter(n => n > 0 && n < threshold)
     val avg = smallBlockSizes.sum / smallBlockSizes.length
     val loc = BlockManagerId("a", "b", 10)
-    val status = MapStatus(Some(loc), sizes, 0)
+    val status = MapStatus(loc, sizes, 0)
     val status1 = compressAndDecompressMapStatus(status)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
-    assert(status1.location.get == loc)
+    assert(status1.location == loc)
     for (i <- 0 until threshold) {
       val estimate = status1.getSizeForBlock(i)
       if (sizes(i) > 0) {
@@ -165,7 +165,7 @@ class MapStatusSuite extends SparkFunSuite {
     SparkEnv.set(env)
     // Value of element in sizes is equal to the corresponding index.
     val sizes = (0L to 2000L).toArray
-    val status1 = MapStatus(Some(BlockManagerId("exec-0", "host-0", 100)), sizes, 0)
+    val status1 = MapStatus(BlockManagerId("exec-0", "host-0", 100), sizes, 0)
     val arrayStream = new ByteArrayOutputStream(102400)
     val objectOutputStream = new ObjectOutputStream(arrayStream)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
@@ -192,9 +192,9 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("Location can be empty") {
     val sizes = (0L to 3000L).toArray
-    val status = MapStatus(None, sizes, 0)
+    val status = MapStatus(null, sizes, 0)
     val status1 = compressAndDecompressMapStatus(status)
     assert(status1.isInstanceOf[HighlyCompressedMapStatus])
-    assert(status1.location.isEmpty)
+    assert(status1.location == null)
   }
 }

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -352,7 +352,7 @@ class KryoSerializerSuite extends SparkFunSuite with SharedSparkContext {
     val sparseBlockSizes = Array[Long](0L, 1L, 0L, 2L)
     Seq(denseBlockSizes, sparseBlockSizes).foreach { blockSizes =>
       ser.serialize(HighlyCompressedMapStatus(
-        Some(BlockManagerId("exec-1", "host", 1234)), blockSizes, 0))
+        BlockManagerId("exec-1", "host", 1234), blockSizes, 0))
     }
   }
 


### PR DESCRIPTION
Using Option[BlockManagerId] clarifies that it's nullable, but it's an API break in MapStatus. We can get around this by just making BlockManagerId null when there isn't a location associated with the shuffle file.