### PR TITLE
Make removing map output by exec id configurable

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -22,6 +22,12 @@ import java.util.Map;
 
 public interface ShuffleDriverComponents {
 
+  enum MapOutputUnregistrationStrategy {
+    MAP_OUTPUT_ONLY,
+    EXECUTOR,
+    HOST,
+  }
+
   /**
    * @return additional SparkConf values necessary for the executors.
    */
@@ -33,11 +39,7 @@ public interface ShuffleDriverComponents {
 
   default void removeShuffle(int shuffleId, boolean blocking) throws IOException {}
 
-  default boolean shouldUnregisterOutputOnHostOnFetchFailure() {
-    return false;
-  }
-
-  default boolean shouldUnregisterOutputOnExecutorOnFetchFailure() {
-    return false;
+  default MapOutputUnregistrationStrategy unregistrationStrategyOnFetchFailure() {
+    return MapOutputUnregistrationStrategy.EXECUTOR;
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -36,4 +36,8 @@ public interface ShuffleDriverComponents {
   default boolean shouldUnregisterOutputOnHostOnFetchFailure() {
     return false;
   }
+
+  default boolean shouldUnregisterOutputOnExecutorOnFetchFailure() {
+    return false;
+  }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/lifecycle/LocalDiskShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/lifecycle/LocalDiskShuffleDriverComponents.java
@@ -48,13 +48,11 @@ public class LocalDiskShuffleDriverComponents implements ShuffleDriverComponents
   }
 
   @Override
-  public boolean shouldUnregisterOutputOnHostOnFetchFailure() {
-    return shouldUnregisterOutputOnHostOnFetchFailure;
-  }
-
-  @Override
-  public boolean shouldUnregisterOutputOnExecutorOnFetchFailure() {
-    return true;
+  public MapOutputUnregistrationStrategy unregistrationStrategyOnFetchFailure() {
+    if (shouldUnregisterOutputOnHostOnFetchFailure) {
+      return MapOutputUnregistrationStrategy.HOST;
+    }
+    return MapOutputUnregistrationStrategy.EXECUTOR;
   }
 
   private void checkInitialized() {

--- a/core/src/main/java/org/apache/spark/shuffle/sort/lifecycle/LocalDiskShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/lifecycle/LocalDiskShuffleDriverComponents.java
@@ -52,6 +52,11 @@ public class LocalDiskShuffleDriverComponents implements ShuffleDriverComponents
     return shouldUnregisterOutputOnHostOnFetchFailure;
   }
 
+  @Override
+  public boolean shouldUnregisterOutputOnExecutorOnFetchFailure() {
+    return true;
+  }
+
   private void checkInitialized() {
     if (blockManagerMaster == null) {
       throw new IllegalStateException("Driver components must be initialized before using");

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -30,6 +30,7 @@ import scala.concurrent.duration._
 import scala.language.existentials
 import scala.language.postfixOps
 import scala.util.control.NonFatal
+
 import org.apache.commons.lang3.SerializationUtils
 
 import org.apache.spark._

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -30,7 +30,6 @@ import scala.concurrent.duration._
 import scala.language.existentials
 import scala.language.postfixOps
 import scala.util.control.NonFatal
-
 import org.apache.commons.lang3.SerializationUtils
 
 import org.apache.spark._
@@ -43,6 +42,7 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator, PartialResult}
 import org.apache.spark.rdd.{DeterministicLevel, RDD, RDDCheckpointData}
 import org.apache.spark.rpc.RpcTimeout
+import org.apache.spark.shuffle.api.ShuffleDriverComponents.MapOutputUnregistrationStrategy
 import org.apache.spark.storage._
 import org.apache.spark.storage.BlockManagerMessages.BlockManagerHeartbeat
 import org.apache.spark.util._
@@ -1672,7 +1672,8 @@ private[spark] class DAGScheduler(
           // TODO: mark the executor as failed only if there were lots of fetch failures on it
           if (bmAddress != null) {
             if (bmAddress.executorId == null) {
-              if (shuffleDriverComponents.shouldUnregisterOutputOnHostOnFetchFailure()) {
+              if (shuffleDriverComponents.unregistrationStrategyOnFetchFailure() ==
+                  MapOutputUnregistrationStrategy.HOST) {
                 val currentEpoch = task.epoch
                 val host = bmAddress.host
                 logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
@@ -1681,7 +1682,8 @@ private[spark] class DAGScheduler(
               }
             } else {
               val hostToUnregisterOutputs =
-                if (shuffleDriverComponents.shouldUnregisterOutputOnHostOnFetchFailure()) {
+                if (shuffleDriverComponents.unregistrationStrategyOnFetchFailure() ==
+                    MapOutputUnregistrationStrategy.HOST) {
                   // We had a fetch failure with the external shuffle service, so we
                   // assume all shuffle data on the node is bad.
                   Some(bmAddress.host)
@@ -1863,7 +1865,8 @@ private[spark] class DAGScheduler(
             logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
             mapOutputTracker.removeOutputsOnHost(host)
           case None =>
-            if (shuffleDriverComponents.shouldUnregisterOutputOnExecutorOnFetchFailure()) {
+            if (shuffleDriverComponents.unregistrationStrategyOnFetchFailure() ==
+                MapOutputUnregistrationStrategy.EXECUTOR) {
               logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
               mapOutputTracker.removeOutputsOnExecutor(execId)
             }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1863,8 +1863,10 @@ private[spark] class DAGScheduler(
             logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
             mapOutputTracker.removeOutputsOnHost(host)
           case None =>
-            logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
-            mapOutputTracker.removeOutputsOnExecutor(execId)
+            if (shuffleDriverComponents.shouldUnregisterOutputOnExecutorOnFetchFailure()) {
+              logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
+              mapOutputTracker.removeOutputsOnExecutor(execId)
+            }
         }
         clearCacheLocs()
 


### PR DESCRIPTION
This is necessary for removing map outputs for the async case so certain mappers are still retried in the next stage retry.