### PR TITLE
Don't restore the build binaries cache for style tests (temporarily)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,8 @@ jobs:
       # Failed to execute goal on project spark-assembly_2.11: Could not resolve dependencies for project org.apache.spark:spark-assembly_2.11:pom:2.4.0-SNAPSHOT
       - restore_cache:
           key: maven-dependency-cache-{{ checksum "pom.xml" }}
-      - *restore-build-binaries-cache
+# Restoring any build binaries for this particular sub-step appears to create problems... for now, force all computation to occur from scratch.
+# - *restore-build-binaries-cache
       - run:
           name: Run style tests
           command: dev/run-style-tests.py


### PR DESCRIPTION
For addressing builds like e.g. https://circleci.com/gh/palantir/spark/17583