### PR TITLE
use available cores in k8s cluster local mode

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -98,7 +98,7 @@ case "$1" in
     shift 1
     CMD=(
       "$SPARK_HOME/bin/spark-submit"
-      --master local
+      --master 'local[*]'
       --deploy-mode client
       "$@"
     )


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
k8s cluster local mode is currently only on our fork

## What changes were proposed in this pull request?
use all available cores from `Runtime.getRuntime.availableCores` in local k8s submission. This will make the cluster local submission to k8s behave the same as k8s cluster submission.

Background:
Currently even when k8s cpu limits are set, java 8 spark applications will fail to derive the correct number of limits (https://bugs.openjdk.java.net/browse/JDK-6515172).
On k8s cluster submission, spark driver cpu overrides will only change the cpu requests, and optionally there is a spark override to set cpu limits, but these will only take effect when running with java 9+
When running with java 9+, with this PR, cpu limits set in k8s will make `availableCores` return the limit, and the local backend will use the correct number of threads.


