### PR TITLE
bump fabric8

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -88,7 +88,7 @@ hk2-api-2.5.0-b32.jar
 hk2-locator-2.5.0-b32.jar
 hk2-utils-2.5.0-b32.jar
 hppc-0.7.2.jar
-htrace-core4-4.1.0-incubating.jar
+htrace-core4-4.4.2-incubating.jar
 httpclient-4.5.6.jar
 httpcore-4.4.10.jar
 ivy-2.4.0.jar
@@ -144,8 +144,8 @@ jtransforms-2.4.0.jar
 jul-to-slf4j-1.7.25.jar
 kafka-clients-2.1.0.jar
 kryo-shaded-4.0.2.jar
-kubernetes-client-4.1.0.jar
-kubernetes-model-4.1.0.jar
+kubernetes-client-4.4.2.jar
+kubernetes-model-4.4.2.jar
 leveldbjni-all-1.8.jar
 log4j-1.2.17.jar
 logging-interceptor-3.11.0.jar

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -63,7 +63,7 @@ logs and remains in "completed" state in the Kubernetes API until it's eventuall
 Note that in the completed state, the driver pod does *not* use any computational or memory resources.
 
 The driver and executor pod scheduling is handled by Kubernetes. Communication to the Kubernetes API is done via fabric8, and we are
-currently running <code>kubernetes-client</code> version <code>4.1.0</code>. Make sure that when you are making infrastructure additions that you are aware of said version. It is possible to schedule the
+currently running <code>kubernetes-client</code> version <code>4.4.2</code>. Make sure that when you are making infrastructure additions that you are aware of said version. It is possible to schedule the
 driver and executor pods on a subset of available nodes through a [node selector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
 using the configuration property for it. It will be possible to use more advanced
 scheduling hints like [node/pod affinities](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) in a future release.

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>4.1.0</kubernetes.client.version>
+    <kubernetes.client.version>4.4.2</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
     <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
     <extraScalaTestArgs></extraScalaTestArgs>
-    <kubernetes-client.version>4.1.0</kubernetes-client.version>
+    <kubernetes-client.version>4.4.2</kubernetes-client.version>
     <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
     <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
     <sbt.project.name>kubernetes-integration-tests</sbt.project.name>


### PR DESCRIPTION
We need this:
https://github.com/fabric8io/kubernetes-client/issues/1667

Otherwise, new versions of k8s will reject the origin header, which is malformed.

cc @ashrayjain @mccheah @robert3005 