### PR TITLE
Force xz to v1.8

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -207,7 +207,7 @@ wildfly-openssl-1.0.7.Final.jar
 woodstox-core-5.0.3.jar
 xbean-asm7-shaded-4.12.jar
 xmlenc-0.52.jar
-xz-1.5.jar
+xz-1.8.jar
 zjsonpatch-0.3.0.jar
 zookeeper-3.4.7.jar
 zstd-jni-1.3.5-3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
     <antlr.version>3.4</antlr.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>2.52.0</selenium.version>
+    <xz.version>1.8</xz.version>
     <!--
     Managed up from older version from Avro; sync with jackson-module-paranamer dependency version
     -->
@@ -523,6 +524,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commons-compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.tukaani</groupId>
+        <artifactId>xz</artifactId>
+        <version>${xz.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
Force `xz` to v1.8 to match `commons-compress`'s dependency on that version