### PR TITLE
default implementation shouldn't wrap streams

### DIFF
--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleReadSupport.java
@@ -37,6 +37,6 @@ public interface ShuffleReadSupport {
       throws IOException;
 
   default boolean shouldWrapStream() {
-    return true;
+    return false;
   }
 }


### PR DESCRIPTION
Because it's already done by the `BlockFetcherIterator`... oops :/ 
