### PR TITLE
[SPARK-28921][BUILD][K8S] Upgrade kubernetes client to 4.4.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -468,6 +468,7 @@ Common Development and Distribution License (CDDL) 1.1
 ------------------------------------------------------
 
 javax.annotation:javax.annotation-api    https://jcp.org/en/jsr/detail?id=250
+javax.el:javax.el-api	https://javaee.github.io/uel-ri/
 javax.servlet:javax.servlet-api   https://javaee.github.io/servlet-spec/
 javax.transaction:jta http://www.oracle.com/technetwork/java/index.html
 javax.ws.rs:javax.ws.rs-api https://github.com/jax-rs

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -57,7 +57,7 @@ dropwizard-util-1.0.0.jar
 dropwizard-validation-1.0.0.jar
 ehcache-3.3.1.jar
 flatbuffers-java-1.9.0.jar
-generex-1.0.1.jar
+generex-1.0.2.jar
 geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson-2.2.4.jar
 guava-14.0.1.jar
@@ -112,7 +112,7 @@ jackson-xc-1.9.13.jar
 janino-3.0.11.jar
 javassist-3.20.0-GA.jar
 javax.annotation-api-1.2.jar
-javax.el-3.0.0.jar
+javax.el-3.0.1-b11.jar
 javax.inject-1.jar
 javax.inject-2.5.0-b32.jar
 javax.servlet-api-3.1.0.jar
@@ -144,8 +144,9 @@ jtransforms-2.4.0.jar
 jul-to-slf4j-1.7.25.jar
 kafka-clients-2.1.0.jar
 kryo-shaded-4.0.2.jar
-kubernetes-client-4.1.0.jar
-kubernetes-model-4.1.0.jar
+kubernetes-client-4.4.2.jar
+kubernetes-model-4.4.2.jar
+kubernetes-model-common-4.4.2.jar
 leveldbjni-all-1.8.jar
 log4j-1.2.17.jar
 logging-interceptor-3.11.0.jar

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>4.1.0</kubernetes.client.version>
+    <kubernetes.client.version>4.4.2</kubernetes.client.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Upstream SPARK-28921 ticket and PR link (if not applicable, explain)

Upgrade kubernetes client from 4.1.2 to 4.4.2

To fix compatibility issue with EKS since Amazon rolled out some security patches over the past week; 1.15.3, 1.14.6, 1.13.10, 1.12.10, and 1.11.10.

No

Pass the Jenkins and manually test on EKS.

Closes #25640 from andygrove/SPARK-28921.

Authored-by: Andy Grove <andygrove73@gmail.com>
Signed-off-by: Dongjoon Hyun <dhyun@apple.com>
