### PR TITLE
Refresh some circle caches temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ deployable-branches-and-tags: &deployable-branches-and-tags
 
 step_templates:
   restore-build-binaries-cache: &restore-build-binaries-cache
-    restore_cache:
-      key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
+    #restore_cache:
+      #key: build-binaries-{{ checksum "build/mvn" }}-{{ checksum "build/sbt" }}
   restore-ivy-cache: &restore-ivy-cache
     restore_cache:
       keys:


### PR DESCRIPTION
Think there's some weirdness going on with the Maven binaries right now:

```
[error] org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for org.apache.spark:spark-parent_2.11:3.0.0-SNAPSHOT
[error] [FATAL] Non-resolvable parent POM: Could not transfer artifact org.apache:apache:pom:18 from/to central ( http://repo.maven.apache.org/maven2): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom from  http://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom and 'parent.relativePath' points at wrong local POM @ line 22, column 11
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? [error] running /home/circleci/project/build/sbt -Phadoop-palantir -Pkubernetes -Phadoop-cloud -Pkinesis-asl -Pyarn -Pspark-ganglia-lgpl -Pmesos test:externalDependencyClasspath oldDeps/test:externalDependencyClasspath ; received return code 1

Exited with code exit status 255
```

Going to try to refresh the Circle caches to get past this. This commit will be reverted when the builds are green again.