### PR TITLE
Not print conda environment  when executing conda process

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -235,9 +235,9 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       extraEnv: _*
     )
 
-    logInfo(s"About to execute $command with environment $extraEnv")
+    logInfo(s"About to execute $command")
     runOrFail(command, description)
-    logInfo(s"Successfully executed $command with environment $extraEnv")
+    logInfo(s"Successfully executed $command")
   }
 
   /**


### PR DESCRIPTION
Not print conda environment as spark doesn't have arg logging and the env can therefore contain unsafe information.