### PR TITLE
[SPARK-28776] SparkML Writer gets hadoop conf from session state

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/ReadWrite.scala
@@ -164,7 +164,7 @@ abstract class MLWriter extends BaseReadWrite with Logging {
   @Since("1.6.0")
   @throws[IOException]("If the input path already exists but overwrite is not enabled.")
   def save(path: String): Unit = {
-    new FileSystemOverwrite().handleOverwrite(path, shouldOverwrite, sc)
+    new FileSystemOverwrite().handleOverwrite(path, shouldOverwrite, sparkSession)
     saveImpl(path)
   }
 
@@ -673,8 +673,8 @@ private[ml] object MetaAlgorithmReadWrite {
 
 private[ml] class FileSystemOverwrite extends Logging {
 
-  def handleOverwrite(path: String, shouldOverwrite: Boolean, sc: SparkContext): Unit = {
-    val hadoopConf = sc.hadoopConfiguration
+  def handleOverwrite(path: String, shouldOverwrite: Boolean, session: SparkSession): Unit = {
+    val hadoopConf = session.sessionState.newHadoopConf()
     val outputPath = new Path(path)
     val fs = outputPath.getFileSystem(hadoopConf)
     val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -127,7 +127,7 @@ class MLWriter(BaseReadWrite):
 
         _java_obj = JavaWrapper._new_java_obj("org.apache.spark.ml.util.FileSystemOverwrite")
         wrapper = JavaWrapper(_java_obj)
-        wrapper._call_java("handleOverwrite", path, True, self.sc._jsc.sc())
+        wrapper._call_java("handleOverwrite", path, True, self.sparkSession._jsparkSession)
 
     def save(self, path):
         """Save the ML instance to the input path."""


### PR DESCRIPTION
## Upstream SPARK-28776 ticket and PR link (if not applicable, explain)
https://github.com/apache/spark/pull/25505
## What changes were proposed in this pull request?
SparkML writer gets hadoop conf from session state, instead of the spark context.

## How was this patch tested?
Tested in pyspark.ml.tests.test_persistence.PersistenceTest test_default_read_write

Please review http://spark.apache.org/contributing.html before opening a pull request.
