### PR TITLE
[SPARK-25299] Add an implementation of the SPARK-25299 shuffle storage plugin that asynchronously backs up shuffle data to remote storage

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -19,11 +19,13 @@
     * yarn: YarnClusterSchedulerBackend, YarnSchedulerBackend
 
 * [SPARK-26626](https://issues.apache.org/jira/browse/SPARK-26626) - Limited the maximum size of repeatedly substituted aliases
+* [SPARK-25299](https://issues.apache.org/jira/browse/SPARK-25299) - Adds the complete plugin tree for shuffle byte storage
 
 # Added
 
 * Gradle plugin to easily create custom docker images for use with k8s
 * Filter rLibDir by exists so that daemon.R references the correct file [460](https://github.com/palantir/spark/pull/460)
+* Implementation of the shuffle I/O plugins from SPARK-25299 that asynchronously backs up shuffle files to remote storage
 
 # Reverted
 * [SPARK-25908](https://issues.apache.org/jira/browse/SPARK-25908) - Removal of `monotonicall_increasing_id`, `toDegree`, `toRadians`, `approxCountDistinct`, `unionAll`

--- a/async-shuffle-upload/async-shuffle-upload-api/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-api/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.11</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-async-shuffle-upload-api_2.11</artifactId>
+  <properties>
+    <sbt.project.name>async-shuffle-upload-api</sbt.project.name>
+  </properties>
+  <packaging>jar</packaging>
+  <name>Spark Project Async Shuffle Upload API</name>
+  <url>http://spark.apache.org/</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>builder</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.palantir.safe-logging</groupId>
+      <artifactId>safe-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.palantir.safe-logging</groupId>
+      <artifactId>preconditions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+    </dependency>
+    <!--
+      This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
+      them will yield errors.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <!-- Disable Scala compilation for modules that don't have Scala. This is because they possibly break our usage of Immutables(?) -->
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <id>eclipse-add-source</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>scala-test-compile-first</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>attach-scaladocs</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <skipMain>false</skipMain> <!-- skip compile -->
+          <skip>false</skip> <!-- skip testCompile -->
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+    

--- a/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.api;
+
+public final class SparkShuffleApiConstants {
+
+  // Identifiers used by the spark shuffle plugin
+  public static final String SHUFFLE_BASE_URI_CONF = "spark.shuffle.hadoop.async.base-uri";
+
+  public static final String SHUFFLE_PLUGIN_APP_NAME_CONF = "spark.shuffle.hadoop.async.appName";
+  public static final String SHUFFLE_PLUGIN_APP_NAME_CONF_DEPRECATED =
+      "spark.plugin.shuffle.async.appName";
+
+  public static final String SHUFFLE_S3A_CREDS_FILE_CONF =
+      "spark.shuffle.hadoop.async.s3a.credsFile";
+  public static final String SHUFFLE_S3A_CREDS_FILE_CONF_DEPRECATED =
+      "spark.plugin.shuffle.async.s3a.credsFile";
+
+  public static final String SHUFFLE_S3A_ENDPOINT_CONF =
+      "spark.shuffle.hadoop.async.s3a.endpoint";
+
+  public static final String METRICS_FACTORY_CLASS_CONF =
+      "spark.shuffle.hadoop.async.metrics.factory.class";
+  public static final String METRICS_FACTORY_CLASS_CONF_DEPRECATED =
+      "spark.plugin.shuffle.async.metricsFactoryClass";
+
+  private SparkShuffleApiConstants() {}
+
+}

--- a/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
@@ -23,6 +23,8 @@ public final class SparkShuffleApiConstants {
   public static final String SHUFFLE_BASE_URI_CONF = "spark.shuffle.hadoop.async.base-uri";
 
   public static final String SHUFFLE_PLUGIN_APP_NAME_CONF = "spark.shuffle.hadoop.async.appName";
+  // Deprecated configurations are picked up as fallbacks when their newer counterparts are not
+  // specified.
   public static final String SHUFFLE_PLUGIN_APP_NAME_CONF_DEPRECATED =
       "spark.plugin.shuffle.async.appName";
 

--- a/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentials.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentials.java
@@ -31,6 +31,13 @@ import org.immutables.value.Value;
 
 import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
 
+/**
+ * Structure for holding AWS credentials for accessing Amazon S3.
+ * <p>
+ * Allowing using a file to store AWS credentials when S3a is used as the backing store for
+ * shuffle files. The path to a file holding the credentials is specified via
+ * {@link SparkShuffleApiConstants#SHUFFLE_S3A_CREDS_FILE_CONF}.
+ */
 @ImmutablesStyle
 @Value.Immutable
 @JsonSerialize(as = ImmutableSparkShuffleAwsCredentials.class)

--- a/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentials.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentials.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.api;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import org.immutables.value.Value;
+
+import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
+
+@ImmutablesStyle
+@Value.Immutable
+@JsonSerialize(as = ImmutableSparkShuffleAwsCredentials.class)
+@JsonDeserialize(as = ImmutableSparkShuffleAwsCredentials.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class SparkShuffleAwsCredentials {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public abstract String accessKeyId();
+
+  public abstract String secretAccessKey();
+
+  public abstract String sessionToken();
+
+  public final byte[] toBytes() {
+    try {
+      return MAPPER.writeValueAsString(this).getBytes(StandardCharsets.UTF_8);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static SparkShuffleAwsCredentials fromBytes(byte[] bytes) {
+    try {
+      return MAPPER.readValue(
+          new String(bytes, StandardCharsets.UTF_8), SparkShuffleAwsCredentials.class);
+    } catch (IOException e) {
+      throw new SafeIllegalArgumentException(
+          "Could not deserialize bytes as AWS credentials.",
+          UnsafeArg.of("cause", e));
+    }
+  }
+
+  public static ImmutableSparkShuffleAwsCredentials.Builder builder() {
+    return ImmutableSparkShuffleAwsCredentials.builder();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-api/src/test/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentialsSuite.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/test/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleAwsCredentialsSuite.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.api;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SparkShuffleAwsCredentialsSuite {
+
+  @Test
+  public void testSerialize() {
+    SparkShuffleAwsCredentials creds = SparkShuffleAwsCredentials.builder()
+        .accessKeyId("access-key")
+        .secretAccessKey("secret-key")
+        .sessionToken("session-token")
+        .build();
+    byte[] bytes = creds.toBytes();
+    assertThat(new String(bytes, StandardCharsets.UTF_8))
+        .isEqualTo("{\"accessKeyId\":\"access-key\","
+            + "\"secretAccessKey\":\"secret-key\","
+            + "\"sessionToken\":\"session-token\"}");
+  }
+
+  @Test
+  public void testDeserialize() {
+    String serializedString = "{\"accessKeyId\":\"access-key\","
+        + "\"secretAccessKey\":\"secret-key\","
+        + "\"sessionToken\":\"session-token\"}";
+
+    SparkShuffleAwsCredentials creds =
+        SparkShuffleAwsCredentials.fromBytes(serializedString.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-core/pom.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.11</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-async-shuffle-upload-core_2.11</artifactId>
+  <properties>
+    <sbt.project.name>async-shuffle-upload-core</sbt.project.name>
+  </properties>
+  <packaging>jar</packaging>
+  <name>Spark Project Async Shuffle Upload Core</name>
+  <url>http://spark.apache.org/</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>builder</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-api_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-scala-test-utils_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-scala_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.palantir.safe-logging</groupId>
+      <artifactId>safe-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.palantir.safe-logging</groupId>
+      <artifactId>preconditions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-java8-compat_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+    </dependency>
+    <!--
+      This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
+      them will yield errors.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <!-- When using SPARK_PREPEND_CLASSES Spark classes compiled locally don't use
+               shaded deps. So here we store jars in their original form which are added
+               when the classpath is computed. -->
+          <!-- See similar execution in mllib/pom.xml -->
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+           <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <useSubDirectoryPerType>true</useSubDirectoryPerType>
+              <includeArtifactIds>
+                guava,jetty-io,jetty-servlet,jetty-servlets,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
+              </includeArtifactIds>
+              <silent>true</silent>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Disable Scala compilation for modules that don't have Scala. This is because they possibly break our usage of Immutables(?) -->
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <id>eclipse-add-source</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>scala-test-compile-first</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>attach-scaladocs</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <skipMain>false</skipMain> <!-- skip compile -->
+          <skip>false</skip> <!-- skip testCompile -->
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+    

--- a/async-shuffle-upload/async-shuffle-upload-core/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-core/pom.xml
@@ -209,6 +209,13 @@
           <skip>false</skip> <!-- skip testCompile -->
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.deploy.SparkHadoopUtil$;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.JavaSparkConf;
+import org.apache.spark.palantir.shuffle.async.api.SparkShuffleAwsCredentials;
+import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
+import org.apache.spark.palantir.shuffle.async.s3a.ConscryptS3ClientFactory;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.compat.java8.OptionConverters;
+
+/**
+ * Extractors for configuration specified via the SparkConf.
+ * <p>
+ * Hides the need to call <code>sparkConf.get(spark.reallyLongKey)</code> everywhere.
+ */
+@Value.Immutable
+@ImmutablesStyle
+public interface BaseHadoopShuffleClientConfiguration {
+
+  Logger LOGGER = LoggerFactory.getLogger(BaseHadoopShuffleClientConfiguration.class);
+
+  SparkConf sparkConf();
+
+  @Value.Derived
+  default Configuration hadoopConf() {
+    Configuration resolvedHadoopConf = SparkHadoopUtil$.MODULE$.newConfiguration(sparkConf());
+    baseUri().filter(baseUri -> baseUri.getScheme().equals("s3a")).ifPresent(baseUri -> {
+      SparkShuffleAwsCredentials awsCredentials = getMandatoryAwsCredentials(sparkConf());
+      resolvedHadoopConf.set("fs.s3a.access.key", awsCredentials.accessKeyId());
+      resolvedHadoopConf.set("fs.s3a.secret.key", awsCredentials.secretAccessKey());
+      resolvedHadoopConf.set("fs.s3a.session.token", awsCredentials.sessionToken());
+      resolvedHadoopConf.set("fs.s3a.aws.credentials.provider",
+          "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider");
+      s3aEndpoint().ifPresent(
+          s3aEndpoint -> resolvedHadoopConf.set("fs.s3a.endpoint", s3aEndpoint));
+      resolvedHadoopConf.setClass(
+          Constants.S3_CLIENT_FACTORY_IMPL, ConscryptS3ClientFactory.class, S3ClientFactory.class);
+      resolvedHadoopConf.set(Constants.INPUT_FADVISE, Constants.INPUT_FADV_RANDOM);
+      resolvedHadoopConf.set(Constants.FAST_UPLOAD_BUFFER, s3aUploadMultipartType());
+      resolvedHadoopConf.set(Constants.MULTIPART_SIZE, s3aUploadMultipartSize());
+    });
+    resolvedHadoopConf.setBoolean("fs.s3a.impl.disable.cache", true);
+    resolvedHadoopConf.setBoolean("fs.s3.impl.disable.cache", true);
+    resolvedHadoopConf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    resolvedHadoopConf.setBoolean("fs.file.impl.disable.cache", true);
+    return resolvedHadoopConf;
+  }
+
+  static SparkShuffleAwsCredentials getMandatoryAwsCredentials(SparkConf sparkConf) {
+    Optional<String> credentialsFilename =
+        OptionConverters.toJava(sparkConf.get(AsyncShuffleDataIoSparkConfigs.S3A_CREDS_FILE()));
+
+    Preconditions.checkNotNull(
+        credentialsFilename,
+        "Expected spark config to be set",
+        SafeArg.of("config", AsyncShuffleDataIoSparkConfigs.S3A_CREDS_FILE().key()));
+    try {
+      return SparkShuffleAwsCredentials.fromBytes(
+          Files.readAllBytes(Paths.get(credentialsFilename.get())));
+    } catch (FileNotFoundException e) {
+      LOGGER.error("Expected aws credentials file to be there",
+          SafeArg.of("credentialsFile", credentialsFilename.get()),
+          e);
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Value.Derived
+  default JavaSparkConf javaSparkConf() {
+    return new JavaSparkConf(sparkConf());
+  }
+
+  @Value.Derived
+  default Optional<URI> baseUri() {
+    return OptionConverters.toJava(
+        sparkConf().get(AsyncShuffleDataIoSparkConfigs.BASE_URI())).map(URI::create);
+  }
+
+  @Value.Derived
+  default Optional<String> s3aEndpoint() {
+    return OptionConverters.toJava(
+        sparkConf().get(AsyncShuffleDataIoSparkConfigs.S3A_ENDPOINT()));
+  }
+
+  @Value.Derived
+  default int localFileBufferSize() {
+    return Math.toIntExact(
+        javaSparkConf().getLong(AsyncShuffleDataIoSparkConfigs.LOCAL_FILE_STREAM_BUFFER_SIZE()));
+  }
+
+  @Value.Derived
+  default int downloadShuffleBlockBufferSize() {
+    return Math.toIntExact(
+        javaSparkConf().getLong(
+            AsyncShuffleDataIoSparkConfigs.DOWNLOAD_SHUFFLE_BLOCK_BUFFER_SIZE()));
+  }
+
+  @Value.Derived
+  default long downloadShuffleBlockInMemoryMaxSize() {
+    return javaSparkConf().getLong(
+        AsyncShuffleDataIoSparkConfigs.DOWNLOAD_SHUFFLE_BLOCKS_IN_MEMORY_MAX_SIZE());
+  }
+
+  @Value.Derived
+  default int downloadParallelism() {
+    return javaSparkConf().getInt(
+        AsyncShuffleDataIoSparkConfigs.DOWNLOAD_PARALLELISM());
+  }
+
+  @Value.Derived
+  default int uploadParallelism() {
+    return javaSparkConf().getInt(
+        AsyncShuffleDataIoSparkConfigs.UPLOAD_PARALLELISM());
+  }
+
+  @Value.Derived
+  default int driverRefCacheSize() {
+    return javaSparkConf().getInt(
+        AsyncShuffleDataIoSparkConfigs.DRIVER_REF_CACHE_MAX_SIZE());
+  }
+
+  @Value.Derived
+  default long driverRefCacheExpirationMillis() {
+    return javaSparkConf().getLong(
+        AsyncShuffleDataIoSparkConfigs.DRIVER_REF_CACHE_EXPIRATION_PERIOD());
+  }
+
+  @Value.Derived
+  default ShuffleStorageStrategy storageStrategy() {
+    return ShuffleStorageStrategy.fromString(
+        sparkConf().get(AsyncShuffleDataIoSparkConfigs.STORAGE_STRATEGY()));
+  }
+
+  @Value.Derived
+  default boolean cacheIndexFilesLocally() {
+    return javaSparkConf().getBoolean(AsyncShuffleDataIoSparkConfigs.CACHE_INDEX_FILES_LOCALLY());
+  }
+
+  @Value.Derived
+  default boolean preferDownloadFromS3() {
+    return javaSparkConf().getBoolean(AsyncShuffleDataIoSparkConfigs.PREFER_DOWNLOAD_FROM_S3());
+  }
+
+  @Value.Derived
+  default String s3aUploadMultipartType() {
+    return javaSparkConf().get(AsyncShuffleDataIoSparkConfigs.S3A_UPLOAD_MULTIPART_TYPE());
+  }
+
+  @Value.Derived
+  default String s3aUploadMultipartSize() {
+    return javaSparkConf().get(AsyncShuffleDataIoSparkConfigs.S3A_UPLOAD_MULTIPART_SIZE());
+  }
+
+  static ImmutableBaseHadoopShuffleClientConfiguration.Builder builder() {
+    return ImmutableBaseHadoopShuffleClientConfiguration.builder();
+  }
+
+  static BaseHadoopShuffleClientConfiguration of(SparkConf sparkConf) {
+    return builder().sparkConf(sparkConf).build();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
@@ -176,8 +176,8 @@ public interface BaseHadoopShuffleClientConfiguration {
   }
 
   @Value.Derived
-  default boolean preferDownloadFromS3() {
-    return javaSparkConf().getBoolean(AsyncShuffleDataIoSparkConfigs.PREFER_DOWNLOAD_FROM_S3());
+  default boolean preferDownloadFromHadoop() {
+    return javaSparkConf().getBoolean(AsyncShuffleDataIoSparkConfigs.PREFER_DOWNLOAD_FROM_HADOOP());
   }
 
   @Value.Derived

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/MergingHadoopShuffleClient.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/MergingHadoopShuffleClient.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.merging.MergingShuffleFiles;
+import org.apache.spark.palantir.shuffle.async.client.merging.MergingShuffleUploadCoordinator;
+import org.apache.spark.palantir.shuffle.async.client.merging.ShuffleMapInput;
+import org.apache.spark.palantir.shuffle.async.io.PartitionDecoder;
+import org.apache.spark.palantir.shuffle.async.merger.FileMerger;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageState;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateVisitor;
+import org.apache.spark.palantir.shuffle.async.metrics.MergingShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.util.EmptySizedInput;
+import org.apache.spark.palantir.shuffle.async.util.FileSizedInput;
+import org.apache.spark.palantir.shuffle.async.util.SizedInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+import org.apache.spark.storage.BlockManagerId;
+
+public final class MergingHadoopShuffleClient implements ShuffleClient {
+
+  private final String appId;
+  private final ListeningExecutorService downloadExecService;
+  private final ListeningExecutorService localReadExecService;
+  private final MergingShuffleClientMetrics events;
+  private final ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+  private final MergingShuffleUploadCoordinator shuffleUploadCoordinator;
+  private final MergingShuffleFiles shuffleFiles;
+  private final Map<Long, ListenableFuture<Void>> downloadDataTasks;
+  private final Map<Long, ListenableFuture<Void>> downloadIndicesTasks;
+  private final Clock clock;
+  private final int localFileBufferSize;
+
+  public MergingHadoopShuffleClient(
+      String appId,
+      ListeningExecutorService downloadExecService,
+      ListeningExecutorService localReadExecService,
+      MergingShuffleClientMetrics events,
+      ShuffleDriverEndpointRef shuffleDriverEndpointRef,
+      MergingShuffleUploadCoordinator shuffleUploadCoordinator,
+      MergingShuffleFiles shuffleFiles,
+      Clock clock,
+      int localFileBufferSize) {
+    this.appId = appId;
+    this.downloadExecService = downloadExecService;
+    this.localReadExecService = localReadExecService;
+    this.events = events;
+    this.shuffleDriverEndpointRef = shuffleDriverEndpointRef;
+    this.shuffleUploadCoordinator = shuffleUploadCoordinator;
+    this.shuffleFiles = shuffleFiles;
+    this.downloadDataTasks = new ConcurrentHashMap<>();
+    this.downloadIndicesTasks = new ConcurrentHashMap<>();
+    this.clock = clock;
+    this.localFileBufferSize = localFileBufferSize;
+  }
+
+  @Override
+  public void asyncWriteIndexFileAndClose(
+      java.nio.file.Path indexFile, int shuffleId, int mapId, long attemptId) {
+    addShuffleMapInputForUpload(
+        new EmptySizedInput(),
+        new FileSizedInput(indexFile.toFile(), localFileBufferSize),
+        shuffleId,
+        mapId,
+        attemptId);
+  }
+
+  @Override
+  public void asyncWriteDataAndIndexFilesAndClose(
+      java.nio.file.Path dataFile,
+      java.nio.file.Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId) {
+    addShuffleMapInputForUpload(
+        new FileSizedInput(dataFile.toFile(), localFileBufferSize),
+        new FileSizedInput(indexFile.toFile(), localFileBufferSize),
+        shuffleId,
+        mapId,
+        attemptId);
+  }
+
+  @Override
+  public ListenableFuture<Supplier<InputStream>> getBlockData(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId) {
+    if (!shuffleFiles.doLocalBackupsExist(shuffleId, mapId, attemptId)) {
+      ShuffleStorageState storageState = shuffleDriverEndpointRef.getShuffleStorageState(
+          new MapOutputId(shuffleId, mapId, attemptId));
+      Optional<Long> mergeId = storageState.visit(new ShuffleStorageStateVisitor<Optional<Long>>() {
+        @Override
+        public Optional<Long> onExecutorOnly(BlockManagerId executorLocation) {
+          throw new SafeIllegalStateException(
+              "Shuffle file was not backed up to remote storage. It was only stored on the" +
+                  " executor, so if the executor is lost, the block must be recomputed.",
+              UnsafeArg.of("executorLocation", executorLocation),
+              SafeArg.of("shuffleId", shuffleId),
+              SafeArg.of("mapId", mapId),
+              SafeArg.of("attemptId", attemptId));
+        }
+
+        @Override
+        public Optional<Long> onExecutorAndRemote(
+            BlockManagerId _executorLocation, Optional<Long> mergeId) {
+          return mergeId;
+        }
+
+        @Override
+        public Optional<Long> onRemoteOnly(Optional<Long> mergeId) {
+          return mergeId;
+        }
+
+        @Override
+        public Optional<Long> unregistered() {
+          throw new SafeIllegalStateException(
+              "Shuffle file was never registered with the driver, or the shuffle was unregistered.",
+              SafeArg.of("shuffleId", shuffleId),
+              SafeArg.of("mapId", mapId),
+              SafeArg.of("attemptId", attemptId));
+        }
+      });
+
+      if (!mergeId.isPresent()) {
+        throw new SafeIllegalStateException(
+            "Shuffle file was not backed up as a merged block.",
+            SafeArg.of("shuffleId", shuffleId),
+            SafeArg.of("mapId", mapId),
+            SafeArg.of("attemptId", attemptId));
+      }
+
+      List<ListenableFuture<Void>> downloadFutures = new ArrayList<>(2);
+      if (!shuffleFiles.doesLocalBackupDataFileExist(shuffleId, mapId, attemptId)) {
+        downloadFutures.add(startDownloadTask(
+            mergeId.get(),
+            downloadDataTasks,
+            () -> {
+              downloadMergedData(shuffleId, mapId, attemptId, mergeId.get());
+              return null;
+            }));
+      }
+
+      if (!shuffleFiles.doesLocalBackupIndexFileExist(shuffleId, mapId, attemptId)) {
+        downloadFutures.add(startDownloadTask(
+            mergeId.get(),
+            downloadIndicesTasks,
+            () -> {
+              downloadMergedIndices(shuffleId, mapId, attemptId, mergeId.get());
+              return null;
+            }));
+      }
+
+      if (!downloadFutures.isEmpty()) {
+        return Futures.transform(Futures.allAsList(downloadFutures),
+            (Function<List<Void>, Supplier<InputStream>>) downloadResults ->
+                () -> getDownloadedBlockDataChecked(shuffleId, mapId, reduceId, attemptId),
+            localReadExecService);
+      } else {
+        return asyncGetDownloadedBlockDataChecked(shuffleId, mapId, reduceId, attemptId);
+      }
+    } else {
+      return asyncGetDownloadedBlockDataChecked(shuffleId, mapId, reduceId, attemptId);
+    }
+  }
+
+  @Override
+  public void deleteDownloadedBlockData(
+      int _shuffleId, int _mapId, int _reduceId, long _attemptId) {
+    // Merging mode is a no-op since it doesn't save data on local disk.
+  }
+
+  private void addShuffleMapInputForUpload(
+      SizedInput dataSizedInput,
+      SizedInput indexSizedInput,
+      int shuffleId,
+      int mapId,
+      long attemptId) {
+    shuffleUploadCoordinator.addShuffleMapInputForUpload(
+        new ShuffleMapInput(
+            new MapOutputId(shuffleId, mapId, attemptId),
+            dataSizedInput,
+            indexSizedInput));
+  }
+
+  private void downloadMergedData(int shuffleId, int mapId, long attemptId, long mergeId) {
+    // Have to double check that something hasn't already done the download
+    // TODO(mcheah): #
+    if (!shuffleFiles.doesLocalBackupDataFileExist(shuffleId, mapId, attemptId)) {
+      events.markDownloadRequested(shuffleId, mapId, attemptId, mergeId, "data");
+      long startTimeMillis = clock.millis();
+      try (InputStream mergedInput = shuffleFiles.openRemoteMergedDataFile(mergeId);
+           DataInputStream mergedDataInput = new DataInputStream(mergedInput)) {
+        events.markDownloadStarted(shuffleId, mapId, attemptId, mergeId, "data");
+        FileMerger.fetchAndSplitMergedInput(
+            mergedDataInput,
+            (splitShuffleId, splitMapId, splitAttemptId) -> {
+              if (!shuffleFiles.doesLocalBackupDataFileExist(
+                  splitShuffleId, splitMapId, splitAttemptId)) {
+                return Optional.of(() -> shuffleFiles.createLocalBackupDataFile(
+                    splitShuffleId, splitMapId, splitAttemptId));
+              } else {
+                return Optional.empty();
+              }
+            });
+      } catch (IOException e) {
+        events.markDownloadFailed(shuffleId, mapId, attemptId, mergeId, "data");
+        throw new RuntimeException(e);
+      }
+      events.markDownloadCompleted(shuffleId, mapId, attemptId, mergeId, "data",
+          clock.millis() - startTimeMillis);
+    }
+  }
+
+  private void downloadMergedIndices(int shuffleId, int mapId, long attemptId, long mergeId) {
+    // Have to double check that something hasn't already done the download
+    if (!shuffleFiles.doesLocalBackupIndexFileExist(shuffleId, mapId, attemptId)) {
+      events.markDownloadRequested(shuffleId, mapId, attemptId, mergeId, "index");
+      long startTimeMillis = clock.millis();
+      try (InputStream mergedInput = shuffleFiles.openRemoteMergedIndexFile(mergeId);
+           DataInputStream mergedDataInput = new DataInputStream(mergedInput)) {
+        events.markDownloadStarted(shuffleId, mapId, attemptId, mergeId, "index");
+        FileMerger.fetchAndSplitMergedInput(
+            mergedDataInput,
+            (splitShuffleId, splitMapId, splitAttemptId) -> {
+              if (!shuffleFiles.doesLocalBackupIndexFileExist(
+                  splitShuffleId, splitMapId, splitAttemptId)) {
+                return Optional.of(() -> shuffleFiles.createLocalBackupIndexFile(
+                    splitShuffleId, splitMapId, splitAttemptId));
+              } else {
+                return Optional.empty();
+              }
+            });
+      } catch (IOException e) {
+        events.markDownloadFailed(shuffleId, mapId, attemptId, mergeId, "index");
+        throw new RuntimeException(e);
+      }
+      events.markDownloadCompleted(shuffleId, mapId, attemptId, mergeId, "index",
+          clock.millis() - startTimeMillis);
+    }
+  }
+
+  private ListenableFuture<Void> startDownloadTask(
+      long mergeId,
+      Map<Long, ListenableFuture<Void>> tasks,
+      Callable<Void> taskRunnable) {
+    return tasks.computeIfAbsent(
+        mergeId,
+        resolvedMergeId -> downloadExecService.submit(taskRunnable));
+  }
+
+  private ListenableFuture<Supplier<InputStream>> asyncGetDownloadedBlockDataChecked(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId) {
+    return localReadExecService.submit(
+        () -> {
+          InputStream downloadedData = getDownloadedBlockDataChecked(
+              shuffleId, mapId, reduceId, attemptId);
+          return () -> downloadedData;
+        });
+  }
+
+  private InputStream getDownloadedBlockDataChecked(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId) {
+    Preconditions.checkState(
+        shuffleFiles.doLocalBackupsExist(shuffleId, mapId, attemptId),
+        "Shuffle backup files should have been downloaded.",
+        SafeArg.of("appId", appId),
+        SafeArg.of("shuffleId", shuffleId),
+        SafeArg.of("mapId", mapId),
+        SafeArg.of("attemptId", attemptId));
+    SeekableInput dataInput = shuffleFiles.getLocalBackupDataFile(shuffleId, mapId, attemptId);
+    SeekableInput indexInput = shuffleFiles.getLocalBackupIndexFile(shuffleId, mapId, attemptId);
+    return PartitionDecoder.decodePartition(dataInput, indexInput, reduceId);
+  }
+
+  @Override
+  public void removeApplicationData() {
+
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/MergingHadoopShuffleClient.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/MergingHadoopShuffleClient.java
@@ -54,6 +54,21 @@ import org.apache.spark.palantir.shuffle.async.util.SizedInput;
 import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
 import org.apache.spark.storage.BlockManagerId;
 
+/**
+ * Experimental implementation of {@link ShuffleClient} that concatenates shuffle data and index
+ * files before writing them to remote storage.
+ * <p>
+ * This implements the {@link ShuffleStorageStrategy#MERGING} storage strategy for backing up
+ * shuffle files. This was originally built under the assumption that reading and writing small
+ * files may be prohibitively expensive. This fact remains to be seen, but this implementation has
+ * been largely untested and also should be updated to match optimizations present in
+ * {@link org.apache.spark.palantir.shuffle.async.client.basic.HadoopShuffleClient}.
+ * <p>
+ * When uploading files, the data is not sent to remote storage automatically. A periodic task
+ * batches together data and index files, and uploads groups of them as concatenated files.
+ * Downloading blocks requires the merged files to be downloaded and split on local disk first
+ * before they can be served to the reducer tasks.
+ */
 public final class MergingHadoopShuffleClient implements ShuffleClient {
 
   private final String appId;

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClient.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClient.java
@@ -23,14 +23,30 @@ import java.util.function.Supplier;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+/**
+ * API for storing shuffle files in remote storage and fetching partition data blocks.
+ */
 public interface ShuffleClient {
 
+  /**
+   * Write only an index file to the backing storage system, assuming there is no data file for
+   * this map output task.
+   * <p>
+   * The backup should be asynchronous, so this method should return immediately after submitting
+   * the work to upload the file.
+   */
   void asyncWriteIndexFileAndClose(
       Path indexFile,
       int shuffleId,
       int mapId,
       long attemptId);
 
+  /**
+   * Back up a map task's data and index files to remote storage.
+   * <p>
+   * The backup should be asynchronous, so this method should return immediately after submitting
+   * the work to upload the file.
+   */
   void asyncWriteDataAndIndexFilesAndClose(
       Path dataFile,
       Path indexFile,
@@ -38,13 +54,33 @@ public interface ShuffleClient {
       int mapId,
       long attemptId);
 
+  /**
+   * Retrieve a handle to an input stream that can be used to read bytes for a given partition.
+   * <p>
+   * The task to fetch the partition is asynchronous, hence the return value being a future that
+   * represents the work being done on a separate thread.
+   * <p>
+   * The value in the future is a {@link Supplier} since we want to open the resources that back
+   * the input stream lazily.
+   */
   ListenableFuture<Supplier<InputStream>> getBlockData(
       int shuffleId,
       int mapId,
       int reduceId,
       long attemptId);
 
+  /**
+   * Clean up any resources that may have been used to fetch a block retrieved by
+   * {@link #getBlockData(int, int, int, long)}.
+   * <p>
+   * Implementations of {@link #getBlockData(int, int, int, long)} may cache data so that the same
+   * block that is fetched twice does not need to be re-fetched from remote storage. This method
+   * serves as a handle to clear any resources that may be tied to fetching that block.
+   */
   void deleteDownloadedBlockData(int shuffleId, int mapId, int reduceId, long attemptId);
 
+  /**
+   * Remove all temporary shuffle files written for this application.
+   */
   void removeApplicationData();
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClient.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClient.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface ShuffleClient {
+
+  void asyncWriteIndexFileAndClose(
+      Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId);
+
+  void asyncWriteDataAndIndexFilesAndClose(
+      Path dataFile,
+      Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId);
+
+  ListenableFuture<Supplier<InputStream>> getBlockData(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId);
+
+  void deleteDownloadedBlockData(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  void removeApplicationData();
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClients.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleClients.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.basic.DefaultPartitionOffsetsFetcher;
+import org.apache.spark.palantir.shuffle.async.client.basic.DefaultRemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.client.basic.HadoopShuffleClient;
+import org.apache.spark.palantir.shuffle.async.client.basic.LocalDownloadShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.client.basic.PartitionOffsetsFetcher;
+import org.apache.spark.palantir.shuffle.async.client.basic.RemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.client.merging.DefaultMergingShuffleFiles;
+import org.apache.spark.palantir.shuffle.async.client.merging.DefaultShuffleFileBatchUploader;
+import org.apache.spark.palantir.shuffle.async.client.merging.MergingHadoopShuffleClientConfiguration;
+import org.apache.spark.palantir.shuffle.async.client.merging.MergingShuffleFiles;
+import org.apache.spark.palantir.shuffle.async.client.merging.MergingShuffleUploadCoordinator;
+import org.apache.spark.palantir.shuffle.async.client.merging.ShuffleFileBatchUploader;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
+import org.apache.spark.palantir.shuffle.async.util.DaemonExecutors;
+import org.apache.spark.palantir.shuffle.async.util.NamedExecutors;
+import org.apache.spark.util.Utils;
+
+import org.immutables.builder.Builder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ShuffleClients {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ShuffleClients.class);
+
+  @Builder.Factory
+  static Optional<ShuffleClient> shuffleClient(
+      String appId,
+      SparkConf sparkConf,
+      ShuffleDriverEndpointRef driverEndpointRef,
+      Clock clock,
+      Optional<ExecutorService> customUploadExecutorService,
+      Optional<ExecutorService> customDownloadExecutorService,
+      Optional<ScheduledExecutorService> customUploadCoordinatorExecutorService,
+      HadoopAsyncShuffleMetrics metrics) {
+    BaseHadoopShuffleClientConfiguration baseConfig =
+        BaseHadoopShuffleClientConfiguration.of(sparkConf);
+    if (!baseConfig.baseUri().isPresent()) {
+      LOGGER.warn("Spark application configured to use the async shuffle upload plugin, but no" +
+          " remote storage location was provided for backing up data. Falling back to only" +
+          " reading and writing shuffle files from local disk.");
+    }
+    return baseConfig.baseUri().map(baseUri -> {
+      LOGGER.info("Setting up shuffle hadoop client.", UnsafeArg.of("baseUri", baseUri));
+      ExecutorService resolvedUploadExecutor = resolveUploadExecutor(
+          customUploadExecutorService, baseConfig);
+      ExecutorService resolvedDownloadExecutor =
+          resolveDownloadExecutor(customDownloadExecutorService, baseConfig);
+      FileSystem backupFs = createBackupFs(baseConfig, baseUri);
+
+      ShuffleStorageStrategy storageStrategy = baseConfig.storageStrategy();
+      switch (storageStrategy) {
+        case BASIC:
+          String localDir = Utils.getLocalDir(sparkConf);
+          LocalDownloadShuffleFileSystem localDownloadFs =
+              LocalDownloadShuffleFileSystem.createWithLocalDir(localDir);
+          RemoteShuffleFileSystem remoteFs = new DefaultRemoteShuffleFileSystem(
+              backupFs,
+              baseUri.toString(),
+              appId);
+          PartitionOffsetsFetcher partitionOffsetsFetcher = new DefaultPartitionOffsetsFetcher(
+              localDownloadFs,
+              remoteFs,
+              NamedExecutors.newFixedThreadScheduledExecutorService(1, "cleanup-index-files"),
+              driverEndpointRef,
+              baseConfig.localFileBufferSize(),
+              baseConfig.downloadShuffleBlockBufferSize(),
+              baseConfig.cacheIndexFilesLocally());
+          return new HadoopShuffleClient(
+              appId,
+              MoreExecutors.listeningDecorator(resolvedUploadExecutor),
+              MoreExecutors.listeningDecorator(resolvedDownloadExecutor),
+              remoteFs,
+              localDownloadFs,
+              partitionOffsetsFetcher,
+              metrics.basicShuffleClientMetrics(),
+              driverEndpointRef,
+              clock,
+              baseConfig.downloadShuffleBlockInMemoryMaxSize(),
+              baseConfig.downloadShuffleBlockBufferSize(),
+              baseConfig.localFileBufferSize());
+        case MERGING:
+          MergingHadoopShuffleClientConfiguration mergingConf =
+              MergingHadoopShuffleClientConfiguration.of(baseConfig);
+          MergingShuffleFiles mergingShuffleFiles = DefaultMergingShuffleFiles.mergingShuffleFiles(
+              appId,
+              baseConfig.localFileBufferSize(),
+              baseUri,
+              backupFs);
+
+          ScheduledExecutorService resolvedUploadCoordinatorExecutor =
+              customUploadCoordinatorExecutorService.orElseGet(() ->
+                  NamedExecutors.newFixedThreadScheduledExecutorService(
+                      1,
+                      "upload-coordinator-%d"));
+          ShuffleFileBatchUploader batchUploader = new DefaultShuffleFileBatchUploader(
+              appId,
+              driverEndpointRef,
+              mergingShuffleFiles,
+              MoreExecutors.listeningDecorator(resolvedUploadExecutor),
+              metrics.mergingShuffleClientMetrics(),
+              clock);
+
+          MergingShuffleUploadCoordinator coordinator = new MergingShuffleUploadCoordinator(
+              mergingConf.maxBatchSizeBytes(),
+              mergingConf.maxBatchAgeMillis(),
+              mergingConf.maxBufferedInputs(),
+              mergingConf.pollingIntervalMillis(),
+              driverEndpointRef,
+              MoreExecutors.listeningDecorator(resolvedUploadCoordinatorExecutor),
+              clock,
+              batchUploader);
+
+          ExecutorService localReadExecService = DaemonExecutors.newFixedDaemonThreadPool(
+              mergingConf.readLocalDiskParallelism());
+          ShuffleClient client = new MergingHadoopShuffleClient(
+              appId,
+              MoreExecutors.listeningDecorator(resolvedDownloadExecutor),
+              MoreExecutors.listeningDecorator(localReadExecService),
+              metrics.mergingShuffleClientMetrics(),
+              driverEndpointRef,
+              coordinator,
+              mergingShuffleFiles,
+              clock,
+              baseConfig.localFileBufferSize());
+
+          coordinator.start();
+          return client;
+        default:
+          throw new SafeIllegalArgumentException(
+              "Storage strategy is invalid.",
+              SafeArg.of("invalidStorageStrategy", storageStrategy));
+      }
+    });
+  }
+
+  private static FileSystem createBackupFs(
+      BaseHadoopShuffleClientConfiguration baseConfig, URI baseUri) {
+    FileSystem backupFs;
+    try {
+      backupFs = FileSystem.get(baseUri, baseConfig.hadoopConf());
+    } catch (IOException e) {
+      LOGGER.error("Failed to create filesystem", e);
+      throw new RuntimeException(e);
+    }
+    return backupFs;
+  }
+
+  private static ExecutorService resolveDownloadExecutor(
+      Optional<ExecutorService> customDownloadExecutorService,
+      BaseHadoopShuffleClientConfiguration baseConfig) {
+    return customDownloadExecutorService.orElseGet(
+        () -> NamedExecutors.newFixedThreadExecutorService(
+            baseConfig.downloadParallelism(), "async-plugin-hadoop-download-%d"));
+  }
+
+  private static ExecutorService resolveUploadExecutor(
+      Optional<ExecutorService> customUploadExecutorService,
+      BaseHadoopShuffleClientConfiguration baseConfig) {
+    return customUploadExecutorService.orElseGet(
+        () -> NamedExecutors.newFixedThreadExecutorService(
+            baseConfig.uploadParallelism(), "async-plugin-hadoop-upload-%d"));
+  }
+
+  public static ShuffleClientBuilder builder() {
+    return new ShuffleClientBuilder();
+  }
+
+  private ShuffleClients() {
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleStorageStrategy.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/ShuffleStorageStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum ShuffleStorageStrategy {
+  BASIC("basic"),
+  MERGING("merging");
+
+  private final String value;
+
+  ShuffleStorageStrategy(String value) {
+    this.value = value;
+  }
+
+  public static ShuffleStorageStrategy fromString(String value) {
+    return Arrays.stream(values())
+        .filter(val -> val.value.equalsIgnoreCase(value))
+        .findFirst()
+        .orElseThrow(() -> new SafeIllegalArgumentException(
+            "Not a valid shuffle storage strategy.",
+            SafeArg.of("Valid strategies", Arrays.asList(ShuffleStorageStrategy.values())),
+            SafeArg.of("Invalid strategy", value)));
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public static Set<ShuffleStorageStrategy> valueSet() {
+    return ImmutableSet.copyOf(values());
+  }
+
+  public static Set<String> strings() {
+    return valueSet().stream().map(ShuffleStorageStrategy::value).collect(Collectors.toSet());
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultLocalDownloadShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultLocalDownloadShuffleFileSystem.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+
+import org.apache.spark.palantir.shuffle.async.util.TempFileOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableFileInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class DefaultLocalDownloadShuffleFileSystem implements LocalDownloadShuffleFileSystem {
+
+  private final File downloadRootDir;
+
+  public DefaultLocalDownloadShuffleFileSystem(File downloadRootDir) {
+    this.downloadRootDir = downloadRootDir;
+  }
+
+  @Override
+  public TempFileOutputStream createLocalDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) throws IOException {
+    File dataBlockFile = getLocalDataBlockFile(shuffleId, mapId, reduceId, attemptId);
+    Files.createParentDirs(dataBlockFile);
+    return TempFileOutputStream.createTempFile(dataBlockFile);
+  }
+
+  @Override
+  public TempFileOutputStream createLocalIndexFile(int shuffleId, int mapId, long attemptId)
+      throws IOException {
+    File indexFile = getLocalIndexFile(shuffleId, mapId, attemptId);
+    Files.createParentDirs(indexFile);
+    return TempFileOutputStream.createTempFile(indexFile);
+  }
+
+  @Override
+  public void deleteDownloadedDataBlock(int shuffleId, int mapId, int reduceId, long attemptId) {
+    FileUtils.deleteQuietly(getLocalDataBlockFile(shuffleId, mapId, reduceId, attemptId));
+  }
+
+  @Override
+  public void deleteDownloadedIndexFile(int shuffleId, int mapId, long attemptId) {
+    FileUtils.deleteQuietly(getLocalIndexFile(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public void deleteDownloadedIndexFilesForShuffleId(int shuffleId) {
+    FileUtils.deleteQuietly(getLocalShuffleIndexDir(shuffleId));
+  }
+
+  @Override
+  public boolean doesLocalDataBlockFileExist(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    return getLocalDataBlockFile(shuffleId, mapId, reduceId, attemptId).isFile();
+  }
+
+  @Override
+  public boolean doesLocalIndexFileExist(int shuffleId, int mapId, long attemptId) {
+    return getLocalIndexFile(shuffleId, mapId, attemptId).isFile();
+  }
+
+  @Override
+  public SeekableInput getLocalSeekableIndexFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableFileInput(getLocalIndexFile(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public byte[] readAllIndexFileBytes(int shuffleId, int mapId, long attemptId) throws IOException {
+    return java.nio.file.Files.readAllBytes(
+        getLocalIndexFile(shuffleId, mapId, attemptId).toPath());
+  }
+
+  @Override
+  public SeekableInput getLocalSeekableDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    return new SeekableFileInput(getLocalDataBlockFile(shuffleId, mapId, reduceId, attemptId));
+  }
+
+  private File getLocalDataBlockFile(int shuffleId, int mapId, int reduceId, long attemptId) {
+    return getLocalShuffleBlocksDir(shuffleId).toPath()
+        .resolve(String.format("map=%d", mapId))
+        .resolve(String.format("attempt=%d", attemptId))
+        .resolve(String.format("reduce=%d", reduceId))
+        .toFile();
+  }
+
+  private File getLocalIndexFile(int shuffleId, int mapId, long attemptId) {
+    return getLocalShuffleIndexDir(shuffleId).toPath()
+        .resolve(String.format("map=%d", mapId))
+        .resolve(String.format("attempt=%d.index", attemptId))
+        .toFile();
+  }
+
+  private File getLocalShuffleBlocksDir(int shuffleId) {
+    return downloadRootDir.toPath().resolve("downloaded-shuffle-blocks")
+        .resolve(String.format("shuffle=%d", shuffleId))
+        .toFile();
+  }
+
+  private File getLocalShuffleIndexDir(int shuffleId) {
+    return downloadRootDir.toPath().resolve("downloaded-index-files")
+        .resolve(String.format("shuffle=%d", shuffleId))
+        .toFile();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcher.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcher.java
@@ -35,6 +35,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
 import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
 import org.apache.spark.palantir.shuffle.async.io.PartitionDecoder;
 import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
@@ -43,6 +44,14 @@ import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
 import org.apache.spark.palantir.shuffle.async.util.streams.BufferedSeekableInput;
 import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
 
+/**
+ * Default implementation of {@link PartitionOffsetsFetcher} that is backed by index files stored
+ * by the {@link HadoopShuffleClient} module.
+ * <p>
+ * This module may cache index files on local disk, if it is so configured via
+ * {@link AsyncShuffleDataIoSparkConfigs#CACHE_INDEX_FILES_LOCALLY()}. An asynchronous task also
+ * periodically removes downloaded index files that are no longer needed.
+ */
 public final class DefaultPartitionOffsetsFetcher implements PartitionOffsetsFetcher {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultPartitionOffsetsFetcher.class);
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcher.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcher.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIoException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.io.PartitionDecoder;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.AbortableOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+import org.apache.spark.palantir.shuffle.async.util.streams.BufferedSeekableInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class DefaultPartitionOffsetsFetcher implements PartitionOffsetsFetcher {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPartitionOffsetsFetcher.class);
+
+  private final LocalDownloadShuffleFileSystem localShuffleFs;
+  private final RemoteShuffleFileSystem remoteShuffleFs;
+  private final int localFileBufferSize;
+  private final int shuffleDownloadBufferSize;
+  private final boolean cacheIndexFilesLocally;
+  private final Map<MapOutputId, Boolean> fetchingIndexFiles;
+  private final Set<Integer> fetchedShuffleIds;
+  private final ListeningScheduledExecutorService cleanupExecutor;
+  private final ShuffleDriverEndpointRef driverEndpointRef;
+
+  public DefaultPartitionOffsetsFetcher(
+      LocalDownloadShuffleFileSystem localShuffleFs,
+      RemoteShuffleFileSystem remoteShuffleFs,
+      ScheduledExecutorService cleanupExecutor,
+      ShuffleDriverEndpointRef driverEndpointRef,
+      int localFileBufferSize,
+      int shuffleDownloadBufferSize,
+      boolean cacheIndexFilesLocally) {
+    this.localShuffleFs = localShuffleFs;
+    this.remoteShuffleFs = remoteShuffleFs;
+    this.cleanupExecutor = MoreExecutors.listeningDecorator(cleanupExecutor);
+    this.driverEndpointRef = driverEndpointRef;
+    this.localFileBufferSize = localFileBufferSize;
+    this.shuffleDownloadBufferSize = shuffleDownloadBufferSize;
+    this.cacheIndexFilesLocally = cacheIndexFilesLocally;
+    this.fetchingIndexFiles = new ConcurrentHashMap<>();
+    this.fetchedShuffleIds = ConcurrentHashMap.newKeySet();
+  }
+
+  public void startCleaningIndexFiles() {
+    cleanupExecutor.scheduleWithFixedDelay(
+        this::cleanupUnregisteredIndexFiles, 30, 30, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public PartitionOffsets fetchPartitionOffsets(
+      int shuffleId, int mapId, long mapAttemptId, int reduceId) {
+    if (cacheIndexFilesLocally) {
+      MapOutputId id = new MapOutputId(shuffleId, mapId, mapAttemptId);
+      fetchIndexFileToDisk(id);
+      SeekableInput indexFileInput = localShuffleFs.getLocalSeekableIndexFile(
+          shuffleId, mapId, mapAttemptId);
+      BufferedSeekableInput bufferedIndexFileInput = new BufferedSeekableInput(
+          indexFileInput, localFileBufferSize);
+      return PartitionDecoder.decodePartitionOffsets(bufferedIndexFileInput, reduceId);
+    } else {
+      try {
+        SeekableInput indexInput = remoteShuffleFs.getRemoteSeekableIndexFile(
+            shuffleId, mapId, mapAttemptId);
+        BufferedSeekableInput bufferedIndexInput = new BufferedSeekableInput(
+            indexInput, shuffleDownloadBufferSize);
+        return PartitionDecoder.decodePartitionOffsets(bufferedIndexInput, reduceId);
+      } catch (IOException e) {
+        throw new SafeRuntimeException(
+            new SafeIoException(
+                "Failed to decode partition offsets from remote storage.",
+                e,
+                SafeArg.of("shuffleId", shuffleId),
+                SafeArg.of("mapId", mapId),
+                SafeArg.of("mapAttemptId", mapAttemptId),
+                SafeArg.of("reduceId", reduceId)));
+      }
+    }
+  }
+
+  private void fetchIndexFileToDisk(MapOutputId key) {
+    if (localShuffleFs.doesLocalIndexFileExist(key.shuffleId(), key.mapId(), key.mapAttemptId())) {
+      return;
+    }
+    fetchingIndexFiles.computeIfAbsent(key, id -> {
+      int shuffleId = key.shuffleId();
+      int mapId = key.mapId();
+      long mapAttemptId = key.mapAttemptId();
+      if (!localShuffleFs.doesLocalIndexFileExist(shuffleId, mapId, mapAttemptId)) {
+        AbortableOutputStream resolvedIndexOutput = null;
+        try (InputStream remoteIndexInput = remoteShuffleFs.openRemoteIndexFile(
+            shuffleId, mapId, mapAttemptId);
+             AbortableOutputStream localIndexOutput = localShuffleFs.createLocalIndexFile(
+                 shuffleId, mapId, mapAttemptId)) {
+          resolvedIndexOutput = localIndexOutput;
+          IOUtils.copy(remoteIndexInput, localIndexOutput, shuffleDownloadBufferSize);
+        } catch (IOException e) {
+          if (resolvedIndexOutput != null) {
+            resolvedIndexOutput.abort(e);
+          }
+          throw new SafeRuntimeException(
+              new SafeIoException(
+                  "Failed to fetch index file from remote storage to local disk.",
+                  e,
+                  SafeArg.of("shuffleId", id.shuffleId()),
+                  SafeArg.of("mapId", id.mapId()),
+                  SafeArg.of("mapAttemptId", id.mapAttemptId())));
+        }
+      }
+      fetchedShuffleIds.add(key.shuffleId());
+      return true;
+    });
+    fetchingIndexFiles.remove(key);
+  }
+
+  private void cleanupUnregisteredIndexFiles() {
+    try {
+      Iterator<Integer> fetchedShufflesIterator = fetchedShuffleIds.iterator();
+      while (fetchedShufflesIterator.hasNext()) {
+        int shuffleId = fetchedShufflesIterator.next();
+        if (!driverEndpointRef.isShuffleRegistered(shuffleId)) {
+          fetchedShufflesIterator.remove();
+          localShuffleFs.deleteDownloadedIndexFilesForShuffleId(shuffleId);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to clean up unregistered index files.", e);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultRemoteShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultRemoteShuffleFileSystem.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableHadoopInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class DefaultRemoteShuffleFileSystem implements RemoteShuffleFileSystem {
+
+  private static final String DATA_PREFIX = "data";
+  private static final String DATA_FILE_TYPE = "data";
+  private static final String INDEX_FILE_TYPE = "index";
+
+  private final FileSystem backupFs;
+  private final String baseUri;
+  private final String appId;
+
+  public DefaultRemoteShuffleFileSystem(FileSystem backupFs, String baseUri, String appId) {
+    this.backupFs = backupFs;
+    this.baseUri = baseUri;
+    this.appId = appId;
+  }
+
+  @Override
+  public void backupDataFile(int shuffleId, int mapId, long attemptId, File localDataFile)
+      throws IOException {
+    backupFs.copyFromLocalFile(
+        new Path(localDataFile.toURI()),
+        getRemoteDataPath(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public void backupIndexFile(int shuffleId, int mapId, long attemptId, File localIndexFile)
+      throws IOException {
+    backupFs.copyFromLocalFile(
+        new Path(localIndexFile.toURI()),
+        getRemoteIndexPath(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public InputStream openRemoteIndexFile(int shuffleId, int mapId, long attemptId)
+      throws IOException {
+    return getRemoteSeekableIndexFile(shuffleId, mapId, attemptId).open();
+  }
+
+  @Override
+  public SeekableInput getRemoteSeekableDataFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableHadoopInput(getRemoteDataPath(shuffleId, mapId, attemptId), backupFs);
+  }
+
+  @Override
+  public SeekableInput getRemoteSeekableIndexFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableHadoopInput(getRemoteIndexPath(shuffleId, mapId, attemptId), backupFs);
+  }
+
+  @Override
+  public void deleteApplicationShuffleData() throws IOException {
+    backupFs.delete(
+        new Path(baseUri, String.format("%s/%s", DATA_PREFIX, appId)), true);
+  }
+
+  private Path getRemoteDataPath(int shuffleId, int mapId, long attemptId) {
+    return getRemotePathForFileType(shuffleId, mapId, attemptId, DATA_FILE_TYPE);
+  }
+
+  private Path getRemoteIndexPath(int shuffleId, int mapId, long attemptId) {
+    return getRemotePathForFileType(shuffleId, mapId, attemptId, INDEX_FILE_TYPE);
+  }
+
+  private Path getRemotePathForFileType(int shuffleId, int mapId, long attemptId, String type) {
+    return new Path(
+        baseUri,
+        String.format("%s/%s/%d/%d/%d.%s", DATA_PREFIX, appId, shuffleId, mapId, attemptId, type));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/HadoopShuffleClient.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/HadoopShuffleClient.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIoException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import org.apache.hadoop.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.io.PartitionDecoder;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metrics.BasicShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.util.AbortableOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+import org.apache.spark.palantir.shuffle.async.util.Suppliers;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class HadoopShuffleClient implements ShuffleClient {
+
+  private static final InputStream EMPTY_INPUT_STREAM = new ByteArrayInputStream(new byte[0]);
+  private static final Supplier<InputStream> EMPTY_INPUT_STREAM_SUPPLIER =
+      Suppliers.ofInstance(EMPTY_INPUT_STREAM);
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HadoopShuffleClient.class);
+
+  private final ListeningExecutorService downloadExecService;
+  private final ListeningExecutorService uploadExecService;
+  private final RemoteShuffleFileSystem remoteShuffleFs;
+  private final LocalDownloadShuffleFileSystem localDownloadShuffleFs;
+  private final PartitionOffsetsFetcher partitionOffsetsFetcher;
+  private final String appId;
+  private final ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+  private final Clock clock;
+  private final int shuffleDownloadBufferSize;
+  private final int localFileBufferSize;
+  private final long maxShuffleBytesInMemory;
+  private final BasicShuffleClientMetrics events;
+  private final AtomicLong pendingOrRunningUploadsCounter = new AtomicLong(0L);
+
+  public HadoopShuffleClient(
+      String appId,
+      ListeningExecutorService uploadExecService,
+      ListeningExecutorService downloadExecService,
+      RemoteShuffleFileSystem remoteShuffleFs,
+      LocalDownloadShuffleFileSystem localDownloadShuffleFs,
+      PartitionOffsetsFetcher partitionOffsetsFetcher,
+      BasicShuffleClientMetrics events,
+      ShuffleDriverEndpointRef shuffleDriverEndpointRef,
+      Clock clock,
+      long maxShuffleBytesInMemory,
+      int shuffleDownloadBufferSize,
+      int localFileBufferSize) {
+    this.appId = appId;
+    this.uploadExecService = uploadExecService;
+    this.downloadExecService = downloadExecService;
+    this.remoteShuffleFs = remoteShuffleFs;
+    this.localDownloadShuffleFs = localDownloadShuffleFs;
+    this.partitionOffsetsFetcher = partitionOffsetsFetcher;
+    this.shuffleDriverEndpointRef = shuffleDriverEndpointRef;
+    this.clock = clock;
+    this.events = events;
+    this.maxShuffleBytesInMemory = maxShuffleBytesInMemory;
+    this.shuffleDownloadBufferSize = shuffleDownloadBufferSize;
+    this.localFileBufferSize = localFileBufferSize;
+  }
+
+  @Override
+  public void asyncWriteIndexFileAndClose(
+      java.nio.file.Path indexFile, int shuffleId, int mapId, long attemptId) {
+    doSubmitUpload(
+        Optional.empty(),
+        indexFile,
+        shuffleId,
+        mapId,
+        attemptId);
+  }
+
+  @Override
+  public void asyncWriteDataAndIndexFilesAndClose(
+      java.nio.file.Path dataFile,
+      java.nio.file.Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId) {
+    doSubmitUpload(
+        Optional.of(dataFile),
+        indexFile,
+        shuffleId,
+        mapId,
+        attemptId);
+  }
+
+  private void doSubmitUpload(
+      Optional<java.nio.file.Path> dataFile,
+      java.nio.file.Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId) {
+    long timeSubmitted = clock.millis();
+    events.markUploadRequested(
+        shuffleId,
+        mapId,
+        attemptId,
+        pendingOrRunningUploadsCounter.incrementAndGet());
+    ListenableFuture<Void> future = uploadExecService.submit(() -> {
+      doWriteFilesAndClose(
+          dataFile,
+          indexFile,
+          shuffleId,
+          mapId,
+          attemptId,
+          timeSubmitted);
+      return null;
+    });
+    Futures.addCallback(future, new FutureCallback<Void>() {
+      @Override
+      public void onSuccess(Void _result) {
+        LOGGER.info("Successfully uploaded shuffle files",
+            SafeArg.of("shuffleId", shuffleId),
+            SafeArg.of("mapId", mapId),
+            SafeArg.of("attemptId", attemptId));
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        LOGGER.info("Failed to upload shuffle files",
+            SafeArg.of("shuffleId", shuffleId),
+            SafeArg.of("mapId", mapId),
+            SafeArg.of("attemptId", attemptId),
+            throwable);
+      }
+    }, uploadExecService);
+    events.markUploadRequestSubmitted(
+        shuffleId,
+        mapId,
+        attemptId,
+        clock.millis() - timeSubmitted);
+  }
+
+  private void doWriteFilesAndClose(
+      Optional<java.nio.file.Path> dataFile,
+      java.nio.file.Path indexFile,
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long timeSubmitted) {
+    try {
+      long startTime = clock.millis();
+      try {
+        if (!shuffleDriverEndpointRef.isShuffleRegistered(shuffleId)) {
+          LOGGER.info(
+              "Shuffle is no longer active; skipping file upload",
+              SafeArg.of("appId", appId),
+              SafeArg.of("shuffleId", shuffleId),
+              SafeArg.of("mapId", mapId),
+              SafeArg.of("attemptId", attemptId));
+          return;
+        }
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception encountered while checking for existence of shuffle.",
+            SafeArg.of("appId", appId),
+            SafeArg.of("shuffleId", shuffleId),
+            SafeArg.of("mapId", mapId),
+            SafeArg.of("attemptId", attemptId),
+            e);
+        throw new RuntimeException(e);
+      }
+
+      events.markUploadStarted(shuffleId, mapId, attemptId);
+      dataFile.ifPresent(
+          input -> {
+            try {
+              remoteShuffleFs.backupDataFile(shuffleId, mapId, attemptId, input.toFile());
+            } catch (IOException e) {
+              throw new SafeRuntimeException(
+                  new SafeIoException("Failed to back up shuffle data file.",
+                      e,
+                      SafeArg.of("shuffleId", shuffleId),
+                      SafeArg.of("mapId", mapId),
+                      SafeArg.of("attemptId", attemptId)));
+            }
+          });
+
+      try {
+        remoteShuffleFs.backupIndexFile(shuffleId, mapId, attemptId, indexFile.toFile());
+      } catch (IOException e) {
+        throw new SafeRuntimeException(
+            new SafeIoException("Failed to back up shuffle index file.",
+                e,
+                SafeArg.of("shuffleId", shuffleId),
+                SafeArg.of("mapId", mapId),
+                SafeArg.of("attemptId", attemptId)));
+      }
+      long totalSize = indexFile.toFile().length() +
+          dataFile.map(input -> indexFile.toFile().length() +
+          input.toFile().length()).orElse(0L);
+      long now = clock.millis();
+
+      shuffleDriverEndpointRef.registerUnmergedMapOutput(
+          new MapOutputId(shuffleId, mapId, attemptId));
+      events.markUploadCompleted(
+          shuffleId,
+          mapId,
+          attemptId,
+          now - startTime,
+          totalSize,
+          now - timeSubmitted,
+          pendingOrRunningUploadsCounter.decrementAndGet());
+    } catch (Exception e) {
+      events.markUploadFailed(
+          shuffleId, mapId, attemptId, pendingOrRunningUploadsCounter.decrementAndGet());
+      throw e;
+    }
+  }
+
+  @Override
+  public void removeApplicationData() {
+    try {
+      remoteShuffleFs.deleteApplicationShuffleData();
+    } catch (IOException e) {
+      LOGGER.error("Encountered error deleting application data",
+          SafeArg.of("appId", appId),
+          e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ListenableFuture<Supplier<InputStream>> getBlockData(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId) {
+    return downloadExecService.submit(() -> {
+      long startTime = clock.millis();
+      events.markDownloadStarted(shuffleId, mapId, reduceId, attemptId);
+      PartitionOffsets offsets = partitionOffsetsFetcher.fetchPartitionOffsets(
+          shuffleId, mapId, attemptId, reduceId);
+      Supplier<InputStream> resolvedBlockDataInput;
+      if (offsets.length() == 0) {
+        resolvedBlockDataInput = EMPTY_INPUT_STREAM_SUPPLIER;
+      } else {
+        SeekableInput dataInput;
+        try {
+          dataInput = remoteShuffleFs.getRemoteSeekableDataFile(shuffleId, mapId, attemptId);
+        } catch (IOException e) {
+          throw new SafeRuntimeException(
+              new SafeIoException(
+                  "Failed to fetch data file from remote storage.",
+                  e,
+                  SafeArg.of("shuffleId", shuffleId),
+                  SafeArg.of("mapId", mapId),
+                  SafeArg.of("reduceId", reduceId),
+                  SafeArg.of("attemptId", attemptId)));
+        }
+        if (offsets.length() < maxShuffleBytesInMemory) {
+          byte[] partitionBytes;
+          try (InputStream partitionInputStream =
+                   PartitionDecoder.decodePartitionData(dataInput, offsets)) {
+            partitionBytes = org.apache.commons.io.IOUtils.toByteArray(
+                partitionInputStream, offsets.length());
+          } catch (IOException e) {
+            throw new SafeRuntimeException(
+                new SafeIoException(
+                    "Failed to decode partition from remote storage.",
+                    e,
+                    SafeArg.of("shuffleId", shuffleId),
+                    SafeArg.of("mapId", mapId),
+                    SafeArg.of("reduceId", reduceId),
+                    SafeArg.of("attemptId", attemptId)));
+          }
+          ByteArrayInputStream partitionBytesInput = new ByteArrayInputStream(partitionBytes);
+          resolvedBlockDataInput = Suppliers.ofInstance(partitionBytesInput);
+        } else {
+          AbortableOutputStream resolvedTempFileOutput = null;
+          try (InputStream blockDataInput =
+                   PartitionDecoder.decodePartitionData(dataInput, offsets);
+               AbortableOutputStream tempFileOutput =
+                   localDownloadShuffleFs.createLocalDataBlockFile(
+                       shuffleId, mapId, reduceId, attemptId)) {
+            resolvedTempFileOutput = tempFileOutput;
+            IOUtils.copyBytes(blockDataInput, tempFileOutput, shuffleDownloadBufferSize);
+          } catch (Exception e) {
+            if (resolvedTempFileOutput != null) {
+              resolvedTempFileOutput.abort(e);
+            }
+            throw new SafeRuntimeException(
+                "Failed to copy block data to local disk.",
+                e,
+                SafeArg.of("shuffleId", shuffleId),
+                SafeArg.of("mapId", mapId),
+                SafeArg.of("reduceId", reduceId),
+                SafeArg.of("attemptId", attemptId));
+          }
+          Preconditions.checkState(
+              localDownloadShuffleFs.doesLocalDataBlockFileExist(
+                  shuffleId, mapId, reduceId, attemptId),
+              "Failed to download shuffle file from remote storage.",
+              SafeArg.of("shuffleId", shuffleId),
+              SafeArg.of("mapId", mapId),
+              SafeArg.of("attemptId", attemptId),
+              SafeArg.of("reduceId", reduceId));
+          resolvedBlockDataInput = Suppliers.memoize(() -> {
+            Preconditions.checkState(
+                localDownloadShuffleFs.doesLocalDataBlockFileExist(
+                    shuffleId, mapId, reduceId, attemptId),
+                "Shuffle file was removed between the time it was downloaded and the" +
+                    " time we are reading it.",
+                SafeArg.of("shuffleId", shuffleId),
+                SafeArg.of("mapId", mapId),
+                SafeArg.of("attemptId", attemptId),
+                SafeArg.of("reduceId", reduceId));
+            try {
+              return new BufferedInputStream(
+                  localDownloadShuffleFs.getLocalSeekableDataBlockFile(
+                      shuffleId, mapId, reduceId, attemptId).open(),
+                  localFileBufferSize);
+            } catch (IOException e) {
+              throw new SafeRuntimeException(
+                  new SafeIoException(
+                      "Failed to open local shuffle data block file.",
+                      e,
+                      SafeArg.of("shuffleId", shuffleId),
+                      SafeArg.of("mapId", mapId),
+                      SafeArg.of("attemptId", attemptId),
+                      SafeArg.of("reduceId", reduceId)));
+            }
+          });
+        }
+      }
+      events.markDownloadCompleted(
+          shuffleId, mapId, reduceId, attemptId, clock.millis() - startTime);
+      return resolvedBlockDataInput;
+    });
+  }
+
+  @Override
+  public void deleteDownloadedBlockData(int shuffleId, int mapId, int reduceId, long attemptId) {
+    localDownloadShuffleFs.deleteDownloadedDataBlock(shuffleId, mapId, reduceId, attemptId);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/LocalDownloadShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/LocalDownloadShuffleFileSystem.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.apache.spark.palantir.shuffle.async.util.AbortableOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+/**
+ * Module to manage shuffle files that we download from remote storage on the local file system,
+ * allowing higher-order entities to manage downloaded data without the need to know specific and
+ * consistent file paths where shuffle files are stored.
+ * <p>
+ * This encodes the notion of shuffle index files and shuffle data block files.
+ */
+public interface LocalDownloadShuffleFileSystem {
+
+  static LocalDownloadShuffleFileSystem createWithLocalDir(String localDir) {
+    File downloadFolder = Paths.get(localDir).resolve("downloaded-shuffle-files").toFile();
+    try {
+      java.nio.file.Files.createDirectories(downloadFolder.toPath());
+    } catch (IOException e) {
+      throw new SafeRuntimeException(
+          "Failed to create shuffle files download directory.",
+          e,
+          SafeArg.of("path", downloadFolder.getAbsolutePath()));
+    }
+    return new DefaultLocalDownloadShuffleFileSystem(downloadFolder);
+  }
+
+  SeekableInput getLocalSeekableDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) throws IOException;
+
+  byte[] readAllIndexFileBytes(int shuffleId, int mapId, long attemptId) throws IOException;
+
+  SeekableInput getLocalSeekableIndexFile(int shuffleId, int mapId, long attemptId);
+
+  boolean doesLocalIndexFileExist(int shuffleId, int mapId, long attemptId);
+
+  boolean doesLocalDataBlockFileExist(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  void deleteDownloadedIndexFile(int shuffleId, int mapId, long attemptId);
+
+  void deleteDownloadedIndexFilesForShuffleId(int shuffleId);
+
+  void deleteDownloadedDataBlock(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  AbortableOutputStream createLocalIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException;
+
+  AbortableOutputStream createLocalDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) throws IOException;
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/PartitionOffsetsFetcher.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/PartitionOffsetsFetcher.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+
+public interface PartitionOffsetsFetcher {
+
+  PartitionOffsets fetchPartitionOffsets(int shuffleId, int mapId, long mapAttemptId, int reduceId);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/PartitionOffsetsFetcher.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/PartitionOffsetsFetcher.java
@@ -19,6 +19,9 @@ package org.apache.spark.palantir.shuffle.async.client.basic;
 
 import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
 
+/**
+ * Manages the fetching of {@link PartitionOffsets} from remote storage.
+ */
 public interface PartitionOffsetsFetcher {
 
   PartitionOffsets fetchPartitionOffsets(int shuffleId, int mapId, long mapAttemptId, int reduceId);

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/RemoteShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/basic/RemoteShuffleFileSystem.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+/**
+ * Module to manage remote shuffle files, allowing for keying shuffle files by identifiers without
+ * the need to know the specific path to the file on the backing file system, nor how to
+ * specifically open streams to read or write to these files.
+ * <p>
+ * This encodes the notion of shuffle index files and shuffle data files.
+ */
+public interface RemoteShuffleFileSystem {
+
+  void deleteApplicationShuffleData() throws IOException;
+
+  SeekableInput getRemoteSeekableIndexFile(int shuffleId, int mapId, long attemptId)
+      throws IOException;
+
+  SeekableInput getRemoteSeekableDataFile(int shuffleId, int mapId, long attemptId)
+      throws IOException;
+
+  InputStream openRemoteIndexFile(int shuffleId, int mapId, long attemptId) throws IOException;
+
+  void backupIndexFile(int shuffleId, int mapId, long attemptId, File localIndexFile)
+      throws IOException;
+
+  void backupDataFile(int shuffleId, int mapId, long attemptId, File localDataFile)
+      throws IOException;
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/DefaultMergingShuffleFiles.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/DefaultMergingShuffleFiles.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.spark.palantir.shuffle.async.util.TempFileOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableFileInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+/**
+ * Simpler wrapper around local and remote file systems for the merging shuffle file storage
+ * strategy.
+ */
+public final class DefaultMergingShuffleFiles implements MergingShuffleFiles {
+
+  private static final String MERGED_DATA_PREFIX = "merged-data";
+
+  private final String appId;
+  private final int localFileBufferSize;
+  private final URI remoteBackupBaseUri;
+  private final FileSystem fs;
+  private final File downloadedBackupsDir;
+
+  private DefaultMergingShuffleFiles(
+      String appId,
+      int localFileBufferSize,
+      URI remoteBackupBaseUri,
+      FileSystem fs,
+      File downloadedBackupsDir) {
+    this.appId = appId;
+    this.localFileBufferSize = localFileBufferSize;
+    this.remoteBackupBaseUri = remoteBackupBaseUri;
+    this.fs = fs;
+    this.downloadedBackupsDir = downloadedBackupsDir;
+  }
+
+  public static MergingShuffleFiles mergingShuffleFiles(
+      String appId,
+      int localFileBufferSize,
+      URI remoteBackupBaseUri,
+      FileSystem fs) {
+    File downloadedBackupsDir;
+    try {
+      downloadedBackupsDir = Files.createTempDirectory("downloaded-shuffle-backups").toFile();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return new DefaultMergingShuffleFiles(
+        appId, localFileBufferSize, remoteBackupBaseUri, fs, downloadedBackupsDir);
+  }
+
+  @Override
+  public OutputStream createRemoteMergedDataFile(long mergeId) throws IOException {
+    return fs.create(mergedDataPath(mergeId));
+  }
+
+  @Override
+  public OutputStream createRemoteMergedIndexFile(long mergeId) throws IOException {
+    return fs.create(mergedIndexPath(mergeId));
+  }
+
+  @Override
+  public InputStream openRemoteMergedDataFile(long mergeId) throws IOException {
+    return fs.open(mergedDataPath(mergeId));
+  }
+
+  @Override
+  public InputStream openRemoteMergedIndexFile(long mergeId) throws IOException {
+    return fs.open(mergedIndexPath(mergeId));
+  }
+
+  @Override
+  public boolean doesLocalBackupIndexFileExist(int shuffleId, int mapId, long attemptId) {
+    return localBackupIndexFile(shuffleId, mapId, attemptId).isFile();
+  }
+
+  @Override
+  public boolean doesLocalBackupDataFileExist(int shuffleId, int mapId, long attemptId) {
+    return localBackupDataFile(shuffleId, mapId, attemptId).isFile();
+  }
+
+  @Override
+  public OutputStream createLocalBackupDataFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    return createTempBackupFile(localBackupDataFile(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public OutputStream createLocalBackupIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    return createTempBackupFile(localBackupIndexFile(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public SeekableInput getLocalBackupDataFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableFileInput(localBackupDataFile(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public SeekableInput getLocalBackupIndexFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableFileInput(localBackupIndexFile(shuffleId, mapId, attemptId));
+  }
+
+  private OutputStream createTempBackupFile(File finalFile) throws IOException {
+    return new BufferedOutputStream(
+        TempFileOutputStream.createTempFile(finalFile),
+        localFileBufferSize);
+  }
+
+  private Path mergedDataPath(long mergeId) {
+    return mergedFilePath("data", mergeId);
+  }
+
+  private Path mergedIndexPath(long mergeId) {
+    return mergedFilePath("index", mergeId);
+  }
+
+  private Path mergedFilePath(String extension, long mergeId) {
+    return new Path(new Path(remoteBackupBaseUri),
+        String.format(
+            "%s/appId=%s/merged-%d.%s",
+            MERGED_DATA_PREFIX,
+            appId,
+            mergeId,
+            extension));
+  }
+
+  private File localBackupDataFile(int shuffleId, int mapId, long attemptId) {
+    return toLocalBackupFile(shuffleId, mapId, attemptId, "data");
+  }
+
+  private File localBackupIndexFile(int shuffleId, int mapId, long attemptId) {
+    return toLocalBackupFile(shuffleId, mapId, attemptId, "index");
+  }
+
+  private File toLocalBackupFile(int shuffleId, int mapId, long attemptId, String extension) {
+    java.nio.file.Path dataDir =
+        downloadedBackupsDir.toPath()
+            .resolve(String.format("shuffle=%d", shuffleId))
+            .resolve(String.format("map=%d", mapId))
+            .resolve(String.format("attempt=%d", attemptId));
+    if (!dataDir.toFile().isDirectory()) {
+      try {
+        Files.createDirectories(dataDir);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return dataDir.resolve(String.format("shuffle.%s", extension)).toFile();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/DefaultShuffleFileBatchUploader.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/DefaultShuffleFileBatchUploader.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import com.google.common.io.CountingOutputStream;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.palantir.logsafe.SafeArg;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.merger.FileMerger;
+import org.apache.spark.palantir.shuffle.async.metrics.MergingShuffleClientMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class DefaultShuffleFileBatchUploader implements ShuffleFileBatchUploader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      DefaultShuffleFileBatchUploader.class);
+
+  private final String appId;
+  private final ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+  private final MergingShuffleFiles shuffleFiles;
+  private final ListeningExecutorService uploadExecutor;
+  private final MergingShuffleClientMetrics events;
+  private final Clock clock;
+
+  public DefaultShuffleFileBatchUploader(
+      String appId,
+      ShuffleDriverEndpointRef shuffleDriverEndpointRef,
+      MergingShuffleFiles shuffleFiles,
+      ListeningExecutorService uploadExecutor,
+      MergingShuffleClientMetrics events,
+      Clock clock) {
+    this.appId = appId;
+    this.shuffleDriverEndpointRef = shuffleDriverEndpointRef;
+    this.shuffleFiles = shuffleFiles;
+    this.uploadExecutor = uploadExecutor;
+    this.events = events;
+    this.clock = clock;
+  }
+
+  @Override
+  public void submitBatchUpload(int shuffleId, ShuffleMapInputBatch batch) {
+    ListenableFuture<?> uploadTask = uploadExecutor.submit(() -> {
+      long timeSubmitted = batch.earliestInputTimestamp();
+      if (shuffleDriverEndpointRef.isShuffleRegistered(shuffleId)) {
+        long mergedOutputId = shuffleDriverEndpointRef.getNextMergeId();
+        ShuffleMapInput[] inputs = batch.inputBatch();
+        uploadMergedData(shuffleId, mergedOutputId, inputs, timeSubmitted);
+        uploadMergedIndices(shuffleId, mergedOutputId, inputs, timeSubmitted);
+
+        shuffleDriverEndpointRef.registerMergedMapOutput(
+            Arrays.stream(inputs).map(ShuffleMapInput::mapOutputId).collect(Collectors.toList()),
+            mergedOutputId);
+      }
+    });
+    Futures.addCallback(uploadTask, new UploadBatchFinishedListener(appId, batch), uploadExecutor);
+  }
+
+  private void uploadMergedIndices(
+      int shuffleId, long mergedOutputId, ShuffleMapInput[] inputs, long timeSubmitted) {
+    events.markUploadStarted(shuffleId, mergedOutputId, "index");
+    long startTime = clock.millis();
+    long bytesWritten;
+    CountingOutputStream resolvedCountingIndexOut = null;
+    try (OutputStream mergedOut = shuffleFiles.createRemoteMergedIndexFile(mergedOutputId);
+         CountingOutputStream countingIndexOut = new CountingOutputStream(mergedOut);
+         DataOutputStream mergedDataOut = new DataOutputStream(countingIndexOut)) {
+      FileMerger.mergeMapOutputs(inputs, mergedDataOut, ShuffleMapInput::indexSizedInput);
+      resolvedCountingIndexOut = countingIndexOut;
+    } catch (IOException e) {
+      events.markUploadFailed(shuffleId, mergedOutputId, "index");
+      throw new RuntimeException(e);
+    } finally {
+      bytesWritten = resolvedCountingIndexOut == null ? 0L : resolvedCountingIndexOut.getCount();
+    }
+    long now = clock.millis();
+    events.markUploadCompleted(
+        shuffleId,
+        mergedOutputId,
+        "index",
+        bytesWritten,
+        now - startTime,
+        now - timeSubmitted);
+  }
+
+  private void uploadMergedData(
+      int shuffleId, long mergedOutputId, ShuffleMapInput[] inputs, long timeSubmitted) {
+    events.markUploadStarted(shuffleId, mergedOutputId, "data");
+    long startTime = clock.millis();
+    long bytesWritten;
+    CountingOutputStream resolvedCountingDataOut = null;
+    try (OutputStream mergedOut = shuffleFiles.createRemoteMergedDataFile(mergedOutputId);
+         CountingOutputStream countingDataOut = new CountingOutputStream(mergedOut);
+         DataOutputStream mergedDataOut = new DataOutputStream(countingDataOut)) {
+      FileMerger.mergeMapOutputs(inputs, mergedDataOut, ShuffleMapInput::dataSizedInput);
+      resolvedCountingDataOut = countingDataOut;
+    } catch (IOException e) {
+      events.markUploadFailed(shuffleId, mergedOutputId, "data");
+      throw new RuntimeException(e);
+    } finally {
+      bytesWritten = resolvedCountingDataOut == null ? 0L : resolvedCountingDataOut.getCount();
+    }
+    long now = clock.millis();
+    events.markUploadCompleted(
+        shuffleId,
+        mergedOutputId,
+        "data",
+        bytesWritten,
+        clock.millis() - startTime,
+        now - timeSubmitted);
+  }
+
+  private static final class UploadBatchFinishedListener implements FutureCallback<Object> {
+    private final String appId;
+    private final ShuffleMapInputBatch batch;
+
+    UploadBatchFinishedListener(String appId, ShuffleMapInputBatch batch) {
+      this.batch = batch;
+      this.appId = appId;
+    }
+
+    @Override
+    public void onSuccess(Object _result) {
+      LOGGER.debug("Finished uploading batch of map task files.",
+          SafeArg.of("appId", appId),
+          SafeArg.of("uploadedMapOutputs", Arrays.asList(batch.mapOutputIds())),
+          SafeArg.of("uploadSize", batch.totalDataSizeInBytes()));
+    }
+
+    @Override
+    public void onFailure(Throwable error) {
+      LOGGER.error("Failed to upload shuffle files to the backing file system. If this executor" +
+              " fails, shuffle data will need to be recomputed.",
+          SafeArg.of("appId", appId),
+          SafeArg.of("failedMapOutputs", Arrays.asList(batch.mapOutputIds())),
+          SafeArg.of("batchDataSize", batch.totalDataSizeInBytes()),
+          SafeArg.of("numBatchItems", batch.inputBatch().length),
+          error);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingHadoopShuffleClientConfiguration.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingHadoopShuffleClientConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.client.BaseHadoopShuffleClientConfiguration;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleStorageStrategy;
+import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
+
+import org.immutables.value.Value;
+
+/**
+ * Extractor for properties that are specific to the merging shuffle storage strategy.
+ */
+@Value.Immutable
+@ImmutablesStyle
+public interface MergingHadoopShuffleClientConfiguration {
+
+  BaseHadoopShuffleClientConfiguration baseConfig();
+
+  @Value.Check
+  default void check() {
+    Preconditions.checkArgument(
+        baseConfig().storageStrategy() == ShuffleStorageStrategy.MERGING,
+        "Should only be using this configuration for the merging storage strategy.",
+        SafeArg.of("incompatibleStrategy", baseConfig().storageStrategy()));
+  }
+
+  @Value.Derived
+  default long maxBatchSizeBytes() {
+    return baseConfig().javaSparkConf().getLong(AsyncShuffleDataIoSparkConfigs.MERGED_BATCH_SIZE());
+  }
+
+  @Value.Derived
+  default long maxBatchAgeMillis() {
+    return baseConfig().javaSparkConf().getLong(
+        AsyncShuffleDataIoSparkConfigs.MERGED_BATCH_MAXIMUM_BUFFERED_AGE());
+  }
+
+  @Value.Derived
+  default int maxBufferedInputs() {
+    return baseConfig().javaSparkConf().getInt(
+        AsyncShuffleDataIoSparkConfigs.MERGING_MAX_BUFFERED_INPUTS());
+  }
+
+  @Value.Derived
+  default long pollingIntervalMillis() {
+    return baseConfig().javaSparkConf().getLong(
+        AsyncShuffleDataIoSparkConfigs.UPLOAD_POLLING_PERIOD());
+  }
+
+  @Value.Derived
+  default int readLocalDiskParallelism() {
+    return baseConfig().javaSparkConf().getInt(
+        AsyncShuffleDataIoSparkConfigs.READ_LOCAL_DISK_PARALLELISM());
+  }
+
+  static MergingHadoopShuffleClientConfiguration of(
+      BaseHadoopShuffleClientConfiguration baseConfig) {
+    return builder().baseConfig(baseConfig).build();
+  }
+
+  static ImmutableMergingHadoopShuffleClientConfiguration.Builder builder() {
+    return ImmutableMergingHadoopShuffleClientConfiguration.builder();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleFiles.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleFiles.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public interface MergingShuffleFiles {
+
+  SeekableInput getLocalBackupIndexFile(int shuffleId, int mapId, long attemptId);
+
+  SeekableInput getLocalBackupDataFile(int shuffleId, int mapId, long attemptId);
+
+  OutputStream createLocalBackupIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException;
+
+  OutputStream createLocalBackupDataFile(
+      int shuffleId, int mapId, long attemptId) throws IOException;
+
+  boolean doesLocalBackupDataFileExist(int shuffleId, int mapId, long attemptId);
+
+  boolean doesLocalBackupIndexFileExist(int shuffleId, int mapId, long attemptId);
+
+  default boolean doLocalBackupsExist(int shuffleId, int mapId, long attemptId) {
+    return doesLocalBackupDataFileExist(shuffleId, mapId, attemptId)
+        && doesLocalBackupIndexFileExist(shuffleId, mapId, attemptId);
+  }
+
+  InputStream openRemoteMergedIndexFile(long mergeId) throws IOException;
+
+  InputStream openRemoteMergedDataFile(long mergeId) throws IOException;
+
+  OutputStream createRemoteMergedIndexFile(long mergeId) throws IOException;
+
+  OutputStream createRemoteMergedDataFile(long mergeId) throws IOException;
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleUploadCoordinator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleUploadCoordinator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MergingShuffleUploadCoordinator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      MergingShuffleUploadCoordinator.class);
+
+  private final long maxBatchSizeBytes;
+  private final int maxBufferedInputs;
+  private final long maxBatchAgeMillis;
+  private final long pollingIntervalMillis;
+  // Mapped to the timestamp at which point the input was inserted into the map.
+  private final Map<ShuffleMapInput, Long> ungroupedMapInputs;
+  private final ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+  private final Map<Integer, ShuffleMapInputBatch> stagedBatches;
+  private final ListeningScheduledExecutorService uploadCoordinatorExecutor;
+  private final Clock clock;
+  private final ShuffleFileBatchUploader batchUploader;
+
+  private ScheduledFuture<?> uploadCoordinatorTask;
+  private int totalStagedInputs;
+
+  public MergingShuffleUploadCoordinator(
+      long maxBatchSizeBytes,
+      long maxBatchAgeMillis,
+      int maxBufferedInputs,
+      long pollingIntervalMillis,
+      ShuffleDriverEndpointRef shuffleDriverEndpointRef,
+      ListeningScheduledExecutorService uploadCoordinatorExecutor,
+      Clock clock,
+      ShuffleFileBatchUploader batchUploader) {
+    this.maxBatchSizeBytes = maxBatchSizeBytes;
+    this.maxBatchAgeMillis = maxBatchAgeMillis;
+    this.maxBufferedInputs = maxBufferedInputs;
+    this.pollingIntervalMillis = pollingIntervalMillis;
+    this.shuffleDriverEndpointRef = shuffleDriverEndpointRef;
+    this.stagedBatches = new HashMap<>();
+    this.uploadCoordinatorExecutor = uploadCoordinatorExecutor;
+    this.clock = clock;
+    this.batchUploader = batchUploader;
+    this.ungroupedMapInputs = new ConcurrentHashMap<>();
+    this.totalStagedInputs = 0;
+  }
+
+  public void start() {
+    if (uploadCoordinatorTask == null) {
+      uploadCoordinatorTask = uploadCoordinatorExecutor.scheduleWithFixedDelay(
+          this::uploadEligibleBatches,
+          pollingIntervalMillis,
+          pollingIntervalMillis,
+          TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public void stop() {
+    if (uploadCoordinatorTask != null) {
+      uploadCoordinatorTask.cancel(true);
+      uploadCoordinatorTask = null;
+    }
+  }
+
+  public void addShuffleMapInputForUpload(ShuffleMapInput inputForUpload) {
+    ungroupedMapInputs.put(inputForUpload, clock.millis());
+  }
+
+  private void uploadEligibleBatches() {
+    try {
+      Iterator<Map.Entry<ShuffleMapInput, Long>> viewIterator =
+          ungroupedMapInputs.entrySet().iterator();
+      while (viewIterator.hasNext()) {
+        Map.Entry<ShuffleMapInput, Long> nextInputWithTimestamp = viewIterator.next();
+        int shuffleId = nextInputWithTimestamp.getKey().mapOutputId().shuffleId();
+        if (shuffleDriverEndpointRef.isShuffleRegistered(shuffleId)) {
+          ShuffleMapInputBatch updatedBatch = stagedBatches.computeIfAbsent(
+              shuffleId,
+              ignored -> new ShuffleMapInputBatch())
+              .addInput(nextInputWithTimestamp.getKey(), nextInputWithTimestamp.getValue());
+          totalStagedInputs++;
+          if (updatedBatch.totalDataSizeInBytes() >= maxBatchSizeBytes) {
+            batchUploader.submitBatchUpload(shuffleId, updatedBatch);
+            removeBatch(shuffleId);
+          }
+        } else {
+          removeBatch(shuffleId);
+        }
+        viewIterator.remove();
+      }
+      Iterator<Map.Entry<Integer, ShuffleMapInputBatch>> stagedBatchesIt =
+          stagedBatches.entrySet().iterator();
+      // This is a hedge against an unbounded growth in the staged inputs, where we get a lot of
+      // tiny inputs in rapid succession such that waiting for the time-based trigger will cause
+      // the data structure to blow up the heap.
+      boolean forceUploadAll = totalStagedInputs > maxBufferedInputs;
+      while (stagedBatchesIt.hasNext()) {
+        Map.Entry<Integer, ShuffleMapInputBatch> stagedBatchEntry = stagedBatchesIt.next();
+        int shuffleId = stagedBatchEntry.getKey();
+        ShuffleMapInputBatch stagedBatch = stagedBatchEntry.getValue();
+        if (!shuffleDriverEndpointRef.isShuffleRegistered(shuffleId)) {
+          removeBatch(stagedBatchesIt, stagedBatch);
+        } else if (forceUploadAll || (stagedBatch.inputBatch().length > 0
+            && clock.millis() - stagedBatch.earliestInputTimestamp()
+            >= maxBatchAgeMillis)) {
+          batchUploader.submitBatchUpload(shuffleId, stagedBatch);
+          removeBatch(stagedBatchesIt, stagedBatch);
+        }
+      }
+      LOGGER.trace("Finished checking for uploading shuffle files to the backing store.");
+    } catch (Exception e) {
+      LOGGER.warn("Failed to process outstanding uploads for shuffle files.", e);
+    }
+  }
+
+  private void removeBatch(int shuffleId) {
+    Optional<ShuffleMapInputBatch> removedBatch = Optional.ofNullable(
+        stagedBatches.remove(shuffleId));
+    removedBatch.ifPresent(batch -> totalStagedInputs -= batch.inputBatch().length);
+  }
+
+  private void removeBatch(
+      Iterator<Map.Entry<Integer, ShuffleMapInputBatch>> it, ShuffleMapInputBatch removedBatch) {
+    it.remove();
+    totalStagedInputs -= removedBatch.inputBatch().length;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleFileBatchUploader.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleFileBatchUploader.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+public interface ShuffleFileBatchUploader {
+
+  void submitBatchUpload(int shuffleId, ShuffleMapInputBatch batch);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleMapInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleMapInput.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.SizedInput;
+
+public final class ShuffleMapInput {
+  private final MapOutputId mapOutputId;
+  private final SizedInput dataSizedInput;
+  private final SizedInput indexSizedInput;
+
+  public ShuffleMapInput(
+      MapOutputId mapOutputId,
+      SizedInput dataSizedInput,
+      SizedInput indexSizedInput) {
+    this.mapOutputId = mapOutputId;
+    this.dataSizedInput = dataSizedInput;
+    this.indexSizedInput = indexSizedInput;
+  }
+
+  @Override
+  public int hashCode() {
+    return mapOutputId.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof ShuffleMapInput
+        && this.mapOutputId.equals(((ShuffleMapInput) other).mapOutputId);
+  }
+
+  public MapOutputId mapOutputId() {
+    return mapOutputId;
+  }
+
+  public SizedInput dataSizedInput() {
+    return dataSizedInput;
+  }
+
+  public SizedInput indexSizedInput() {
+    return indexSizedInput;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleMapInputBatch.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleMapInputBatch.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+
+public final class ShuffleMapInputBatch {
+  private final List<ShuffleMapInput> inputBatch;
+  private long totalDataSizeInBytes;
+  private long earliestInputTimestamp;
+
+  ShuffleMapInputBatch() {
+    this.inputBatch = new ArrayList<>();
+    this.totalDataSizeInBytes = 0L;
+    this.earliestInputTimestamp = Long.MAX_VALUE;
+  }
+
+  public ShuffleMapInputBatch addInput(ShuffleMapInput newInput, long inputCreationTimestamp) {
+    inputBatch.add(newInput);
+    totalDataSizeInBytes += newInput.dataSizedInput().getStreamSizeInBytes();
+    earliestInputTimestamp = Long.min(earliestInputTimestamp, inputCreationTimestamp);
+    return this;
+  }
+
+  public ShuffleMapInput[] inputBatch() {
+    return inputBatch.toArray(new ShuffleMapInput[0]);
+  }
+
+  public MapOutputId[] mapOutputIds() {
+    return inputBatch.stream().map(ShuffleMapInput::mapOutputId).toArray(MapOutputId[]::new);
+  }
+
+  public long totalDataSizeInBytes() {
+    return totalDataSizeInBytes;
+  }
+
+  public long earliestInputTimestamp() {
+    return earliestInputTimestamp;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/DefaultShuffleFileLocator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/DefaultShuffleFileLocator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.File;
+
+import org.apache.spark.shuffle.IndexShuffleBlockResolver;
+
+public final class DefaultShuffleFileLocator implements ShuffleFileLocator {
+
+  private final IndexShuffleBlockResolver blockResolver;
+
+  public DefaultShuffleFileLocator(IndexShuffleBlockResolver blockResolver) {
+    this.blockResolver = blockResolver;
+  }
+
+  @Override
+  public File getDataFile(int shuffleId, int mapId) {
+    return blockResolver.getDataFile(shuffleId, mapId);
+  }
+
+  @Override
+  public File getIndexFile(int shuffleId, int mapId) {
+    return blockResolver.getIndexFile(shuffleId, mapId);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDataIo.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDataIo.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.util.function.Supplier;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker;
+import org.apache.spark.palantir.shuffle.async.util.Suppliers;
+import org.apache.spark.shuffle.api.ShuffleDataIO;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HadoopAsyncShuffleDataIo implements ShuffleDataIO {
+  private static final Logger log = LoggerFactory.getLogger(HadoopAsyncShuffleDataIo.class);
+
+  private final SparkConf sparkConf;
+  private final LocalDiskShuffleDataIO delegate;
+  private final Supplier<ShuffleDriverComponents> shuffleDriverComponentsSupplier;
+
+  public HadoopAsyncShuffleDataIo(SparkConf sparkConf) {
+    this.sparkConf = sparkConf;
+    this.delegate = new LocalDiskShuffleDataIO(sparkConf);
+    // HACK: this is a workaround until spark changes merge so that we only call
+    // shuffleDataIO.driver() in a single place
+    this.shuffleDriverComponentsSupplier = Suppliers.memoize(() ->
+        new HadoopAsyncShuffleDriverComponents(
+            delegate.driver(), new ShuffleStorageStateTracker()));
+  }
+
+  @Override
+  public ShuffleDriverComponents driver() {
+    log.info("Initializing shuffle driver");
+    return shuffleDriverComponentsSupplier.get();
+  }
+
+  @Override
+  public ShuffleExecutorComponents executor() {
+    log.info("Initializing shuffle executor");
+    return new HadoopAsyncShuffleExecutorComponents(sparkConf, delegate.executor());
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDataIo.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDataIo.java
@@ -30,6 +30,13 @@ import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Root of the plugin tree, that implements shuffle plugins proposed in SPARK-25299 via
+ * asynchronously backing up data to a remote storage system.
+ * <p>
+ * Throughout the plugin tree, we delegate operations to the local disk implementation. This makes
+ * it such that we don't have to re-invent the local disk work from scratch.
+ */
 public final class HadoopAsyncShuffleDataIo implements ShuffleDataIO {
   private static final Logger log = LoggerFactory.getLogger(HadoopAsyncShuffleDataIo.class);
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
@@ -63,6 +63,12 @@ public final class HadoopAsyncShuffleDriverComponents implements ShuffleDriverCo
     return delegate.initializeApplication();
   }
 
+  /**
+   * Called when the application is shutting down.
+   * <p>
+   * For now, we don't clear all the data on the remote storage layer. This is because the removal
+   * operation may be prohibitively expensive, particularly in the case of S3.
+   */
   @Override
   public void cleanupApplication() throws IOException {
     LOG.info("Cleaning up application data");
@@ -83,6 +89,13 @@ public final class HadoopAsyncShuffleDriverComponents implements ShuffleDriverCo
     delegate.removeShuffle(shuffleId, blocking);
   }
 
+  /**
+   * Called by the {@link org.apache.spark.MapOutputTracker} to determine if a block should be
+   * re-computed by a retried task.
+   * <p>
+   * The implementation will report that the block does not need to be recomputed if it can be
+   * fetched from remote storage.
+   */
   @Override
   public boolean checkIfMapOutputStoredOutsideExecutor(
       int shuffleId, int mapId, long mapTaskAttemptId) {

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import com.palantir.logsafe.SafeArg;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleUploadDriverEndpoint;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateVisitor;
+import org.apache.spark.rpc.RpcEndpoint;
+import org.apache.spark.rpc.RpcEnv;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.storage.BlockManagerId;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HadoopAsyncShuffleDriverComponents implements ShuffleDriverComponents {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HadoopAsyncShuffleDriverComponents.class);
+
+  private final ShuffleDriverComponents delegate;
+  private final ShuffleStorageStateTracker shuffleStorageStateTracker;
+
+  private RpcEndpoint shuffleUploadDriverEndpoint;
+
+  public HadoopAsyncShuffleDriverComponents(
+      ShuffleDriverComponents delegate,
+      ShuffleStorageStateTracker shuffleStorageStateTracker) {
+    this.delegate = delegate;
+    this.shuffleStorageStateTracker = shuffleStorageStateTracker;
+  }
+
+  @Override
+  public Map<String, String> initializeApplication() {
+    RpcEnv sparkRpcEnv = SparkEnv.get().rpcEnv();
+    shuffleUploadDriverEndpoint = new AsyncShuffleUploadDriverEndpoint(
+        sparkRpcEnv,
+        shuffleStorageStateTracker);
+    sparkRpcEnv.setupEndpoint(AsyncShuffleUploadDriverEndpoint.NAME(), shuffleUploadDriverEndpoint);
+    return delegate.initializeApplication();
+  }
+
+  @Override
+  public void cleanupApplication() throws IOException {
+    LOG.info("Cleaning up application data");
+    shuffleUploadDriverEndpoint.stop();
+    delegate.cleanupApplication();
+  }
+
+  @Override
+  public void registerShuffle(int shuffleId) throws IOException {
+    shuffleStorageStateTracker.registerShuffle(shuffleId);
+    delegate.registerShuffle(shuffleId);
+  }
+
+  @Override
+  public void removeShuffle(int shuffleId, boolean blocking) throws IOException {
+    LOG.info("Cleaning up shuffle data ", SafeArg.of("shuffleId", shuffleId));
+    shuffleStorageStateTracker.unregisterShuffle(shuffleId);
+    delegate.removeShuffle(shuffleId, blocking);
+  }
+
+  @Override
+  public boolean checkIfMapOutputStoredOutsideExecutor(
+      int shuffleId, int mapId, long mapTaskAttemptId) {
+    return shuffleStorageStateTracker.getShuffleStorageState(
+        new MapOutputId(shuffleId, mapId, mapTaskAttemptId))
+        .visit(new ShuffleStorageStateVisitor<Boolean>() {
+          @Override
+          public Boolean unregistered() {
+            return false;
+          }
+
+          @Override
+          public Boolean onExecutorOnly(BlockManagerId _executorLocation) {
+            return false;
+          }
+
+          @Override
+          public Boolean onExecutorAndRemote(
+              BlockManagerId _executorLocation, Optional<Long> _mergeId) {
+            return true;
+          }
+
+          @Override
+          public Boolean onRemoteOnly(Optional<Long> _mergeId) {
+            return true;
+          }
+        });
+  }
+
+  @Override
+  public boolean unregisterOutputOnHostOnFetchFailure() {
+    return delegate.unregisterOutputOnHostOnFetchFailure();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponents.java
@@ -56,9 +56,8 @@ public final class HadoopAsyncShuffleDriverComponents implements ShuffleDriverCo
   @Override
   public Map<String, String> initializeApplication() {
     RpcEnv sparkRpcEnv = SparkEnv.get().rpcEnv();
-    shuffleUploadDriverEndpoint = new AsyncShuffleUploadDriverEndpoint(
-        sparkRpcEnv,
-        shuffleStorageStateTracker);
+    shuffleUploadDriverEndpoint = AsyncShuffleUploadDriverEndpoint.create(
+        sparkRpcEnv, shuffleStorageStateTracker);
     sparkRpcEnv.setupEndpoint(AsyncShuffleUploadDriverEndpoint.NAME(), shuffleUploadDriverEndpoint);
     return delegate.initializeApplication();
   }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
@@ -155,7 +155,7 @@ public final class HadoopAsyncShuffleExecutorComponents implements ShuffleExecut
             serializerManager,
             compressionCodecSupplier.get(),
             shouldCompressShuffle,
-            resolvedMetrics.s3FetcherIteratorMetrics(),
+            resolvedMetrics.hadoopFetcherIteratorMetrics(),
             () -> Optional.ofNullable(TaskContext.get()),
             shuffleDriverEndpointRef,
             shuffleClientConf.preferDownloadFromHadoop()));

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
@@ -158,7 +158,7 @@ public final class HadoopAsyncShuffleExecutorComponents implements ShuffleExecut
             resolvedMetrics.s3FetcherIteratorMetrics(),
             () -> Optional.ofNullable(TaskContext.get()),
             shuffleDriverEndpointRef,
-            shuffleClientConf.preferDownloadFromS3()));
+            shuffleClientConf.preferDownloadFromHadoop()));
   }
 
   @Override

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import scala.compat.java8.OptionConverters;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.logsafe.SafeArg;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.TaskContext;
+import org.apache.spark.internal.config.package$;
+import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.io.CompressionCodec$;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleUploadDriverEndpoint;
+import org.apache.spark.palantir.shuffle.async.JavaShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.api.SparkShuffleApiConstants;
+import org.apache.spark.palantir.shuffle.async.client.BaseHadoopShuffleClientConfiguration;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClients;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetricsFactory;
+import org.apache.spark.palantir.shuffle.async.metrics.slf4j.Slf4JHadoopAsyncShuffleMetricsFactory;
+import org.apache.spark.palantir.shuffle.async.util.Suppliers;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.shuffle.IndexShuffleBlockResolver;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.util.RpcUtils;
+
+public final class HadoopAsyncShuffleExecutorComponents implements ShuffleExecutorComponents {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      HadoopAsyncShuffleExecutorComponents.class);
+
+  private final ShuffleExecutorComponents delegate;
+  private final SparkConf sparkConf;
+  private final Optional<Clock> customClock;
+  private final Optional<ExecutorService> customUploadExecutorService;
+  private final Optional<ExecutorService> customDownloadExecutorService;
+  private final Optional<ScheduledExecutorService> customUploadCoordinatorExecutorService;
+  private final Supplier<SparkEnv> sparkEnvSupplier;
+  private final Supplier<ShuffleFileLocator> shuffleFileLocatorSupplier;
+  private final Supplier<CompressionCodec> compressionCodecSupplier;
+  private final Supplier<HadoopAsyncShuffleMetricsFactory> metrics;
+
+  private SerializerManager serializerManager;
+  private Optional<ShuffleClient> maybeClient;
+  private boolean shouldCompressShuffle;
+  private ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+
+  // Read support is split off primarily to reduce the number of lines in the class.
+  private Optional<HadoopAsyncShuffleReadSupport> maybeReadSupport;
+
+  public HadoopAsyncShuffleExecutorComponents(
+      SparkConf sparkConf,
+      ShuffleExecutorComponents delegate) {
+    this(
+        sparkConf,
+        delegate,
+        Optional.empty(),
+        SparkEnv::get,
+        Suppliers.memoize(() -> new DefaultShuffleFileLocator(
+            new IndexShuffleBlockResolver(sparkConf, SparkEnv.get().blockManager()))),
+        Suppliers.memoize(() -> CompressionCodec$.MODULE$.createCodec(sparkConf)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  @VisibleForTesting
+  HadoopAsyncShuffleExecutorComponents(
+      SparkConf sparkConf,
+      ShuffleExecutorComponents delegate,
+      Optional<Clock> customClock,
+      Supplier<SparkEnv> sparkEnvSupplier,
+      Supplier<ShuffleFileLocator> shuffleFileLocatorSupplier,
+      Supplier<CompressionCodec> compressionCodecSupplier,
+      Optional<ExecutorService> customUploadExecutorService,
+      Optional<ExecutorService> customDownloadExecutorService,
+      Optional<ScheduledExecutorService> customUploadCoordinatorExecutorService,
+      Optional<Supplier<HadoopAsyncShuffleMetricsFactory>> metrics) {
+    this.sparkConf = sparkConf;
+    this.delegate = delegate;
+    this.customClock = customClock;
+    this.sparkEnvSupplier = sparkEnvSupplier;
+    this.shuffleFileLocatorSupplier = shuffleFileLocatorSupplier;
+    this.compressionCodecSupplier = compressionCodecSupplier;
+    this.customUploadExecutorService = customUploadExecutorService;
+    this.customDownloadExecutorService = customDownloadExecutorService;
+    this.customUploadCoordinatorExecutorService = customUploadCoordinatorExecutorService;
+    this.metrics = metrics.orElseGet(() -> this::loadMetricsFactory);
+  }
+
+  @Override
+  public void initializeExecutor(
+      String execAppId, String execId, Map<String, String> extraConfigs) {
+    delegate.initializeExecutor(execAppId, execId, extraConfigs);
+    SparkEnv sparkEnv = sparkEnvSupplier.get();
+    BaseHadoopShuffleClientConfiguration shuffleClientConf =
+        BaseHadoopShuffleClientConfiguration.of(sparkConf);
+    Clock resolvedClock = customClock.orElseGet(Clock::systemUTC);
+    shuffleDriverEndpointRef = createDriverEndpointRef(
+        sparkEnv, shuffleClientConf);
+    String appName = getShufflePluginAppName(sparkConf).orElse(execAppId);
+    HadoopAsyncShuffleMetrics resolvedMetrics = metrics.get().create(sparkConf, appName);
+    this.serializerManager = sparkEnv.serializerManager();
+    this.shouldCompressShuffle = (boolean) sparkConf.get(package$.MODULE$.SHUFFLE_COMPRESS());
+    this.maybeClient = ShuffleClients.builder()
+        .appId(execAppId)
+        .clock(resolvedClock)
+        .driverEndpointRef(shuffleDriverEndpointRef)
+        .customDownloadExecutorService(customDownloadExecutorService)
+        .customUploadExecutorService(customUploadExecutorService)
+        .customUploadCoordinatorExecutorService(customUploadCoordinatorExecutorService)
+        .sparkConf(sparkConf)
+        .metrics(resolvedMetrics)
+        .build();
+    resolvedMetrics.markUsingAsyncShuffleUploadPlugin();
+    this.maybeReadSupport = maybeClient.map(client ->
+        new HadoopAsyncShuffleReadSupport(
+            delegate,
+            client,
+            serializerManager,
+            compressionCodecSupplier.get(),
+            shouldCompressShuffle,
+            resolvedMetrics.s3FetcherIteratorMetrics(),
+            () -> Optional.ofNullable(TaskContext.get()),
+            shuffleDriverEndpointRef,
+            shuffleClientConf.preferDownloadFromS3()));
+  }
+
+  @Override
+  public ShuffleMapOutputWriter createMapOutputWriter(
+      int shuffleId, int mapId, long mapTaskAttemptId, int numPartitions) throws IOException {
+    LOG.debug("Created MapOutputWriter for shuffle partition with numPartitions",
+        SafeArg.of("shuffleId", shuffleId),
+        SafeArg.of("mapId", mapId),
+        SafeArg.of("attemptId", mapTaskAttemptId),
+        SafeArg.of("numPartitions", numPartitions));
+    ShuffleMapOutputWriter delegateWriter = delegate.createMapOutputWriter(
+        shuffleId, mapId, mapTaskAttemptId, numPartitions);
+    return maybeClient.<ShuffleMapOutputWriter>map(client ->
+        new HadoopAsyncShuffleMapOutputWriter(
+            delegateWriter,
+            client,
+            shuffleFileLocatorSupplier.get(),
+            shuffleDriverEndpointRef,
+            shuffleId,
+            mapId,
+            mapTaskAttemptId
+        ))
+        .orElse(delegateWriter);
+  }
+
+  @Override
+  public Iterable<ShuffleBlockInputStream> getPartitionReaders(
+      Iterable<ShuffleBlockInfo> blockMetadata) throws IOException {
+    if (maybeReadSupport.isPresent()) {
+      return maybeReadSupport.get().getPartitionReaders(blockMetadata);
+    } else {
+      return delegate.getPartitionReaders(blockMetadata);
+    }
+  }
+
+  @Override
+  public boolean shouldWrapPartitionReaderStream() {
+    // Both of these return false, but still check for presence to match pattern-wise and to
+    // future-proof against changes in the underlying local disk impl
+    if (maybeClient.isPresent()) {
+      return false;
+    } else {
+      return delegate.shouldWrapPartitionReaderStream();
+    }
+  }
+
+  private static ShuffleDriverEndpointRef createDriverEndpointRef(
+      SparkEnv sparkEnv, BaseHadoopShuffleClientConfiguration baseConfig) {
+    return new JavaShuffleDriverEndpointRef(
+        RpcUtils.makeDriverRef(
+            AsyncShuffleUploadDriverEndpoint.NAME(),
+            baseConfig.sparkConf(),
+            sparkEnv.rpcEnv()),
+        sparkEnv.blockManager().blockManagerId());
+  }
+
+  private HadoopAsyncShuffleMetricsFactory loadMetricsFactory() {
+    String factoryClassName = sparkConf.get(AsyncShuffleDataIoSparkConfigs.METRICS_FACTORY_CLASS());
+    try {
+      return Class.forName(factoryClassName)
+          .asSubclass(HadoopAsyncShuffleMetricsFactory.class)
+          .getDeclaredConstructor()
+          .newInstance();
+    } catch (Exception e) {
+      LOG.error("Failed to load async shuffle plugin's metrics factory specified by the Spark" +
+              "configuration. Falling back to SLF4J-logging based implementation.",
+          SafeArg.of("confKey", SparkShuffleApiConstants.METRICS_FACTORY_CLASS_CONF),
+          SafeArg.of("metricsFactoryClass", factoryClassName),
+          e);
+      return new Slf4JHadoopAsyncShuffleMetricsFactory();
+    }
+  }
+
+  private static Optional<String> getShufflePluginAppName(SparkConf sparkConf) {
+    return OptionConverters.toJava(sparkConf.get(AsyncShuffleDataIoSparkConfigs.APP_NAME()));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleMapOutputWriter.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleMapOutputWriter.java
@@ -29,6 +29,12 @@ import org.apache.spark.shuffle.api.MapOutputWriterCommitMessage;
 import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
 import org.apache.spark.shuffle.api.ShufflePartitionWriter;
 
+/**
+ * Implementation of {@link ShuffleMapOutputWriter} that delegates to a
+ * {@link org.apache.spark.shuffle.sort.io.LocalDiskShuffleMapOutputWriter} to write partitions
+ * to local disk, then kicks off an asynchronous backup task to upload the map output data and
+ * index files to remote storage.
+ */
 public final class HadoopAsyncShuffleMapOutputWriter implements ShuffleMapOutputWriter {
 
   private final ShuffleMapOutputWriter delegate;

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleMapOutputWriter.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleMapOutputWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.shuffle.api.MapOutputWriterCommitMessage;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+
+public final class HadoopAsyncShuffleMapOutputWriter implements ShuffleMapOutputWriter {
+
+  private final ShuffleMapOutputWriter delegate;
+  private final ShuffleClient shuffleClient;
+  private final ShuffleFileLocator shuffleFileLocator;
+  private final Set<ShufflePartitionWriter> shufflePartitionWriters;
+  private final ShuffleDriverEndpointRef shuffleDriverEndpointRef;
+  private final int shuffleId;
+  private final int mapId;
+  private final long attemptId;
+
+  public HadoopAsyncShuffleMapOutputWriter(
+      ShuffleMapOutputWriter delegate,
+      ShuffleClient shuffleClient,
+      ShuffleFileLocator shuffleFileLocator,
+      ShuffleDriverEndpointRef shuffleDriverEndpointRef, int shuffleId,
+      int mapId,
+      long attemptId) {
+    this.delegate = delegate;
+    this.shuffleClient = shuffleClient;
+    this.shuffleFileLocator = shuffleFileLocator;
+    this.shuffleDriverEndpointRef = shuffleDriverEndpointRef;
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+    this.attemptId = attemptId;
+    this.shufflePartitionWriters = new HashSet<>();
+  }
+
+  @Override
+  public ShufflePartitionWriter getPartitionWriter(int partitionId) throws IOException {
+    ShufflePartitionWriter writer = delegate.getPartitionWriter(partitionId);
+    shufflePartitionWriters.add(writer);
+    return writer;
+  }
+
+  @Override
+  public MapOutputWriterCommitMessage commitAllPartitions() throws IOException {
+    MapOutputWriterCommitMessage delegateCommitMessage = delegate.commitAllPartitions();
+
+    File dataFile = shuffleFileLocator.getDataFile(shuffleId, mapId);
+    File indexFile = shuffleFileLocator.getIndexFile(shuffleId, mapId);
+    shuffleDriverEndpointRef.registerLocallyWrittenMapOutput(new MapOutputId(
+        shuffleId, mapId, attemptId));
+    if (dataFile.exists()) {
+      shuffleClient.asyncWriteDataAndIndexFilesAndClose(
+          dataFile.toPath(),
+          indexFile.toPath(),
+          shuffleId,
+          mapId,
+          attemptId);
+    } else {
+      shuffleClient.asyncWriteIndexFileAndClose(
+          indexFile.toPath(),
+          shuffleId,
+          mapId,
+          attemptId);
+    }
+
+    return delegateCommitMessage;
+  }
+
+  @Override
+  public void abort(Throwable error) throws IOException {
+    delegate.abort(error);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
@@ -36,7 +36,7 @@ import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageState;
 import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateVisitor;
 import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
 import org.apache.spark.palantir.shuffle.async.reader.DefaultHadoopFetcherIteratorFactory;
-import org.apache.spark.palantir.shuffle.async.reader.ExecutorThenS3FetcherIterator;
+import org.apache.spark.palantir.shuffle.async.reader.ExecutorThenHadoopFetcherIterator;
 import org.apache.spark.serializer.SerializerManager;
 import org.apache.spark.shuffle.api.ShuffleBlockInfo;
 import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
@@ -132,7 +132,7 @@ public final class HadoopAsyncShuffleReadSupport {
     Iterable<ShuffleBlockInputStream> inputStreams = delegate.getPartitionReaders(
         shuffleBlocksFromExecutors);
     return () -> {
-      ExecutorThenS3FetcherIterator iterator = new ExecutorThenS3FetcherIterator(
+      ExecutorThenHadoopFetcherIterator iterator = new ExecutorThenHadoopFetcherIterator(
           shuffleId,
           inputStreams.iterator(),
           shuffleBlocksFromExecutors,
@@ -153,9 +153,9 @@ public final class HadoopAsyncShuffleReadSupport {
   private static final class FallbackToS3ShuffleCompletionIterator
       implements TaskCompletionListener {
 
-    private final ExecutorThenS3FetcherIterator fallbackToS3Iterator;
+    private final ExecutorThenHadoopFetcherIterator fallbackToS3Iterator;
 
-    FallbackToS3ShuffleCompletionIterator(ExecutorThenS3FetcherIterator fallbackToS3Iterator) {
+    FallbackToS3ShuffleCompletionIterator(ExecutorThenHadoopFetcherIterator fallbackToS3Iterator) {
       this.fallbackToS3Iterator = fallbackToS3Iterator;
     }
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
@@ -60,7 +60,8 @@ import org.slf4j.LoggerFactory;
  * {@link ExecutorThenHadoopFetcherIterator} that can read blocks from both buckets.
  * <p>
  * If {@link #preferDownloadFromHadoop} is set, blocks that could be fetched from either remote
- * storage or from executors are preferred to be fetched from the remote store.
+ * storage or from executors are preferred to be fetched from the remote store. Otherwise, we
+ * prefer downloading blocks from executors whenever possible.
  */
 public final class HadoopAsyncShuffleReadSupport {
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
@@ -172,7 +172,8 @@ public final class HadoopAsyncShuffleReadSupport {
 
     private final ExecutorThenHadoopFetcherIterator executorThenHadoopFetcherIterator;
 
-    ExecutorThenHadoopShuffleCompletionListener(ExecutorThenHadoopFetcherIterator executorThenHadoopFetcherIterator) {
+    ExecutorThenHadoopShuffleCompletionListener(
+        ExecutorThenHadoopFetcherIterator executorThenHadoopFetcherIterator) {
       this.executorThenHadoopFetcherIterator = executorThenHadoopFetcherIterator;
     }
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleReadSupport.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.spark.TaskContext;
+import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageState;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateVisitor;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+import org.apache.spark.palantir.shuffle.async.reader.DefaultHadoopFetcherIteratorFactory;
+import org.apache.spark.palantir.shuffle.async.reader.ExecutorThenS3FetcherIterator;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.util.TaskCompletionListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HadoopAsyncShuffleReadSupport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopAsyncShuffleReadSupport.class);
+
+  private final ShuffleExecutorComponents delegate;
+  private final ShuffleClient client;
+  private final SerializerManager serializerManager;
+  private final CompressionCodec compressionCodec;
+  private final boolean shouldCompressShuffle;
+  private final HadoopFetcherIteratorMetrics metrics;
+  private final Supplier<Optional<TaskContext>> taskContext;
+  private final ShuffleDriverEndpointRef driverEndpointRef;
+  private final boolean preferDownloadFromS3;
+
+  public HadoopAsyncShuffleReadSupport(
+      ShuffleExecutorComponents delegate,
+      ShuffleClient client,
+      SerializerManager serializerManager,
+      CompressionCodec compressionCodec,
+      boolean shouldCompressShuffle,
+      HadoopFetcherIteratorMetrics metrics,
+      Supplier<Optional<TaskContext>> taskContext,
+      ShuffleDriverEndpointRef driverEndpointRef,
+      boolean preferDownloadFromS3) {
+    this.delegate = delegate;
+    this.client = client;
+    this.serializerManager = serializerManager;
+    this.compressionCodec = compressionCodec;
+    this.shouldCompressShuffle = shouldCompressShuffle;
+    this.metrics = metrics;
+    this.taskContext = taskContext;
+    this.driverEndpointRef = driverEndpointRef;
+    this.preferDownloadFromS3 = preferDownloadFromS3;
+  }
+
+  public Iterable<ShuffleBlockInputStream> getPartitionReaders(
+      Iterable<ShuffleBlockInfo> blockMetadata) throws IOException {
+    LOG.debug("Creating s3 shuffle partition reader");
+    Iterator<ShuffleBlockInfo> blockInfoIterator = blockMetadata.iterator();
+    if (!blockInfoIterator.hasNext()) {
+      return ImmutableList.of();
+    }
+    final Set<ShuffleBlockInfo> shuffleBlocksFromExecutors = new HashSet<>();
+    final Set<ShuffleBlockInfo> shuffleBlocksFromRemote = new HashSet<>();
+    int shuffleId = blockInfoIterator.next().getShuffleId();
+    Map<MapOutputId, ShuffleStorageState> registeredMapOutputs = driverEndpointRef
+        .getShuffleStorageStates(shuffleId);
+    blockMetadata.forEach(blockInfo -> {
+      ShuffleStorageState blockStorageState = registeredMapOutputs.get(
+          new MapOutputId(
+              blockInfo.getShuffleId(),
+              blockInfo.getMapId(),
+              blockInfo.getMapTaskAttemptId()));
+      blockStorageState.visit(new ShuffleStorageStateVisitor<Set<ShuffleBlockInfo>>() {
+
+        @Override
+        public Set<ShuffleBlockInfo> unregistered() {
+          return shuffleBlocksFromExecutors;
+        }
+
+        @Override
+        public Set<ShuffleBlockInfo> onExecutorOnly(BlockManagerId _executorLocation) {
+          return shuffleBlocksFromExecutors;
+        }
+
+        @Override
+        public Set<ShuffleBlockInfo> onExecutorAndRemote(
+            BlockManagerId _executorLocation, Optional<Long> _mergeId) {
+          if (preferDownloadFromS3) {
+            return shuffleBlocksFromRemote;
+          } else {
+            return shuffleBlocksFromExecutors;
+          }
+        }
+
+        @Override
+        public Set<ShuffleBlockInfo> onRemoteOnly(Optional<Long> _mergeId) {
+          return shuffleBlocksFromRemote;
+        }
+      }).add(blockInfo);
+    });
+
+    Iterable<ShuffleBlockInputStream> inputStreams = delegate.getPartitionReaders(
+        shuffleBlocksFromExecutors);
+    return () -> {
+      ExecutorThenS3FetcherIterator iterator = new ExecutorThenS3FetcherIterator(
+          shuffleId,
+          inputStreams.iterator(),
+          shuffleBlocksFromExecutors,
+          shouldCompressShuffle,
+          serializerManager,
+          compressionCodec,
+          shuffleBlocksFromRemote,
+          new DefaultHadoopFetcherIteratorFactory(
+              client,
+              metrics),
+          driverEndpointRef);
+      taskContext.get().ifPresent(context ->
+          context.addTaskCompletionListener(new FallbackToS3ShuffleCompletionIterator(iterator)));
+      return iterator;
+    };
+  }
+
+  private static final class FallbackToS3ShuffleCompletionIterator
+      implements TaskCompletionListener {
+
+    private final ExecutorThenS3FetcherIterator fallbackToS3Iterator;
+
+    FallbackToS3ShuffleCompletionIterator(ExecutorThenS3FetcherIterator fallbackToS3Iterator) {
+      this.fallbackToS3Iterator = fallbackToS3Iterator;
+    }
+
+    @Override
+    @SuppressWarnings("StrictUnusedVariable")
+    public void onTaskCompletion(TaskContext context) {
+      this.fallbackToS3Iterator.cleanup();
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/PartitionDecoder.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/PartitionDecoder.java
@@ -29,6 +29,14 @@ import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Helper module for extracting partition index offsets and data blocks from shuffle data
+ * files and index files represented by {@link SeekableInput} streams.
+ * <p>
+ * Recall that shuffle data files are sequences of byte blocks - each byte block has a byte start
+ * index and a byte end index. An index file that is the companion of a data file indicates the byte
+ * start and end offsets where a partition data block starts and ends.
+ */
 public final class PartitionDecoder {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionDecoder.class);

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/PartitionDecoder.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/PartitionDecoder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class PartitionDecoder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionDecoder.class);
+
+  public static PartitionOffsets decodePartitionOffsets(SeekableInput index, int partitionId) {
+    long dataOffset;
+    long nextOffset;
+    try (InputStream indexInputStream = index.seekToAndOpen(partitionId * 8L, 16);
+         DataInputStream indexDataInputStream = new DataInputStream(indexInputStream)) {
+      dataOffset = indexDataInputStream.readLong();
+      nextOffset = indexDataInputStream.readLong();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return PartitionOffsets.of(dataOffset, nextOffset);
+  }
+
+  public static InputStream decodePartitionData(SeekableInput data, PartitionOffsets offsets) {
+    InputStream dataInputStream = null;
+    LimitedInputStream limitedDataInputStream = null;
+    try {
+      dataInputStream = data.seekToAndOpen(offsets.dataOffset(), offsets.length());
+      limitedDataInputStream = new LimitedInputStream(dataInputStream, offsets.length());
+    } catch (IOException e) {
+      closeQuietly(limitedDataInputStream, e);
+      closeQuietly(dataInputStream, e);
+      throw new RuntimeException(e);
+    }
+    return limitedDataInputStream;
+  }
+
+  public static InputStream decodePartition(
+      SeekableInput data, SeekableInput index, int partitionId) {
+    PartitionOffsets offsets = decodePartitionOffsets(index, partitionId);
+    return decodePartitionData(data, offsets);
+  }
+
+  private static void closeQuietly(Closeable closeable, IOException rootException) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (IOException e) {
+        rootException.addSuppressed(e);
+        LOGGER.warn("Error encountered when trying to close resource after an error occurred" +
+            " trying to read from it.", e);
+      }
+    }
+  }
+
+  private PartitionDecoder() {
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/ShuffleFileLocator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/ShuffleFileLocator.java
@@ -19,6 +19,9 @@ package org.apache.spark.palantir.shuffle.async.io;
 
 import java.io.File;
 
+/**
+ * Thin wrapper for locating local shuffle files that were written by Spark's map tasks.
+ */
 public interface ShuffleFileLocator {
 
   File getDataFile(int shuffleId, int mapId);

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/ShuffleFileLocator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/ShuffleFileLocator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.File;
+
+public interface ShuffleFileLocator {
+
+  File getDataFile(int shuffleId, int mapId);
+
+  File getIndexFile(int shuffleId, int mapId);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/merger/FileMerger.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/merger/FileMerger.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.merger;
+
+import com.google.common.io.ByteStreams;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.palantir.shuffle.async.client.merging.ShuffleMapInput;
+import org.apache.spark.palantir.shuffle.async.util.SizedInput;
+
+/**
+ * Utility for merging map output files together and for splicing a merged file into its original
+ * parts.
+ * <p>
+ * The merged file has the following format:
+ * <p>
+ * <code>
+ *   numMapOutputs
+ *   fileHeader1
+ *   file1Contents
+ *   fileHeader2
+ *   file2Contents
+ *   ...
+ *   fileHeaderN
+ *   fileNContents
+ *   EOF
+ * </code>
+ * <p>
+ * where each fileHeader has the format:
+ * <p>
+ * <code>fileMapId|fileMapAttemptId|fileSize</code>
+ * <p>
+ * and fileMapId is an integer, while fileSize is a long.
+ * <p>
+ * This would be used to merge both the data and the index files from map outputs.
+ */
+public final class FileMerger {
+
+  /**
+   * Combine an array of files and pushes the merged data to the provided output stream.
+   */
+  public static void mergeMapOutputs(
+      ShuffleMapInput[] inputs,
+      DataOutputStream mergedOutput,
+      Function<ShuffleMapInput, SizedInput> inputFileExtractor) throws IOException {
+    mergedOutput.writeInt(inputs.length);
+
+    for (ShuffleMapInput input : inputs) {
+      int shuffleId = input.mapOutputId().shuffleId();
+      int mapId = input.mapOutputId().mapId();
+      long attemptId = input.mapOutputId().mapAttemptId();
+      SizedInput stream = inputFileExtractor.apply(input);
+      mergedOutput.writeInt(shuffleId);
+      mergedOutput.writeInt(mapId);
+      mergedOutput.writeLong(attemptId);
+      mergedOutput.writeLong(stream.getStreamSizeInBytes());
+      if (stream.getStreamSizeInBytes() > 0L) {
+        try (InputStream inputStream = stream.openStream()) {
+          ByteStreams.copy(inputStream, mergedOutput);
+        }
+      }
+    }
+  }
+
+  /**
+   * Takes an input stream that provides bytes written by
+   * {@link #mergeMapOutputs(ShuffleMapInput[], DataOutputStream, Function)}, and extracts the
+   * bytes to their original split form.
+   * <p>
+   * This downloads all of the contents from the given input stream. This assumes that it is more
+   * optimal to fetch all the data to local disk before working with it. An alternative approach
+   * would be to only fetch the chunks of the merged data that are required, but this would result
+   * in multiple requests to the remote storage layer. It's worth investigating the alternative
+   * data access strategy in the future.
+   */
+  public static void fetchAndSplitMergedInput(
+      DataInputStream mergedInput,
+      MapOutputStreamProvider mapOutputStreamProvider) throws IOException {
+    int numMapIds = mergedInput.readInt();
+
+    for (int i = 0; i < numMapIds; i++) {
+      int shuffleId = mergedInput.readInt();
+      int mapId = mergedInput.readInt();
+      long attemptId = mergedInput.readLong();
+      long mapFileSize = mergedInput.readLong();
+      Optional<OutputStreamSupplier> maybeOutputStream =
+          mapOutputStreamProvider.getMapOutputStreamIfNotExists(shuffleId, mapId, attemptId);
+      if (maybeOutputStream.isPresent()) {
+        try (OutputStream mapOut = maybeOutputStream.get().openStream();
+             LimitedInputStream limitedInput = new LimitedInputStream(
+                 mergedInput, mapFileSize, false)) {
+          ByteStreams.copy(limitedInput, mapOut);
+        }
+      } else {
+        long skipped = mergedInput.skip(mapFileSize);
+        Preconditions.checkState(
+            skipped == mapFileSize,
+            "Unexpected number of bytes skipped during download when the local file" +
+                " already existed.",
+            SafeArg.of("expectedBytesToSkip", mapFileSize),
+            SafeArg.of("actualBytesSkipped", skipped));
+      }
+    }
+  }
+
+  @FunctionalInterface
+  public interface MapOutputStreamProvider {
+    Optional<OutputStreamSupplier> getMapOutputStreamIfNotExists(
+        int shuffleId, int mapId, long attemptId) throws IOException;
+  }
+
+  @FunctionalInterface
+  public interface OutputStreamSupplier {
+    OutputStream openStream() throws IOException;
+  }
+
+  private FileMerger() {
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/BasicShuffleClientMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/BasicShuffleClientMetrics.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics;
+
+public interface BasicShuffleClientMetrics {
+
+  void markDownloadStarted(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  void markDownloadCompleted(
+      int shuffleId, int mapId, int reduceId, long attemptId, long downloadDurationMillis);
+
+  void markUploadFailed(int shuffleId, int mapId, long attemptId, long numRunningOrPendingUploads);
+
+  void markUploadCompleted(
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long durationMillis,
+      long bytesUploaded,
+      long latencyMillis,
+      long numPendingOrRunningUploads);
+
+  void markUploadStarted(int shuffleId, int mapId, long attemptId);
+
+  void markUploadRequestSubmitted(
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long requestSubmissionLatencyMillis);
+
+  void markUploadRequested(
+      int shuffleId, int mapId, long attemptId, long numRunningOrPendingUploads);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetrics.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics;
+
+public interface HadoopAsyncShuffleMetrics {
+
+  void markUsingAsyncShuffleUploadPlugin();
+
+  BasicShuffleClientMetrics basicShuffleClientMetrics();
+
+  MergingShuffleClientMetrics mergingShuffleClientMetrics();
+
+  HadoopFetcherIteratorMetrics s3FetcherIteratorMetrics();
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetrics.java
@@ -25,5 +25,5 @@ public interface HadoopAsyncShuffleMetrics {
 
   MergingShuffleClientMetrics mergingShuffleClientMetrics();
 
-  HadoopFetcherIteratorMetrics s3FetcherIteratorMetrics();
+  HadoopFetcherIteratorMetrics hadoopFetcherIteratorMetrics();
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetricsFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetricsFactory.java
@@ -31,7 +31,6 @@ public interface HadoopAsyncShuffleMetricsFactory {
 
   /**
    * Instantiate a metrics system for measuring the performance of shuffle uploads and downloads.
-   * <p>
    *
    * @param sparkConf    The Spark configuration of the application.
    * @param sparkAppName The name of the application. Either the appId, or can be overridden by

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetricsFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopAsyncShuffleMetricsFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.api.SparkShuffleApiConstants;
+
+/**
+ * Entry point for collecting metrics from shuffle uploads.
+ * <p>
+ * Implementations are instantiated reflectively with a no-arg constructor. Specify the
+ * implementation class via {@link AsyncShuffleDataIoSparkConfigs#METRICS_FACTORY_CLASS()}.
+ */
+public interface HadoopAsyncShuffleMetricsFactory {
+
+  /**
+   * Instantiate a metrics system for measuring the performance of shuffle uploads and downloads.
+   * <p>
+   *
+   * @param sparkConf    The Spark configuration of the application.
+   * @param sparkAppName The name of the application. Either the appId, or can be overridden by
+   *                     {@link SparkShuffleApiConstants#SHUFFLE_PLUGIN_APP_NAME_CONF} to give a
+   *                     custom tag for metrics that are collected by the system.
+   */
+  HadoopAsyncShuffleMetrics create(SparkConf sparkConf, String sparkAppName);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopFetcherIteratorMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/HadoopFetcherIteratorMetrics.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics;
+
+public interface HadoopFetcherIteratorMetrics {
+
+  void markFetchFromRemoteFailed(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  void markFetchFromRemoteSucceeded(int shuffleId, int mapId, int reduceId, long attemptId);
+
+  void markFetchFromExecutorFailed(int shuffleId, int mapId, int reduceId, long attemptId);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/MergingShuffleClientMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/MergingShuffleClientMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics;
+
+public interface MergingShuffleClientMetrics {
+
+  void markDownloadFailed(int shuffleId, int mapId, long attemptId, long mergeId, String type);
+
+  void markDownloadCompleted(
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long mergeId,
+      String type,
+      long durationMillis);
+
+  void markDownloadStarted(int shuffleId, int mapId, long attemptId, long mergeId, String type);
+
+  void markDownloadRequested(int shuffleId, int mapId, long attemptId, long mergeId, String type);
+
+  void markUploadFailed(int shuffleId, long mergeId, String type);
+
+  void markUploadCompleted(
+      int shuffleId,
+      long mergeId,
+      String type,
+      long batchSizeBytes,
+      long durationMillis,
+      long latencyMillis);
+
+  void markUploadStarted(int shuffleId, long mergeId, String type);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Args.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Args.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import com.palantir.logsafe.SafeArg;
+
+final class Args {
+
+  static SafeArg<String> sparkAppNameArg(String sparkAppName) {
+    return SafeArg.of("sparkAppName", sparkAppName);
+  }
+
+  static SafeArg<Integer> shuffleIdArg(int shuffleId) {
+    return SafeArg.of("shuffleId", shuffleId);
+  }
+
+  static SafeArg<Integer> mapIdArg(int mapId) {
+    return SafeArg.of("mapId", mapId);
+  }
+
+  static SafeArg<Integer> reduceIdArg(int reduceId) {
+    return SafeArg.of("reduceId", reduceId);
+  }
+
+  static SafeArg<Long> attemptIdArg(long attemptId) {
+    return SafeArg.of("mapTaskAttemptId", attemptId);
+  }
+
+  static SafeArg<Long> durationMillisArg(long durationMillis) {
+    return SafeArg.of("durationMillis", durationMillis);
+  }
+
+  static SafeArg<Long> latencyMillisArg(long latencyMillis) {
+    return SafeArg.of("latencyMillis", latencyMillis);
+  }
+
+  private Args() {
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetrics.java
@@ -33,13 +33,13 @@ public final class Slf4JHadoopAsyncShuffleMetrics implements HadoopAsyncShuffleM
   private final String sparkAppName;
   private final Slf4jBasicShuffleClientMetrics basicShuffleClientMetrics;
   private final Slf4jMergingShuffleClientMetrics mergingShuffleClientMetrics;
-  private final Slf4JHadoopFetcherIteratorMetrics s3FetcherIteratorMetrics;
+  private final Slf4JHadoopFetcherIteratorMetrics hadoopFetcherIteratorMetrics;
 
   public Slf4JHadoopAsyncShuffleMetrics(String sparkAppName) {
     this.sparkAppName = sparkAppName;
     this.basicShuffleClientMetrics = new Slf4jBasicShuffleClientMetrics(sparkAppName);
     this.mergingShuffleClientMetrics = new Slf4jMergingShuffleClientMetrics(sparkAppName);
-    this.s3FetcherIteratorMetrics = new Slf4JHadoopFetcherIteratorMetrics(sparkAppName);
+    this.hadoopFetcherIteratorMetrics = new Slf4JHadoopFetcherIteratorMetrics(sparkAppName);
   }
 
   @Override
@@ -58,7 +58,7 @@ public final class Slf4JHadoopAsyncShuffleMetrics implements HadoopAsyncShuffleM
   }
 
   @Override
-  public HadoopFetcherIteratorMetrics s3FetcherIteratorMetrics() {
-    return s3FetcherIteratorMetrics;
+  public HadoopFetcherIteratorMetrics hadoopFetcherIteratorMetrics() {
+    return hadoopFetcherIteratorMetrics;
   }
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetrics.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import org.apache.spark.palantir.shuffle.async.metrics.BasicShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.MergingShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Slf4JHadoopAsyncShuffleMetrics implements HadoopAsyncShuffleMetrics {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      Slf4JHadoopAsyncShuffleMetrics.class);
+
+  private final String sparkAppName;
+  private final Slf4jBasicShuffleClientMetrics basicShuffleClientMetrics;
+  private final Slf4jMergingShuffleClientMetrics mergingShuffleClientMetrics;
+  private final Slf4JHadoopFetcherIteratorMetrics s3FetcherIteratorMetrics;
+
+  public Slf4JHadoopAsyncShuffleMetrics(String sparkAppName) {
+    this.sparkAppName = sparkAppName;
+    this.basicShuffleClientMetrics = new Slf4jBasicShuffleClientMetrics(sparkAppName);
+    this.mergingShuffleClientMetrics = new Slf4jMergingShuffleClientMetrics(sparkAppName);
+    this.s3FetcherIteratorMetrics = new Slf4JHadoopFetcherIteratorMetrics(sparkAppName);
+  }
+
+  @Override
+  public void markUsingAsyncShuffleUploadPlugin() {
+    LOGGER.info("Using the async shuffle upload plugin.", Args.sparkAppNameArg(sparkAppName));
+  }
+
+  @Override
+  public BasicShuffleClientMetrics basicShuffleClientMetrics() {
+    return basicShuffleClientMetrics;
+  }
+
+  @Override
+  public MergingShuffleClientMetrics mergingShuffleClientMetrics() {
+    return mergingShuffleClientMetrics;
+  }
+
+  @Override
+  public HadoopFetcherIteratorMetrics s3FetcherIteratorMetrics() {
+    return s3FetcherIteratorMetrics;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetricsFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetricsFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetricsFactory;
+
+public final class Slf4JHadoopAsyncShuffleMetricsFactory
+    implements HadoopAsyncShuffleMetricsFactory {
+
+  @Override
+  public HadoopAsyncShuffleMetrics create(SparkConf _sparkConf, String sparkAppName) {
+    return new Slf4JHadoopAsyncShuffleMetrics(sparkAppName);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetricsFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopAsyncShuffleMetricsFactory.java
@@ -21,6 +21,9 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
 import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetricsFactory;
 
+/**
+ * Root of the default implementation of metrics recording that simply logs metrics via SLF4J.
+ */
 public final class Slf4JHadoopAsyncShuffleMetricsFactory
     implements HadoopAsyncShuffleMetricsFactory {
 

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopFetcherIteratorMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4JHadoopFetcherIteratorMetrics.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import com.palantir.logsafe.SafeArg;
+
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Slf4JHadoopFetcherIteratorMetrics implements HadoopFetcherIteratorMetrics {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      Slf4JHadoopFetcherIteratorMetrics.class);
+
+  private final SafeArg<String> sparkAppNameArg;
+
+  public Slf4JHadoopFetcherIteratorMetrics(String sparkAppName) {
+    this.sparkAppNameArg = Args.sparkAppNameArg(sparkAppName);
+  }
+
+  @Override
+  public void markFetchFromRemoteFailed(int shuffleId, int mapId, int reduceId, long attemptId) {
+    LOGGER.info("Failed to fetch shuffle blocks from remote storage.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.reduceIdArg(reduceId),
+        Args.attemptIdArg(attemptId));
+  }
+
+  @Override
+  public void markFetchFromRemoteSucceeded(int shuffleId, int mapId, int reduceId, long attemptId) {
+    LOGGER.info("Successfully fetched shuffle blocks from remote storage.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.reduceIdArg(reduceId),
+        Args.attemptIdArg(attemptId));
+  }
+
+  @Override
+  public void markFetchFromExecutorFailed(int shuffleId, int mapId, int reduceId, long attemptId) {
+    LOGGER.info("Failed to fetch shuffle blocks from other executors in the application.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.reduceIdArg(reduceId),
+        Args.attemptIdArg(attemptId));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4jBasicShuffleClientMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4jBasicShuffleClientMetrics.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import com.palantir.logsafe.SafeArg;
+
+import org.apache.spark.palantir.shuffle.async.metrics.BasicShuffleClientMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Slf4jBasicShuffleClientMetrics implements BasicShuffleClientMetrics {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      Slf4jBasicShuffleClientMetrics.class);
+
+  private final SafeArg<String> sparkAppNameArg;
+
+  public Slf4jBasicShuffleClientMetrics(String sparkAppName) {
+    this.sparkAppNameArg = Args.sparkAppNameArg(sparkAppName);
+  }
+
+  @Override
+  public void markDownloadStarted(int shuffleId, int mapId, int reduceId, long attemptId) {
+    LOGGER.info("Starting to download shuffle block from remote storage.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.reduceIdArg(reduceId),
+        Args.attemptIdArg(attemptId));
+  }
+
+  @Override
+  public void markDownloadCompleted(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long attemptId,
+      long downloadDurationMillis) {
+    LOGGER.info("Finished downloading shuffle block from remote storage.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.reduceIdArg(reduceId),
+        Args.attemptIdArg(attemptId),
+        Args.durationMillisArg(downloadDurationMillis));
+  }
+
+  @Override
+  public void markUploadRequested(
+      int shuffleId, int mapId, long attemptId, long numRunningOrPendingUploads) {
+    LOGGER.info("Requested to upload map output file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        numRunningOrPendingUploadsArg(numRunningOrPendingUploads));
+  }
+
+  @Override
+  public void markUploadRequestSubmitted(
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long requestSubmissionLatencyMillis) {
+    LOGGER.info("Requested to upload map output file was submitted to the thread pool.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        SafeArg.of("requestSubmissionLatencyMillis", requestSubmissionLatencyMillis));
+  }
+
+  @Override
+  public void markUploadStarted(int shuffleId, int mapId, long attemptId) {
+    LOGGER.info("Beginning to upload shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId));
+  }
+
+  @Override
+  public void markUploadFailed(
+      int shuffleId, int mapId, long attemptId, long numRunningOrPendingUploads) {
+    LOGGER.info("Failed to upload shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        numRunningOrPendingUploadsArg(numRunningOrPendingUploads));
+  }
+
+  @Override
+  public void markUploadCompleted(
+      int shuffleId,
+      int mapId,
+      long attemptId,
+      long durationMillis,
+      long bytesUploaded,
+      long latencyMillis,
+      long numRunningOrPendingUploads) {
+    LOGGER.info("Finished uploading shuffle map output file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        Args.durationMillisArg(durationMillis),
+        SafeArg.of("bytesUploaded", bytesUploaded),
+        Args.latencyMillisArg(latencyMillis),
+        numRunningOrPendingUploadsArg(numRunningOrPendingUploads));
+  }
+
+  private static SafeArg<Long> numRunningOrPendingUploadsArg(long numRunningOrPendingUploads) {
+    return SafeArg.of("numRunningOrPendingUploads", numRunningOrPendingUploads);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4jMergingShuffleClientMetrics.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/metrics/slf4j/Slf4jMergingShuffleClientMetrics.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metrics.slf4j;
+
+import com.palantir.logsafe.SafeArg;
+
+import org.apache.spark.palantir.shuffle.async.metrics.MergingShuffleClientMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Slf4jMergingShuffleClientMetrics implements MergingShuffleClientMetrics {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      Slf4jMergingShuffleClientMetrics.class);
+
+  private final SafeArg<String> sparkAppNameArg;
+
+  public Slf4jMergingShuffleClientMetrics(String sparkAppName) {
+    sparkAppNameArg = Args.sparkAppNameArg(sparkAppName);
+  }
+
+  @Override
+  public void markDownloadRequested(
+      int shuffleId, int mapId, long attemptId, long mergeId, String type) {
+    LOGGER.info("Requested download of merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type));
+  }
+
+  @Override
+  public void markDownloadStarted(
+      int shuffleId, int mapId, long attemptId, long mergeId, String type) {
+    LOGGER.info("Started download of merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type));
+  }
+
+  @Override
+  public void markDownloadFailed(
+      int shuffleId, int mapId, long attemptId, long mergeId, String type) {
+    LOGGER.info("Failed download of merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type));
+  }
+
+  @Override
+  public void markDownloadCompleted(
+      int shuffleId, int mapId, long attemptId, long mergeId, String type, long durationMillis) {
+    LOGGER.info("Finished download of merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        Args.mapIdArg(mapId),
+        Args.attemptIdArg(attemptId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type),
+        Args.durationMillisArg(durationMillis));
+  }
+
+  @Override
+  public void markUploadFailed(int shuffleId, long mergeId, String type) {
+    LOGGER.info("Failed to upload merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type));
+  }
+
+  @Override
+  public void markUploadCompleted(
+      int shuffleId,
+      long mergeId,
+      String type,
+      long batchSizeBytes,
+      long durationMillis,
+      long latencyMillis) {
+    LOGGER.info("Successfully uploaded merged shuffle file.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type),
+        SafeArg.of("batchSizeBytes", batchSizeBytes),
+        Args.durationMillisArg(durationMillis),
+        Args.latencyMillisArg(latencyMillis));
+  }
+
+  @Override
+  public void markUploadStarted(int shuffleId, long mergeId, String type) {
+    LOGGER.info("Started merged shuffle file upload.",
+        sparkAppNameArg,
+        Args.shuffleIdArg(shuffleId),
+        mergeIdArg(mergeId),
+        fileTypeArg(type));
+  }
+
+  private static SafeArg<Long> mergeIdArg(long mergeId) {
+    return SafeArg.of("mergeId", mergeId);
+  }
+
+  private static SafeArg<String> fileTypeArg(String fileType) {
+    return SafeArg.of("fileType", fileType);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIterator.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.palantir.shuffle.async.FetchFailedExceptionThrower;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+import org.apache.spark.palantir.shuffle.async.util.Suppliers;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.storage.BlockId;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockId;
+
+public final class DefaultHadoopFetcherIterator implements HadoopFetcherIterator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHadoopFetcherIterator.class);
+
+  private final BlockingQueue<BlockDataResult> fetchResults;
+  private final ShuffleClient client;
+  private final AtomicInteger streamCount;
+  private final HadoopFetcherIteratorMetrics metrics;
+
+  private final Collection<ShuffleBlockInfo> blocksToFetch;
+  private final Map<ShuffleBlockId, ListenableFuture<BlockDataResult>> activeFetchRequests;
+
+  public DefaultHadoopFetcherIterator(
+      ShuffleClient client,
+      Collection<ShuffleBlockInfo> blocksToFech,
+      HadoopFetcherIteratorMetrics metrics) {
+    this.fetchResults = Queues.newLinkedBlockingQueue();
+    this.activeFetchRequests = new ConcurrentHashMap<>();
+    this.client = client;
+    this.streamCount = new AtomicInteger();
+    this.metrics = metrics;
+    this.blocksToFetch = blocksToFech;
+  }
+
+  void fetchDataFromS3() {
+    // Find all blocks that were not yet successfully fetched from the executors.
+    blocksToFetch.forEach(shuffleBlockInfo -> {
+      // Request all remaining blocks from remote storage.
+      // Not necessarily 100% accurate - for example, there may be other executors
+      // remaining where we could have fetched the data from. But:
+
+      // 1. The lifecycle of using the underlying iterator that fetches from other
+      //    executors, is more or less unpredictable after a fetch failure. And,
+      // 2. It's better to go to remote storage excessively, than attempting to fetch blocks
+      //    from any executors that might be down at all - since attempting to fetch from
+      //    dead executors requires waiting for a costly timeout
+      fetchBlock(shuffleBlockInfo);
+      metrics.markFetchFromExecutorFailed(
+          shuffleBlockInfo.getShuffleId(),
+          shuffleBlockInfo.getMapId(),
+          shuffleBlockInfo.getReduceId(),
+          shuffleBlockInfo.getMapTaskAttemptId());
+    });
+  }
+
+  private void fetchBlock(ShuffleBlockInfo shuffleBlockInfo) {
+    int shuffleId = shuffleBlockInfo.getShuffleId();
+    int mapId = shuffleBlockInfo.getMapId();
+    int reduceId = shuffleBlockInfo.getReduceId();
+    long attemptId = shuffleBlockInfo.getMapTaskAttemptId();
+
+    streamCount.incrementAndGet();
+    ShuffleBlockId shuffleBlockId = ShuffleBlockId.apply(shuffleId, mapId, reduceId);
+    ListenableFuture<BlockDataResult> fetchFuture =
+        Futures.withFallback(
+            Futures.transform(client.getBlockData(shuffleId, mapId, reduceId, attemptId),
+                (Function<Supplier<InputStream>, BlockDataResult>) stream -> {
+                  LOG.info("Successfully opened input stream for map output from remote storage.",
+                      SafeArg.of("shuffleId", shuffleId),
+                      SafeArg.of("mapId", mapId),
+                      SafeArg.of("reduceId", reduceId),
+                      SafeArg.of("attemptId", attemptId));
+                  metrics.markFetchFromRemoteSucceeded(shuffleId, mapId, reduceId, attemptId);
+                  return BlockDataSuccessResult.of(Suppliers.compose(
+                      stream,
+                      resolvedStream ->
+                          new ShuffleBlockInputStream(shuffleBlockId, resolvedStream)));
+                }),
+            error -> {
+              LOG.error("Failed to get stream for map output from remote storage.",
+                  SafeArg.of("shuffleId", shuffleId),
+                  SafeArg.of("mapId", mapId),
+                  SafeArg.of("reduceId", reduceId),
+                  SafeArg.of("attemptId", attemptId),
+                  error);
+              metrics.markFetchFromRemoteFailed(shuffleId, mapId, reduceId, attemptId);
+              return Futures.immediateFuture(
+                  BlockDataErrorResult.builder()
+                      .error(error)
+                      .shuffleBlockId(shuffleBlockId)
+                      .blockManagerId(shuffleBlockInfo.getShuffleLocation().get())
+                      .build());
+            });
+    activeFetchRequests.put(shuffleBlockId, fetchFuture);
+    Futures.addCallback(fetchFuture, new FutureCallback<BlockDataResult>() {
+
+      @Override
+      public void onSuccess(BlockDataResult result) {
+        fetchResults.add(result);
+        LOG.debug("Successfully added block data result to queue.");
+      }
+
+      @Override
+      public void onFailure(Throwable error) {
+        LOG.error("Failed to create block data result.", error);
+      }
+    });
+  }
+
+  @Override
+  public void cleanup() {
+    // cancel all active things
+    LOG.info("Cleaning up the DefaultHadoopFetcherIterator");
+    AtomicInteger numFuturesCancelled = new AtomicInteger();
+    activeFetchRequests.values().forEach(future -> {
+      if (!future.isDone()) {
+        future.cancel(true);
+        numFuturesCancelled.addAndGet(1);
+      }
+    });
+    blocksToFetch.forEach(block -> client.deleteDownloadedBlockData(
+        block.getShuffleId(), block.getMapId(), block.getReduceId(), block.getMapTaskAttemptId()));
+  }
+
+  @Override
+  public boolean hasNext() {
+    return streamCount.get() > 0;
+  }
+
+  @Override
+  public ShuffleBlockInputStream next() {
+    if (streamCount.getAndDecrement() > 0) {
+      try {
+        BlockDataResult result = fetchResults.take();
+        activeFetchRequests.remove(result.getShuffleBlockId());
+        return result.getResult().get();
+      } catch (InterruptedException e) {
+        LOG.error("Error encountered while waiting for InputStream to become available", e);
+        throw new SafeRuntimeException(e);
+      }
+    }
+    throw new SafeRuntimeException("Next should not be called because iterator is empty");
+  }
+
+  interface BlockDataResult {
+    ShuffleBlockId getShuffleBlockId();
+
+    Supplier<ShuffleBlockInputStream> getResult();
+  }
+
+  @Value.Immutable
+  @ImmutablesStyle
+  abstract static class BlockDataSuccessResult implements BlockDataResult {
+    abstract Supplier<ShuffleBlockInputStream> blockDataStream();
+
+    @Override
+    public ShuffleBlockId getShuffleBlockId() {
+      return toShuffleBlockId(blockDataStream().get().getBlockId());
+    }
+
+    @Override
+    public final Supplier<ShuffleBlockInputStream> getResult() {
+      return blockDataStream();
+    }
+
+    static BlockDataSuccessResult of(Supplier<ShuffleBlockInputStream> blockDataStream) {
+      return builder().blockDataStream(blockDataStream).build();
+    }
+
+    static ImmutableBlockDataSuccessResult.Builder builder() {
+      return ImmutableBlockDataSuccessResult.builder();
+    }
+  }
+
+  @Value.Immutable
+  @ImmutablesStyle
+  abstract static class BlockDataErrorResult implements BlockDataResult {
+    abstract Throwable error();
+
+    abstract ShuffleBlockId shuffleBlockId();
+
+    abstract BlockManagerId blockManagerId();
+
+    @Override
+    public ShuffleBlockId getShuffleBlockId() {
+      return shuffleBlockId();
+    }
+
+    @Override
+    public final Supplier<ShuffleBlockInputStream> getResult() {
+      // The below actually throws an error - but since FetchFailedException is a checked
+      // exception, run Scala code to throw this exception and bypass the need to declare
+      // throws or catch and wrap with RuntimeException. We have to throw exactly a
+      // FetchFailedException and cannot wrap that exception in anything else.
+      return FetchFailedExceptionThrower.throwFetchFailedException(
+          shuffleBlockId().shuffleId(),
+          shuffleBlockId().mapId(),
+          shuffleBlockId().reduceId(),
+          blockManagerId(),
+          "Exception thrown when fetching data from remote storage.",
+          error());
+    }
+
+    static ImmutableBlockDataErrorResult.Builder builder() {
+      return ImmutableBlockDataErrorResult.builder();
+    }
+  }
+
+  private static ShuffleBlockId toShuffleBlockId(BlockId blockId) {
+    if (blockId instanceof ShuffleBlockId) {
+      return (ShuffleBlockId) blockId;
+    }
+    throw new SafeRuntimeException("Expected block id to be of instance ShuffleBLockAttemptId");
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIterator.java
@@ -54,7 +54,7 @@ import org.apache.spark.storage.ShuffleBlockId;
  * <p>
  * Download requests are immediately pushed to the backing
  * {@link org.apache.spark.palantir.shuffle.async.client.basic.HadoopShuffleClient} in
- * {@link #fetchDataFromS3()}. As each result is returned from the shuffle client, it is pushed
+ * {@link #fetchDataFromHadoop()}. As each result is returned from the shuffle client, it is pushed
  * onto a blocking queue. Calls to {@link #next} block on a result to become available. Thus this
  * implementation is a classic case of the producer-consumer paradigm.
  * <p>
@@ -89,7 +89,7 @@ public final class DefaultHadoopFetcherIterator implements HadoopFetcherIterator
     this.blocksToFetch = blocksToFech;
   }
 
-  void fetchDataFromS3() {
+  void fetchDataFromHadoop() {
     // Find all blocks that were not yet successfully fetched from the executors.
     blocksToFetch.forEach(shuffleBlockInfo -> {
       // Request all remaining blocks from remote storage.

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import java.util.Collection;
+
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+
+public final class DefaultHadoopFetcherIteratorFactory implements HadoopFetcherIteratorFactory {
+
+  private final ShuffleClient shuffleClient;
+  private final HadoopFetcherIteratorMetrics metrics;
+
+  public DefaultHadoopFetcherIteratorFactory(
+      ShuffleClient shuffleClient,
+      HadoopFetcherIteratorMetrics metrics) {
+    this.shuffleClient = shuffleClient;
+    this.metrics = metrics;
+  }
+
+  @Override
+  public HadoopFetcherIterator createFetcherIteratorForBlocks(
+      Collection<ShuffleBlockInfo> blocks) {
+    DefaultHadoopFetcherIterator iterator = new DefaultHadoopFetcherIterator(
+        shuffleClient,
+        blocks,
+        metrics);
+    iterator.fetchDataFromS3();
+    return iterator;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorFactory.java
@@ -42,7 +42,7 @@ public final class DefaultHadoopFetcherIteratorFactory implements HadoopFetcherI
         shuffleClient,
         blocks,
         metrics);
-    iterator.fetchDataFromS3();
+    iterator.fetchDataFromHadoop();
     return iterator;
   }
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIterator.java
@@ -49,9 +49,10 @@ import org.apache.spark.storage.ShuffleIndexBlockId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class ExecutorThenS3FetcherIterator implements Iterator<ShuffleBlockInputStream> {
+public final class ExecutorThenHadoopFetcherIterator implements Iterator<ShuffleBlockInputStream> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ExecutorThenS3FetcherIterator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(
+      ExecutorThenHadoopFetcherIterator.class);
 
   private final Iterator<ShuffleBlockInputStream> fetchFromExecutorsIterator;
   private final HadoopFetcherIteratorFactory hadoopFetcherIteratorFactory;
@@ -64,7 +65,7 @@ public final class ExecutorThenS3FetcherIterator implements Iterator<ShuffleBloc
 
   private HadoopFetcherIterator hadoopFetcherIterator = null;
 
-  public ExecutorThenS3FetcherIterator(
+  public ExecutorThenHadoopFetcherIterator(
       int shuffleId,
       Iterator<ShuffleBlockInputStream> fetchFromExecutorsIterator,
       Set<ShuffleBlockInfo> shuffleBlocksFromExecutor,

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenS3FetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenS3FetcherIterator.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import com.google.common.collect.Maps;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.spark.TaskContext;
+import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageState;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateVisitor;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.shuffle.FetchFailedException;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.storage.BlockId;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockAttemptId;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.apache.spark.storage.ShuffleDataBlockId;
+import org.apache.spark.storage.ShuffleIndexBlockId;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ExecutorThenS3FetcherIterator implements Iterator<ShuffleBlockInputStream> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorThenS3FetcherIterator.class);
+
+  private final Iterator<ShuffleBlockInputStream> fetchFromExecutorsIterator;
+  private final HadoopFetcherIteratorFactory hadoopFetcherIteratorFactory;
+  private final Map<ShuffleBlockId, ShuffleBlockInfo> remainingAttemptsByBlock;
+  private final boolean shouldCompressShuffle;
+  private final SerializerManager serializerManager;
+  private final CompressionCodec compressionCodec;
+  private final ShuffleDriverEndpointRef driverEndpointRef;
+  private final int shuffleId;
+
+  private HadoopFetcherIterator hadoopFetcherIterator = null;
+
+  public ExecutorThenS3FetcherIterator(
+      int shuffleId,
+      Iterator<ShuffleBlockInputStream> fetchFromExecutorsIterator,
+      Set<ShuffleBlockInfo> shuffleBlocksFromExecutor,
+      boolean shouldCompressShuffle,
+      SerializerManager serializerManager,
+      CompressionCodec compressionCodec,
+      Set<ShuffleBlockInfo> shuffleBlocksFromRemote,
+      HadoopFetcherIteratorFactory hadoopFetcherIteratorFactory,
+      ShuffleDriverEndpointRef driverEndpointRef) {
+    this.shuffleId = shuffleId;
+    this.fetchFromExecutorsIterator = fetchFromExecutorsIterator;
+    this.shouldCompressShuffle = shouldCompressShuffle;
+    this.serializerManager = serializerManager;
+    this.compressionCodec = compressionCodec;
+    this.remainingAttemptsByBlock =
+        Maps.newHashMapWithExpectedSize(
+            shuffleBlocksFromExecutor.size() + shuffleBlocksFromRemote.size());
+    shuffleBlocksFromExecutor.forEach(block -> remainingAttemptsByBlock.put(
+        new ShuffleBlockId(block.getShuffleId(), block.getMapId(), block.getReduceId()),
+        block));
+    shuffleBlocksFromRemote.forEach(block -> remainingAttemptsByBlock.put(
+        new ShuffleBlockId(block.getShuffleId(), block.getMapId(), block.getReduceId()),
+        block));
+    this.hadoopFetcherIteratorFactory = hadoopFetcherIteratorFactory;
+    this.driverEndpointRef = driverEndpointRef;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !remainingAttemptsByBlock.isEmpty();
+  }
+
+  @Override
+  public ShuffleBlockInputStream next() {
+    ShuffleBlockInputStream resultStream = null;
+    while (resultStream == null && hasNext()) {
+      if (hadoopFetcherIterator == null && fetchFromExecutorsIterator.hasNext()) {
+        try {
+          resultStream = fetchFromExecutorsIterator.next();
+          BlockId resultBlock = resultStream.getBlockId();
+          ShuffleBlockId resolvedBlockId = convertBlockId(resultBlock);
+          remainingAttemptsByBlock.remove(resolvedBlockId);
+        } catch (Throwable e) {
+          if (e instanceof FetchFailedException) {
+            LOG.warn(
+                "Failed to fetch block the regular way, due to a fetch failed"
+                    + " exception. Fetching from the hadoop file system instead.",
+                e);
+            ShuffleBlockInfo blockInfo =
+                remainingAttemptsByBlock.get(((FetchFailedException) e).getShuffleBlockId());
+            driverEndpointRef.blacklistExecutor(blockInfo.getShuffleLocation().get());
+            if (canRetrieveRemainingBlocksFromS3()) {
+              unsetFetchFailure();
+              hadoopFetcherIterator = hadoopFetcherIteratorFactory
+                  .createFetcherIteratorForBlocks(remainingAttemptsByBlock.values());
+            } else {
+              throw e;
+            }
+          }
+        }
+      } else if (hadoopFetcherIterator == null) {
+        hadoopFetcherIterator = hadoopFetcherIteratorFactory
+            .createFetcherIteratorForBlocks(remainingAttemptsByBlock.values());
+        resultStream = fetchFromS3();
+      } else {
+        resultStream = fetchFromS3();
+      }
+    }
+    // TODO(mcheah): #8 this should be FetchFailedException, not IllegalStateException.
+    if (resultStream == null) {
+      throw new SafeIllegalStateException("Could not fetch shuffle blocks from either the" +
+          " distributed store or the mapper executor.");
+    }
+    return resultStream;
+  }
+
+  private void unsetFetchFailure() {
+    TaskContext taskContext = TaskContext.get();
+    if (taskContext != null) {
+      taskContext.setFetchFailed(null);
+    }
+  }
+
+  private ShuffleBlockInputStream fetchFromS3() {
+    Preconditions.checkNotNull(
+        hadoopFetcherIterator, "S3 fetcher iterator expected to not be null");
+    ShuffleBlockInputStream resultStream = hadoopFetcherIterator.next();
+    BlockId blockId = resultStream.getBlockId();
+    InputStream resultDeserialized = resultStream;
+    if (shouldCompressShuffle) {
+      resultDeserialized = compressionCodec.compressedInputStream(
+          serializerManager.wrapForEncryption(resultDeserialized));
+    } else {
+      resultDeserialized = serializerManager.wrapForEncryption(resultDeserialized);
+    }
+    remainingAttemptsByBlock.remove(convertBlockId(blockId));
+
+    if (resultDeserialized == resultStream) {
+      return resultStream;
+    } else {
+      return new ShuffleBlockInputStream(blockId, resultDeserialized);
+    }
+  }
+
+  public boolean canRetrieveRemainingBlocksFromS3() {
+    Map<MapOutputId, ShuffleStorageState> registeredMapOutputs = driverEndpointRef
+        .getShuffleStorageStates(shuffleId);
+    return remainingAttemptsByBlock.values().stream().allMatch(block -> {
+      ShuffleStorageState blockStorageState = registeredMapOutputs.get(
+          new MapOutputId(block.getShuffleId(), block.getMapId(), block.getMapTaskAttemptId()));
+      if (blockStorageState == null) {
+        return false;
+      }
+      boolean existsOnRemote = blockStorageState.visit(new ShuffleStorageStateVisitor<Boolean>() {
+        @Override
+        public Boolean onExecutorAndRemote(
+            BlockManagerId _executorLocation, Optional<Long> _mergeId) {
+          return true;
+        }
+
+        @Override
+        public Boolean onExecutorOnly(BlockManagerId _executorLocation) {
+          return false;
+        }
+
+        @Override
+        public Boolean unregistered() {
+          return false;
+        }
+
+        @Override
+        public Boolean onRemoteOnly(Optional<Long> _mergeId) {
+          return true;
+        }
+      });
+      return existsOnRemote;
+    });
+  }
+
+  public void cleanup() {
+    if (hadoopFetcherIterator != null) {
+      hadoopFetcherIterator.cleanup();
+    }
+  }
+
+  private static ShuffleBlockId convertBlockId(BlockId blockId) {
+    int shuffleId;
+    int mapId;
+    int reduceId;
+    if (blockId instanceof ShuffleBlockId) {
+      return (ShuffleBlockId) blockId;
+    } else if (blockId instanceof ShuffleBlockAttemptId) {
+      shuffleId = ((ShuffleBlockAttemptId) blockId).shuffleId();
+      mapId = ((ShuffleBlockAttemptId) blockId).mapId();
+      reduceId = ((ShuffleBlockAttemptId) blockId).reduceId();
+    } else if (blockId instanceof ShuffleDataBlockId) {
+      shuffleId = ((ShuffleDataBlockId) blockId).shuffleId();
+      mapId = ((ShuffleDataBlockId) blockId).mapId();
+      reduceId = ((ShuffleDataBlockId) blockId).reduceId();
+    } else if (blockId instanceof ShuffleIndexBlockId) {
+      shuffleId = ((ShuffleIndexBlockId) blockId).shuffleId();
+      mapId = ((ShuffleIndexBlockId) blockId).mapId();
+      reduceId = ((ShuffleIndexBlockId) blockId).reduceId();
+    } else {
+      throw new SafeIllegalArgumentException(
+          "Block id is not valid - must be a shuffle block id.",
+          SafeArg.of("blockId", blockId));
+    }
+    return new ShuffleBlockId(shuffleId, mapId, reduceId);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIterator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import java.util.Iterator;
+
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+
+public interface HadoopFetcherIterator extends Iterator<ShuffleBlockInputStream> {
+
+  void cleanup();
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIterator.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIterator.java
@@ -21,6 +21,9 @@ import java.util.Iterator;
 
 import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
 
+/**
+ * Iterator for fetching input streams from the remote storage system.
+ */
 public interface HadoopFetcherIterator extends Iterator<ShuffleBlockInputStream> {
 
   void cleanup();

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIteratorFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/reader/HadoopFetcherIteratorFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import java.util.Collection;
+
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+
+public interface HadoopFetcherIteratorFactory {
+
+  HadoopFetcherIterator createFetcherIteratorForBlocks(Collection<ShuffleBlockInfo> blocks);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/s3a/ConscryptS3ClientFactory.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/s3a/ConscryptS3ClientFactory.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.s3a;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.http.conn.ssl.SdkTLSSocketFactory;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AUtils;
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+import org.apache.hadoop.util.VersionInfo;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.conscrypt.Conscrypt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mirrors {@link org.apache.hadoop.fs.s3a.DefaultS3ClientFactory}, but forces the usage of
+ * Conscrypt for the TLS implementation.
+ */
+public final class ConscryptS3ClientFactory extends Configured implements S3ClientFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConscryptS3ClientFactory.class);
+
+  @Override
+  public AmazonS3 createS3Client(URI name) throws IOException {
+    Configuration conf = getConf();
+    AWSCredentialsProvider credentials = S3AUtils.createAWSCredentialProviderSet(name, conf);
+    final ClientConfiguration awsConf = createAwsConf(getConf());
+    AmazonS3 s3 = newAmazonS3Client(credentials, awsConf);
+    return createAmazonS3Client(s3, conf);
+  }
+
+  /**
+   * Create a new {@link ClientConfiguration}.
+   *
+   * @param conf The Hadoop configuration
+   * @return new AWS client configuration
+   */
+  private static ClientConfiguration createAwsConf(Configuration conf) {
+    final ClientConfiguration awsConf = new ClientConfiguration();
+    initConnectionSettings(conf, awsConf);
+    initProxySupport(conf, awsConf);
+    initUserAgent(conf, awsConf);
+    SecureRandom rand = awsConf.getSecureRandom();
+    SSLContext ctx = getConscryptSslContext(rand).orElseGet(() -> getDefaultSslContext(rand));
+    SdkTLSSocketFactory socketFactory = new SdkTLSSocketFactory(
+        ctx, new DefaultHostnameVerifier(PublicSuffixMatcherLoader.getDefault()));
+    awsConf.getApacheHttpClientConfig().setSslSocketFactory(socketFactory);
+    return awsConf;
+  }
+
+  private static SSLContext getDefaultSslContext(SecureRandom rand) {
+    SSLContext ctx;
+    try {
+      ctx = SSLContext.getInstance("TLS");
+      ctx.init(null, null, rand);
+    } catch (KeyManagementException | NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    return ctx;
+  }
+
+  private static Optional<SSLContext> getConscryptSslContext(SecureRandom rand) {
+    SSLContext ctx;
+    try {
+      ctx = SSLContext.getInstance("TLS", Conscrypt.newProvider());
+      // Logic taken from ApacheConnectionManagerFactory
+      ctx.init(null, null, rand);
+    } catch (KeyManagementException | NoSuchAlgorithmException e) {
+      LOGGER.warn("Failed to load Conscrypt SSL Context, falling back to the JVM's" +
+          " implementation.", e);
+      return Optional.empty();
+    }
+    return Optional.of(ctx);
+  }
+
+  /**
+   * Wrapper around constructor for {@link AmazonS3} client.  Override this to
+   * provide an extended version of the client
+   *
+   * @param credentials credentials to use
+   * @param awsConf     AWS configuration
+   * @return new AmazonS3 client
+   */
+  private AmazonS3 newAmazonS3Client(
+      AWSCredentialsProvider credentials, ClientConfiguration awsConf) {
+    return new AmazonS3Client(credentials, awsConf);
+  }
+
+  /**
+   * Initializes all AWS SDK settings related to connection management.
+   *
+   * @param conf    Hadoop configuration
+   * @param awsConf AWS SDK configuration
+   */
+  private static void initConnectionSettings(Configuration conf,
+                                             ClientConfiguration awsConf) {
+    awsConf.setMaxConnections(
+        intOption(conf, Constants.MAXIMUM_CONNECTIONS,
+            Constants.DEFAULT_MAXIMUM_CONNECTIONS, 1));
+    boolean secureConnections = conf.getBoolean(Constants.SECURE_CONNECTIONS,
+        Constants.DEFAULT_SECURE_CONNECTIONS);
+    awsConf.setProtocol(secureConnections ? Protocol.HTTPS : Protocol.HTTP);
+    awsConf.setMaxErrorRetry(intOption(conf, Constants.MAX_ERROR_RETRIES,
+        Constants.DEFAULT_MAX_ERROR_RETRIES, 0));
+    awsConf.setConnectionTimeout(intOption(conf, Constants.ESTABLISH_TIMEOUT,
+        Constants.DEFAULT_ESTABLISH_TIMEOUT, 0));
+    awsConf.setSocketTimeout(intOption(conf, Constants.SOCKET_TIMEOUT,
+        Constants.DEFAULT_SOCKET_TIMEOUT, 0));
+    int sockSendBuffer = intOption(conf, Constants.SOCKET_SEND_BUFFER,
+        Constants.DEFAULT_SOCKET_SEND_BUFFER, 2048);
+    int sockRecvBuffer = intOption(conf, Constants.SOCKET_RECV_BUFFER,
+        Constants.DEFAULT_SOCKET_RECV_BUFFER, 2048);
+    awsConf.setSocketBufferSizeHints(sockSendBuffer, sockRecvBuffer);
+    String signerOverride = conf.getTrimmed(Constants.SIGNING_ALGORITHM, "");
+    if (!signerOverride.isEmpty()) {
+      awsConf.setSignerOverride(signerOverride);
+    }
+  }
+
+  /**
+   * Initializes AWS SDK proxy support if configured.
+   *
+   * @param conf    Hadoop configuration
+   * @param awsConf AWS SDK configuration
+   * @throws IllegalArgumentException if misconfigured
+   */
+  private static void initProxySupport(
+      Configuration conf, ClientConfiguration awsConf) throws IllegalArgumentException {
+    String proxyHost = conf.getTrimmed(Constants.PROXY_HOST, "");
+    int proxyPort = conf.getInt(Constants.PROXY_PORT, -1);
+    if (!proxyHost.isEmpty()) {
+      awsConf.setProxyHost(proxyHost);
+      if (proxyPort >= 0) {
+        awsConf.setProxyPort(proxyPort);
+      } else {
+        if (conf.getBoolean(Constants.SECURE_CONNECTIONS, Constants.DEFAULT_SECURE_CONNECTIONS)) {
+          awsConf.setProxyPort(443);
+        } else {
+          awsConf.setProxyPort(80);
+        }
+      }
+      String proxyUsername = conf.getTrimmed(Constants.PROXY_USERNAME);
+      String proxyPassword = conf.getTrimmed(Constants.PROXY_PASSWORD);
+      Preconditions.checkArgument((proxyUsername == null) != (proxyPassword == null),
+          "Proxy username or proxy password should not be used without the other.");
+      awsConf.setProxyUsername(proxyUsername);
+      awsConf.setProxyPassword(proxyPassword);
+      awsConf.setProxyDomain(conf.getTrimmed(Constants.PROXY_DOMAIN));
+      awsConf.setProxyWorkstation(conf.getTrimmed(Constants.PROXY_WORKSTATION));
+    } else if (proxyPort >= 0) {
+      throw new SafeIllegalArgumentException("Proxy port set without proxy host.");
+    }
+  }
+
+  /**
+   * Initializes the User-Agent header to send in HTTP requests to the S3
+   * back-end.  We always include the Hadoop version number.  The user also
+   * may set an optional custom prefix to put in front of the Hadoop version
+   * number.  The AWS SDK interally appends its own information, which seems
+   * to include the AWS SDK version, OS and JVM version.
+   *
+   * @param conf    Hadoop configuration
+   * @param awsConf AWS SDK configuration
+   */
+  private static void initUserAgent(Configuration conf,
+                                    ClientConfiguration awsConf) {
+    String userAgent = String.format("Hadoop %s", VersionInfo.getVersion());
+    String userAgentPrefix = conf.getTrimmed(Constants.USER_AGENT_PREFIX, "");
+    if (!userAgentPrefix.isEmpty()) {
+      userAgent = userAgentPrefix + ", " + userAgent;
+    }
+    awsConf.setUserAgentPrefix(userAgent);
+  }
+
+  /**
+   * Creates an {@link AmazonS3Client} from the established configuration.
+   *
+   * @param conf Hadoop configuration
+   * @return S3 client
+   * @throws IllegalArgumentException if misconfigured
+   */
+  private static AmazonS3 createAmazonS3Client(AmazonS3 s3, Configuration conf)
+      throws IllegalArgumentException {
+    String endPoint = conf.getTrimmed(Constants.ENDPOINT, "");
+    if (!endPoint.isEmpty()) {
+      try {
+        s3.setEndpoint(endPoint);
+      } catch (IllegalArgumentException e) {
+        String msg = "Incorrect endpoint: " + e.getMessage();
+        throw new IllegalArgumentException(msg, e);
+      }
+    }
+    enablePathStyleAccessIfRequired(s3, conf);
+    return s3;
+  }
+
+  /**
+   * Enables path-style access to S3 buckets if configured.  By default, the
+   * behavior is to use virtual hosted-style access with URIs of the form
+   * http://bucketname.s3.amazonaws.com.  Enabling path-style access and a
+   * region-specific endpoint switches the behavior to use URIs of the form
+   * http://s3-eu-west-1.amazonaws.com/bucketname.
+   *
+   * @param s3   S3 client
+   * @param conf Hadoop configuration
+   */
+  private static void enablePathStyleAccessIfRequired(AmazonS3 s3,
+                                                      Configuration conf) {
+    final boolean pathStyleAccess = conf.getBoolean(Constants.PATH_STYLE_ACCESS, false);
+    if (pathStyleAccess) {
+      s3.setS3ClientOptions(S3ClientOptions.builder()
+          .setPathStyleAccess(true)
+          .build());
+    }
+  }
+
+  /**
+   * Get a integer option >= the minimum allowed value.
+   * <p>
+   * Taken from {@link Constants}.
+   *
+   * @param conf   configuration
+   * @param key    key to look up
+   * @param defVal default value
+   * @param min    minimum value
+   * @return the value
+   * @throws IllegalArgumentException if the value is below the minimum
+   */
+  private static int intOption(Configuration conf, String key, int defVal, int min) {
+    int value = conf.getInt(key, defVal);
+    Preconditions.checkArgument(value >= min,
+        "Configuration value is lower than the required minimum.",
+        SafeArg.of("key", key),
+        SafeArg.of("min", min),
+        SafeArg.of("given", value));
+    return value;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/AbortableOutputStream.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/AbortableOutputStream.java
@@ -20,11 +20,19 @@ package org.apache.spark.palantir.shuffle.async.util;
 import java.io.FilterOutputStream;
 import java.io.OutputStream;
 
+/**
+ * Output stream that may create some temporary resources that should be cleaned up
+ * if an error were to occur while the stream is open.
+ */
 public abstract class AbortableOutputStream extends FilterOutputStream {
 
   protected AbortableOutputStream(OutputStream out) {
     super(out);
   }
 
+  /**
+   * Has distinct semantics from {@link #close()} in that in the case of an error, no state that
+   * was created by this output stream should remain.
+   */
   public abstract void abort(Exception cause);
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/AbortableOutputStream.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/AbortableOutputStream.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.io.FilterOutputStream;
+import java.io.OutputStream;
+
+public abstract class AbortableOutputStream extends FilterOutputStream {
+
+  protected AbortableOutputStream(OutputStream out) {
+    super(out);
+  }
+
+  public abstract void abort(Exception cause);
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/DaemonExecutors.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/DaemonExecutors.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public final class DaemonExecutors {
+
+  private DaemonExecutors() {
+  }
+
+  public static ExecutorService newFixedDaemonThreadPool(int numExecutors) {
+    return Executors.newFixedThreadPool(numExecutors,
+        new ThreadFactory() {
+          @Override
+          public Thread newThread(Runnable runnable) {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setDaemon(true);
+            return thread;
+          }
+        });
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/EmptySizedInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/EmptySizedInput.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public final class EmptySizedInput implements SizedInput {
+
+  @Override
+  public long getStreamSizeInBytes() {
+    return 0;
+  }
+
+  @Override
+  public InputStream openStream() {
+    return new ByteArrayInputStream(new byte[0]);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/FileSizedInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/FileSizedInput.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.spark.io.NioBufferedFileInputStream;
+
+public final class FileSizedInput implements SizedInput {
+
+  private final File file;
+  private final int bufferSize;
+
+  public FileSizedInput(File file, int bufferSize) {
+    this.file = file;
+    this.bufferSize = bufferSize;
+  }
+
+  @Override
+  public long getStreamSizeInBytes() {
+    return file.length();
+  }
+
+  @Override
+  public InputStream openStream() throws IOException {
+    return new NioBufferedFileInputStream(file, bufferSize);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/NamedExecutors.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/NamedExecutors.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+public final class NamedExecutors {
+
+  private NamedExecutors() {
+  }
+
+  public static ExecutorService newFixedThreadExecutorService(int numExecutors, String name) {
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat(name)
+        .setDaemon(true)
+        .build();
+
+    return Executors.newFixedThreadPool(numExecutors, threadFactory);
+  }
+
+  public static ScheduledExecutorService newFixedThreadScheduledExecutorService(
+      int numExecutors, String name) {
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat(name)
+        .setDaemon(true)
+        .build();
+
+    return Executors.newScheduledThreadPool(numExecutors, threadFactory);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/PartitionOffsets.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/PartitionOffsets.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutablesStyle
+public interface PartitionOffsets {
+
+  long dataOffset();
+
+  long nextOffset();
+
+  @Value.Derived
+  default long length() {
+    return nextOffset() - dataOffset();
+  }
+
+  static PartitionOffsets of(long dataOffset, long nextOffset) {
+    return builder().dataOffset(dataOffset).nextOffset(nextOffset).build();
+  }
+
+  static ImmutablePartitionOffsets.Builder builder() {
+    return ImmutablePartitionOffsets.builder();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/PartitionOffsets.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/PartitionOffsets.java
@@ -21,14 +21,26 @@ import org.apache.spark.palantir.shuffle.async.immutables.ImmutablesStyle;
 
 import org.immutables.value.Value;
 
+/**
+ * Structure representing the position where a data block starts and ends in a shuffle data file.
+ */
 @Value.Immutable
 @ImmutablesStyle
 public interface PartitionOffsets {
 
+  /**
+   * The byte index where the partition begins.
+   */
   long dataOffset();
 
+  /**
+   * The byte index where this partition ends and the next partition begins.
+   */
   long nextOffset();
 
+  /**
+   * The number of bytes that are in the partition.
+   */
   @Value.Derived
   default long length() {
     return nextOffset() - dataOffset();

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/SizedInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/SizedInput.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Extension to {@link java.io.InputStream} that allows getting the number of bytes
+ * the stream will provide.
+ */
+public interface SizedInput {
+
+  long getStreamSizeInBytes();
+
+  InputStream openStream() throws IOException;
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/Suppliers.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/Suppliers.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Workarounds for the fact that Guava suppliers are not compatible with Java ones, and when
+ * methods are missing.
+ */
+public final class Suppliers {
+
+  public static <T> Supplier<T> ofInstance(T instance) {
+    return () -> instance;
+  }
+
+  public static <T> Supplier<T> memoize(Supplier<T> delegate) {
+    com.google.common.base.Supplier<T> guavaMemoizingSupplier =
+        com.google.common.base.Suppliers.memoize(delegate::get);
+    return guavaMemoizingSupplier::get;
+  }
+
+  public static <T, U> Supplier<U> compose(Supplier<T> base, Function<T, U> composer) {
+    return () -> composer.apply(base.get());
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/TempFileOutputStream.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/TempFileOutputStream.java
@@ -33,6 +33,13 @@ import org.apache.spark.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Output stream that creates a temporary file, and then atomically renames the temporary  file
+ * to the final file when {@link #close()} is called.
+ * <p>
+ * If {@link #abort(Exception)} is called, the temporary file is deleted and the final file is
+ * never created.
+ */
 public final class TempFileOutputStream extends AbortableOutputStream {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TempFileOutputStream.class);

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/TempFileOutputStream.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/TempFileOutputStream.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.commons.io.FileUtils;
+
+import org.apache.spark.util.Utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TempFileOutputStream extends AbortableOutputStream {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TempFileOutputStream.class);
+
+  private final File tempFile;
+  private final File outputFile;
+
+  private boolean isClosed;
+
+  public static TempFileOutputStream createTempFile(File outputFile) throws IOException {
+    File tempFile = Utils.tempFileWith(outputFile);
+    try {
+      return new TempFileOutputStream(tempFile, outputFile);
+    } catch (IOException e) {
+      FileUtils.deleteQuietly(tempFile);
+      throw e;
+    }
+  }
+
+  private TempFileOutputStream(File tempFile, File outputFile) throws IOException {
+    super(Files.newOutputStream(tempFile.toPath(), StandardOpenOption.CREATE_NEW));
+    this.tempFile = tempFile;
+    this.outputFile = outputFile;
+    this.isClosed = false;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!isClosed) {
+      super.close();
+      Preconditions.checkState(tempFile.isFile(), "Temporary file was not created.");
+      try {
+        Files.move(tempFile.toPath(), outputFile.toPath());
+      } catch (FileAlreadyExistsException e) {
+        LOGGER.warn("Map output file was already created; perhaps another thread"
+                + " accidentally downloaded the same data.",
+            SafeArg.of("mapOutputFilePath", outputFile.getAbsolutePath()),
+            e);
+      }
+      isClosed = true;
+    }
+  }
+
+  @Override
+  public void abort(Exception cause) {
+    try {
+      if (!isClosed) {
+        super.close();
+        if (tempFile.isFile()) {
+          Files.delete(tempFile.toPath());
+        }
+        isClosed = true;
+      }
+    } catch (IOException e) {
+      cause.addSuppressed(e);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/BufferedSeekableInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/BufferedSeekableInput.java
@@ -21,6 +21,10 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Implementation of {@link SeekableInput} that wraps returned streams with a
+ * {@link BufferedInputStream}, with a buffer of the specified size.
+ */
 public final class BufferedSeekableInput implements SeekableInput {
 
   private final SeekableInput delegate;

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/BufferedSeekableInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/BufferedSeekableInput.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.streams;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class BufferedSeekableInput implements SeekableInput {
+
+  private final SeekableInput delegate;
+  private final int bufferSize;
+
+  public BufferedSeekableInput(SeekableInput delegate, int bufferSize) {
+    this.delegate = delegate;
+    this.bufferSize = bufferSize;
+  }
+
+  @Override
+  public InputStream open() throws IOException {
+    return new BufferedInputStream(delegate.open(), bufferSize);
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition, long len) throws IOException {
+    return new BufferedInputStream(delegate.seekToAndOpen(startPosition, len), bufferSize);
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition) throws IOException {
+    return new BufferedInputStream(delegate.seekToAndOpen(startPosition), bufferSize);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableFileInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableFileInput.java
@@ -24,6 +24,9 @@ import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 
+/**
+ * Implementation of {@link SeekableInput} that reads bytes from a file on local disk.
+ */
 public final class SeekableFileInput implements SeekableInput {
 
   private final File file;

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableFileInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableFileInput.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.streams;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+
+public final class SeekableFileInput implements SeekableInput {
+
+  private final File file;
+
+  public SeekableFileInput(File file) {
+    this.file = file;
+  }
+
+  @Override
+  public InputStream open() throws IOException {
+    return Channels.newInputStream(Files.newByteChannel(file.toPath()));
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition, long _len) throws IOException {
+    return seekToAndOpen(startPosition);
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition) throws IOException {
+    SeekableByteChannel channel = Files.newByteChannel(file.toPath());
+    channel.position(startPosition);
+    return Channels.newInputStream(channel);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableHadoopInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableHadoopInput.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.streams;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hadoop.fs.CanSetReadahead;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public final class SeekableHadoopInput implements SeekableInput {
+
+  private final Path path;
+  private final FileSystem fs;
+
+  public SeekableHadoopInput(Path path, FileSystem fs) {
+    this.path = path;
+    this.fs = fs;
+  }
+
+  @Override
+  public InputStream open() throws IOException {
+    return fs.open(path);
+  }
+
+  @Override
+  public FSDataInputStream seekToAndOpen(long startPosition, long len) throws IOException {
+    FSDataInputStream fsInput = this.seekToAndOpen(startPosition);
+    InputStream wrapped = fsInput.getWrappedStream();
+    if (wrapped instanceof CanSetReadahead) {
+      fsInput.setReadahead(len);
+    }
+    return fsInput;
+  }
+
+  @Override
+  public FSDataInputStream seekToAndOpen(long startPosition) throws IOException {
+    FSDataInputStream fsInput = fs.open(path);
+    fsInput.seek(startPosition);
+    return fsInput;
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableHadoopInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableHadoopInput.java
@@ -25,6 +25,9 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+/**
+ * Implementation of {@link SeekableInput} that reads bytes from a file from remote storage.
+ */
 public final class SeekableHadoopInput implements SeekableInput {
 
   private final Path path;

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableInput.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.streams;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface SeekableInput {
+
+  InputStream open() throws IOException;
+
+  InputStream seekToAndOpen(long startPosition, long len) throws IOException;
+
+  InputStream seekToAndOpen(long startPosition) throws IOException;
+
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/streams/SeekableInput.java
@@ -20,12 +20,26 @@ package org.apache.spark.palantir.shuffle.async.util.streams;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Interface for opening input streams lazily at a given position.
+ */
 public interface SeekableInput {
 
+  /**
+   * Opens from the beginning of the stream.
+   */
   InputStream open() throws IOException;
 
+  /**
+   * Open the stream from the given starting position, with a known number of bytes to
+   * be read from the stream.
+   */
   InputStream seekToAndOpen(long startPosition, long len) throws IOException;
 
+  /**
+   * Open the stream from the given startingposition, without knowing the number of byte to read
+   * from the stream.
+   */
   InputStream seekToAndOpen(long startPosition) throws IOException;
 
 }

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/FileMergerTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/FileMergerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.spark.palantir.shuffle.async.client.merging.ShuffleMapInput;
+import org.apache.spark.palantir.shuffle.async.merger.FileMerger;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.FileSizedInput;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class FileMergerTest {
+
+  private static final String FILE_1_CONTENTS = "file1_contents1_a";
+  private static final String FILE_2_CONTENTS = "file2_contents2_bbetfs";
+  // File3 is empty
+  private static final String FILE_4_CONTENTS = "file4_contents4_asdqwttgdsa";
+  private static final String[] ALL_FILE_CONTENTS = new String[]{
+      FILE_1_CONTENTS, FILE_2_CONTENTS, "", FILE_4_CONTENTS
+  };
+
+  private static final int[] MAP_IDS = new int[]{1, 5, 10, 31};
+  private static final long[] ATTEMPT_IDS = new long[]{0, 2, 1, 4};
+  private static final int SHUFFLE_ID = 97;
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private List<ShuffleMapInput> inputs;
+
+  @Before
+  public void before() throws IOException {
+    File file1 = tempFolder.newFile();
+    File file2 = tempFolder.newFile();
+    File file3 = tempFolder.newFile();
+    File file4 = tempFolder.newFile();
+    writeString(file1, FILE_1_CONTENTS);
+    writeString(file2, FILE_2_CONTENTS);
+    writeString(file4, FILE_4_CONTENTS);
+    inputs = new ArrayList<>();
+    File[] files = new File[]{file1, file2, file3, file4};
+    for (int i = 0; i < files.length; i++) {
+      int mapId = MAP_IDS[i];
+      long attemptId = ATTEMPT_IDS[i];
+      File file = files[i];
+      ShuffleMapInput shuffleMapInput = new ShuffleMapInput(
+          new MapOutputId(SHUFFLE_ID, mapId, attemptId),
+          new FileSizedInput(file, 128),
+          new FileSizedInput(file, 128));
+      inputs.add(shuffleMapInput);
+    }
+  }
+
+  @Test
+  public void testMergeAndSplit() throws IOException {
+    ByteArrayOutputStream mergedBytes = new ByteArrayOutputStream();
+    try (DataOutputStream mergedOutput = new DataOutputStream(mergedBytes)) {
+      FileMerger.mergeMapOutputs(
+          inputs.toArray(new ShuffleMapInput[0]),
+          mergedOutput,
+          ShuffleMapInput::dataSizedInput);
+    }
+    TestMapOutputFileProvider testMapOutputFileProvider = new TestMapOutputFileProvider(tempFolder);
+    ByteArrayInputStream mergedBytesInput = new ByteArrayInputStream(mergedBytes.toByteArray());
+    try (DataInputStream mergedBytesDataIn = new DataInputStream(mergedBytesInput)) {
+      FileMerger.fetchAndSplitMergedInput(
+          mergedBytesDataIn, testMapOutputFileProvider);
+    }
+    List<File> createdFiles = testMapOutputFileProvider.getCreatedFiles();
+    Assertions.assertThat(createdFiles).hasSize(4);
+    List<String> createdFilesContents = createdFiles.stream()
+        .map(FileMergerTest::readToString)
+        .collect(Collectors.toList());
+    Assertions.assertThat(createdFilesContents).containsExactly(ALL_FILE_CONTENTS);
+  }
+
+  @Test
+  public void testSkipDownloadingExistingFiles() throws IOException {
+    ByteArrayOutputStream mergedBytes = new ByteArrayOutputStream();
+    try (DataOutputStream mergedOutput = new DataOutputStream(mergedBytes)) {
+      FileMerger.mergeMapOutputs(
+          inputs.toArray(new ShuffleMapInput[0]),
+          mergedOutput,
+          ShuffleMapInput::dataSizedInput);
+    }
+    TestMapOutputFileProvider testMapOutputFileProvider = new TestMapOutputFileProvider(
+        tempFolder, MAP_IDS[0]);
+
+    ByteArrayInputStream mergedBytesInput = new ByteArrayInputStream(mergedBytes.toByteArray());
+    try (DataInputStream mergedBytesDataIn = new DataInputStream(mergedBytesInput)) {
+      FileMerger.fetchAndSplitMergedInput(
+          mergedBytesDataIn, testMapOutputFileProvider);
+    }
+
+    List<File> createdFiles = testMapOutputFileProvider.getCreatedFiles();
+    Assertions.assertThat(createdFiles).hasSize(3);
+    List<String> createdFilesContents = createdFiles.stream()
+        .map(FileMergerTest::readToString)
+        .collect(Collectors.toList());
+    Assertions.assertThat(createdFilesContents).isEqualTo(
+        ImmutableList.copyOf(ALL_FILE_CONTENTS).subList(1, ALL_FILE_CONTENTS.length));
+  }
+
+  private static final class TestMapOutputFileProvider
+      implements FileMerger.MapOutputStreamProvider {
+    private final TemporaryFolder tempFolder;
+    private final List<File> createdFiles;
+    private final Set<Integer> mapIdsToSkip;
+
+    TestMapOutputFileProvider(TemporaryFolder tempFolder, int... mapIdsToSkip) {
+      this.tempFolder = tempFolder;
+      this.createdFiles = new ArrayList<>();
+      this.mapIdsToSkip = ImmutableSet.copyOf(Arrays.stream(mapIdsToSkip).iterator());
+    }
+
+    @Override
+    public Optional<FileMerger.OutputStreamSupplier> getMapOutputStreamIfNotExists(
+        int shuffleId, int mapId, long attemptId) {
+      if (mapIdsToSkip.contains(mapId)) {
+        return Optional.empty();
+      }
+      File newFile;
+      try {
+        newFile = tempFolder.newFile(
+            String.format("shuffle-%d-%d-%d", shuffleId, mapId, attemptId));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      createdFiles.add(newFile);
+      return Optional.of(() -> new FileOutputStream(newFile));
+    }
+
+    public List<File> getCreatedFiles() {
+      return createdFiles;
+    }
+  }
+
+  private static void writeString(File file, String str) {
+    try {
+      Files.write(str.getBytes(StandardCharsets.UTF_8), file);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String readToString(File file) {
+    try {
+      return new String(Files.toByteArray(file), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/HadoopShuffleClientTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/HadoopShuffleClientTest.java
@@ -67,7 +67,7 @@ public final class HadoopShuffleClientTest {
   @Mock
   private ShuffleDriverEndpointRef mockDriverEndpointRef;
 
-  private HadoopShuffleClient s3Client;
+  private HadoopShuffleClient clientUnderTest;
 
   private byte[][] data;
   private File dataFile;
@@ -100,7 +100,7 @@ public final class HadoopShuffleClientTest {
     RemoteShuffleFileSystem remoteShuffleFs = new InMemoryRemoteShuffleFileSystem();
     PartitionOffsetsFetcher partitionOffsetsFetcher = new TestPartitionOffsetsFetcher(
         remoteShuffleFs);
-    s3Client = new HadoopShuffleClient(
+    clientUnderTest = new HadoopShuffleClient(
         APP_ID,
         MoreExecutors.listeningDecorator(uploadExecService),
         MoreExecutors.listeningDecorator(downloadExecService),
@@ -119,7 +119,7 @@ public final class HadoopShuffleClientTest {
   @Test
   public void testWriteAndRead() throws Exception {
     when(mockDriverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(true);
-    s3Client.asyncWriteDataAndIndexFilesAndClose(
+    clientUnderTest.asyncWriteDataAndIndexFilesAndClose(
         dataFile.toPath(),
         indexFile.toPath(),
         SHUFFLE_ID,
@@ -133,7 +133,7 @@ public final class HadoopShuffleClientTest {
   @Test
   public void testShuffleDoesNotExist() {
     when(mockDriverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(false);
-    s3Client.asyncWriteDataAndIndexFilesAndClose(
+    clientUnderTest.asyncWriteDataAndIndexFilesAndClose(
         dataFile.toPath(),
         indexFile.toPath(),
         SHUFFLE_ID,
@@ -147,7 +147,7 @@ public final class HadoopShuffleClientTest {
   private void checkPartitionData(int partitionId)
       throws ExecutionException, InterruptedException, IOException {
     ListenableFuture<Supplier<InputStream>> inputStreamFuture =
-        s3Client.getBlockData(
+        clientUnderTest.getBlockData(
             SHUFFLE_ID, MAP_ID, partitionId, ATTEMPT_ID);
     downloadExecService.runUntilIdle();
     InputStream inputStream = inputStreamFuture.get().get();

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/HadoopShuffleClientTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/HadoopShuffleClientTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Clock;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.basic.HadoopShuffleClient;
+import org.apache.spark.palantir.shuffle.async.client.basic.PartitionOffsetsFetcher;
+import org.apache.spark.palantir.shuffle.async.client.basic.RemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.metrics.slf4j.Slf4jBasicShuffleClientMetrics;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+public final class HadoopShuffleClientTest {
+
+  private static final int NUM_PARTITIONS = 7;
+  private static final int MAX_PARTITION_SIZE_BYTES = 1000;
+  private static final String APP_ID = "my-app";
+  private static final int SHUFFLE_ID = 10;
+  private static final int MAP_ID = 1;
+  private static final int ATTEMPT_ID = 0;
+
+  private static final DeterministicScheduler downloadExecService = new DeterministicScheduler();
+  private static final DeterministicScheduler uploadExecService = new DeterministicScheduler();
+
+  private static final Random random = new Random();
+
+  @Mock
+  private ShuffleDriverEndpointRef mockDriverEndpointRef;
+
+  private HadoopShuffleClient s3Client;
+
+  private byte[][] data;
+  private File dataFile;
+  private File indexFile;
+
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Before
+  public void before() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    data = new byte[NUM_PARTITIONS][];
+    dataFile = tempDir.newFile();
+    indexFile = tempDir.newFile();
+
+    long lengthSoFar = 0;
+
+    try (OutputStream dataInput = new FileOutputStream(dataFile);
+         DataOutputStream indexInput = new DataOutputStream(new FileOutputStream(indexFile))) {
+      for (int i = 0; i < NUM_PARTITIONS; i++) {
+        int size = random.nextInt(MAX_PARTITION_SIZE_BYTES);
+        byte[] randomBytes = new byte[size];
+        random.nextBytes(randomBytes);
+        dataInput.write(randomBytes);
+        indexInput.writeLong(lengthSoFar);
+        lengthSoFar += size;
+        data[i] = randomBytes;
+      }
+    }
+    RemoteShuffleFileSystem remoteShuffleFs = new InMemoryRemoteShuffleFileSystem();
+    PartitionOffsetsFetcher partitionOffsetsFetcher = new TestPartitionOffsetsFetcher(
+        remoteShuffleFs);
+    s3Client = new HadoopShuffleClient(
+        APP_ID,
+        MoreExecutors.listeningDecorator(uploadExecService),
+        MoreExecutors.listeningDecorator(downloadExecService),
+        remoteShuffleFs,
+        new InMemoryLocalDownloadShuffleFileSystem(),
+        partitionOffsetsFetcher,
+        new Slf4jBasicShuffleClientMetrics("app-id"),
+        mockDriverEndpointRef,
+        Clock.systemUTC(),
+        5,
+        128,
+        128
+    );
+  }
+
+  @Test
+  public void testWriteAndRead() throws Exception {
+    when(mockDriverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(true);
+    s3Client.asyncWriteDataAndIndexFilesAndClose(
+        dataFile.toPath(),
+        indexFile.toPath(),
+        SHUFFLE_ID,
+        MAP_ID,
+        ATTEMPT_ID);
+    uploadExecService.runUntilIdle();
+    checkPartitionData(0);
+    checkPartitionData(4);
+  }
+
+  @Test
+  public void testShuffleDoesNotExist() {
+    when(mockDriverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(false);
+    s3Client.asyncWriteDataAndIndexFilesAndClose(
+        dataFile.toPath(),
+        indexFile.toPath(),
+        SHUFFLE_ID,
+        MAP_ID,
+        ATTEMPT_ID);
+    uploadExecService.runUntilIdle();
+    assertThatThrownBy(() -> checkPartitionData(0))
+        .hasRootCauseExactlyInstanceOf(ShuffleIndexMissingException.class);
+  }
+
+  private void checkPartitionData(int partitionId)
+      throws ExecutionException, InterruptedException, IOException {
+    ListenableFuture<Supplier<InputStream>> inputStreamFuture =
+        s3Client.getBlockData(
+            SHUFFLE_ID, MAP_ID, partitionId, ATTEMPT_ID);
+    downloadExecService.runUntilIdle();
+    InputStream inputStream = inputStreamFuture.get().get();
+
+    byte[] partitionData = data[partitionId];
+    byte[] readBytes = ByteStreams.toByteArray(inputStream);
+    assertThat(readBytes).containsExactly(partitionData);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryFile.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryFile.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+// Simple wrapper around an in-memory file that tracks the number of times its contents are read.
+public final class InMemoryFile {
+  private final byte[] contents;
+  private final AtomicInteger readCount;
+
+  public static InMemoryFile of(byte[] contents) {
+    return new InMemoryFile(contents);
+  }
+
+  private InMemoryFile(byte[] contents) {
+    this.contents = contents;
+    this.readCount = new AtomicInteger(0);
+  }
+
+  public byte[] read() {
+    readCount.incrementAndGet();
+    return contents;
+  }
+
+  public int getReadCount() {
+    return readCount.get();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryLocalDownloadShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryLocalDownloadShuffleFileSystem.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.spark.palantir.shuffle.async.client.basic.LocalDownloadShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.io.SeekableByteArrayInput;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.AbortableOutputStream;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class InMemoryLocalDownloadShuffleFileSystem
+    implements LocalDownloadShuffleFileSystem {
+
+  private final Map<MapOutputId, Map<Integer, InMemoryFile>> dataBlocks = Maps.newConcurrentMap();
+  private final Map<MapOutputId, InMemoryFile> indexFiles = Maps.newConcurrentMap();
+
+  @Override
+  public SeekableInput getLocalSeekableDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    return new SeekableByteArrayInput(
+        dataBlocks.get(new MapOutputId(shuffleId, mapId, attemptId))
+            .get(reduceId)
+            .read());
+  }
+
+  @Override
+  public byte[] readAllIndexFileBytes(int shuffleId, int mapId, long attemptId) {
+    return indexFiles.get(new MapOutputId(shuffleId, mapId, attemptId)).read();
+  }
+
+  @Override
+  public SeekableInput getLocalSeekableIndexFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableByteArrayInput(readAllIndexFileBytes(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public boolean doesLocalIndexFileExist(int shuffleId, int mapId, long attemptId) {
+    return indexFiles.containsKey(new MapOutputId(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public boolean doesLocalDataBlockFileExist(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    return dataBlocks.getOrDefault(
+        new MapOutputId(shuffleId, mapId, attemptId),
+        ImmutableMap.of())
+        .containsKey(reduceId);
+  }
+
+  @Override
+  public void deleteDownloadedIndexFile(int shuffleId, int mapId, long attemptId) {
+    indexFiles.remove(new MapOutputId(shuffleId, mapId, attemptId));
+  }
+
+  @Override
+  public void deleteDownloadedIndexFilesForShuffleId(int shuffleId) {
+    Iterator<Map.Entry<MapOutputId, InMemoryFile>> indexFilesIt = indexFiles.entrySet().iterator();
+    while (indexFilesIt.hasNext()) {
+      if (indexFilesIt.next().getKey().shuffleId() == shuffleId) {
+        indexFilesIt.remove();
+      }
+    }
+  }
+
+  @Override
+  public void deleteDownloadedDataBlock(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    dataBlocks.getOrDefault(
+        new MapOutputId(shuffleId, mapId, attemptId), new HashMap<>())
+        .remove(reduceId);
+  }
+
+  @Override
+  public AbortableOutputStream createLocalIndexFile(int shuffleId, int mapId, long attemptId) {
+    ByteArrayOutputStream indexFileBytesOut = new ByteArrayOutputStream();
+    return new AbortableOutputStream(indexFileBytesOut) {
+      @Override
+      public void abort(Exception _cause) {
+
+      }
+
+      @Override
+      public void close() throws IOException {
+        super.close();
+        indexFiles.put(
+            new MapOutputId(shuffleId, mapId, attemptId),
+            InMemoryFile.of(indexFileBytesOut.toByteArray()));
+      }
+    };
+  }
+
+  @Override
+  public AbortableOutputStream createLocalDataBlockFile(
+      int shuffleId, int mapId, int reduceId, long attemptId) {
+    ByteArrayOutputStream dataBlockBytesOut = new ByteArrayOutputStream();
+    return new AbortableOutputStream(dataBlockBytesOut) {
+      @Override
+      public void abort(Exception _cause) {
+
+      }
+
+      @Override
+      public void close() throws IOException {
+        super.close();
+        dataBlocks.computeIfAbsent(
+            new MapOutputId(shuffleId, mapId, attemptId), _key -> new HashMap<>())
+            .put(reduceId, InMemoryFile.of(dataBlockBytesOut.toByteArray()));
+      }
+    };
+  }
+
+  public Map<MapOutputId, Map<Integer, Integer>> dataBlockReadCounts() {
+    return Maps.transformValues(
+        ImmutableMap.copyOf(dataBlocks),
+        blocks -> Maps.transformValues(
+            ImmutableMap.copyOf(blocks),
+            InMemoryFile::getReadCount));
+  }
+
+  public Map<MapOutputId, Integer> indexFileReadCounts() {
+    return Maps.transformValues(
+        ImmutableMap.copyOf(indexFiles),
+        InMemoryFile::getReadCount);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryRemoteShuffleFileSystem.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/InMemoryRemoteShuffleFileSystem.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.apache.spark.palantir.shuffle.async.client.basic.RemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.io.SeekableByteArrayInput;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class InMemoryRemoteShuffleFileSystem implements RemoteShuffleFileSystem {
+
+  private final Map<MapOutputId, InMemoryFile> dataFiles = Maps.newConcurrentMap();
+  private final Map<MapOutputId, InMemoryFile> indexFiles = Maps.newConcurrentMap();
+
+  @Override
+  public void deleteApplicationShuffleData() {
+    dataFiles.clear();
+    indexFiles.clear();
+  }
+
+  @Override
+  public SeekableInput getRemoteSeekableIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    MapOutputId id = new MapOutputId(shuffleId, mapId, attemptId);
+    if (!indexFiles.containsKey(id)) {
+      throw new ShuffleIndexMissingException(shuffleId, mapId, attemptId);
+    }
+    return new SeekableByteArrayInput(
+        indexFiles.get(new MapOutputId(shuffleId, mapId, attemptId)).read());
+  }
+
+  @Override
+  public SeekableInput getRemoteSeekableDataFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    MapOutputId id = new MapOutputId(shuffleId, mapId, attemptId);
+    if (!dataFiles.containsKey(id)) {
+      throw new ShuffleDataMissingException(shuffleId, mapId, attemptId);
+    }
+    return new SeekableByteArrayInput(dataFiles.get(id).read());
+  }
+
+  @Override
+  public InputStream openRemoteIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    MapOutputId id = new MapOutputId(shuffleId, mapId, attemptId);
+    if (!indexFiles.containsKey(id)) {
+      throw new ShuffleIndexMissingException(shuffleId, mapId, attemptId);
+    }
+    return new ByteArrayInputStream(indexFiles.get(id).read());
+  }
+
+  @Override
+  public void backupIndexFile(
+      int shuffleId, int mapId, long attemptId, File localIndexFile) throws IOException {
+    indexFiles.put(
+        new MapOutputId(shuffleId, mapId, attemptId),
+        InMemoryFile.of(Files.readAllBytes(localIndexFile.toPath())));
+  }
+
+  @Override
+  public void backupDataFile(
+      int shuffleId, int mapId, long attemptId, File localDataFile) throws IOException {
+    dataFiles.put(
+        new MapOutputId(shuffleId, mapId, attemptId),
+        InMemoryFile.of(Files.readAllBytes(localDataFile.toPath())));
+  }
+
+  public void putIndexFile(int shuffleId, int mapId, long attemptId, byte[] indexFileContents) {
+    indexFiles.put(
+        new MapOutputId(shuffleId, mapId, attemptId),
+        InMemoryFile.of(indexFileContents));
+  }
+
+  public Map<MapOutputId, Integer> dataFileReadCounts() {
+    return Maps.transformValues(ImmutableMap.copyOf(dataFiles), InMemoryFile::getReadCount);
+  }
+
+  public Map<MapOutputId, Integer> indexFileReadCounts() {
+    return Maps.transformValues(ImmutableMap.copyOf(indexFiles), InMemoryFile::getReadCount);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/ShuffleDataMissingException.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/ShuffleDataMissingException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.io.IOException;
+
+public final class ShuffleDataMissingException extends IOException {
+
+  public ShuffleDataMissingException(int shuffleId, int mapId, long attemptId) {
+    super(
+        String.format("Shuffle data file is missing. {shuffleId=%d}, {mapId=%d}, {attemptId=%d}",
+            shuffleId,
+            mapId,
+            attemptId));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/ShuffleIndexMissingException.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/ShuffleIndexMissingException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.io.IOException;
+
+public final class ShuffleIndexMissingException extends IOException {
+
+  public ShuffleIndexMissingException(int shuffleId, int mapId, long attemptId) {
+    super(
+        String.format("Shuffle index file is missing. {shuffleId=%d}, {mapId=%d}, {attemptId=%d}",
+            shuffleId,
+            mapId,
+            attemptId));
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/TestClock.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/TestClock.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public final class TestClock extends Clock {
+
+  private final ZoneId initialZoneId;
+  private Instant currentInstant;
+
+  public TestClock() {
+    Clock utcCLock = Clock.systemUTC();
+    this.initialZoneId = utcCLock.getZone();
+    this.currentInstant = utcCLock.instant();
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return initialZoneId;
+  }
+
+  @Override
+  public Clock withZone(ZoneId _zone) {
+    return this;
+  }
+
+  @Override
+  public Instant instant() {
+    return currentInstant;
+  }
+
+  public void addMillis(long millis) {
+    currentInstant = currentInstant.plusMillis(millis);
+  }
+
+  public void addSeconds(long seconds) {
+    currentInstant = currentInstant.plusSeconds(seconds);
+  }
+
+  public void addMinutes(long minutes) {
+    currentInstant = currentInstant.plusSeconds(minutes);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/TestPartitionOffsetsFetcher.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/TestPartitionOffsetsFetcher.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client;
+
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+import java.io.IOException;
+
+import org.apache.spark.palantir.shuffle.async.client.basic.PartitionOffsetsFetcher;
+import org.apache.spark.palantir.shuffle.async.client.basic.RemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.io.PartitionDecoder;
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+
+public final class TestPartitionOffsetsFetcher implements PartitionOffsetsFetcher {
+
+  private final RemoteShuffleFileSystem remoteShuffleFs;
+
+  public TestPartitionOffsetsFetcher(RemoteShuffleFileSystem remoteShuffleFs) {
+    this.remoteShuffleFs = remoteShuffleFs;
+  }
+
+  @Override
+  public PartitionOffsets fetchPartitionOffsets(
+      int shuffleId, int mapId, long mapAttemptId, int reduceId) {
+    try {
+      return PartitionDecoder.decodePartitionOffsets(
+          remoteShuffleFs.getRemoteSeekableIndexFile(
+              shuffleId, mapId, mapAttemptId), reduceId);
+    } catch (IOException e) {
+      throw new SafeRuntimeException(e);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcherTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/basic/DefaultPartitionOffsetsFetcherTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.basic;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.InMemoryLocalDownloadShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.client.InMemoryRemoteShuffleFileSystem;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.PartitionOffsets;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public final class DefaultPartitionOffsetsFetcherTest {
+
+  private static final long[] TEST_OFFSETS_1 = new long[]{0L, 3L, 7L, 20L};
+  private static final byte[] TEST_OFFSETS_1_BYTES;
+
+  static {
+    ByteArrayOutputStream resolvedBytesOut;
+    try (ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+         DataOutputStream dataOut = new DataOutputStream(bytesOut)) {
+      resolvedBytesOut = bytesOut;
+      for (long offset : TEST_OFFSETS_1) {
+        dataOut.writeLong(offset);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    TEST_OFFSETS_1_BYTES = resolvedBytesOut.toByteArray();
+  }
+
+  private static final int SHUFFLE_ID = 0;
+  private static final int MAP_ID = 0;
+  private static final long ATTEMPT_ID = 0L;
+  private static final MapOutputId ALL_IDS = new MapOutputId(SHUFFLE_ID, MAP_ID, ATTEMPT_ID);
+
+  @Mock
+  private ShuffleDriverEndpointRef driverEndpointRef;
+
+  private InMemoryLocalDownloadShuffleFileSystem localShuffleFs;
+  private InMemoryRemoteShuffleFileSystem remoteShuffleFs;
+  private DefaultPartitionOffsetsFetcher offsetsFetcherUnderTest;
+  private DeterministicScheduler cleanupScheduler;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    when(driverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(true);
+    localShuffleFs = new InMemoryLocalDownloadShuffleFileSystem();
+    remoteShuffleFs = new InMemoryRemoteShuffleFileSystem();
+    cleanupScheduler = new DeterministicScheduler();
+    remoteShuffleFs.putIndexFile(SHUFFLE_ID, MAP_ID, ATTEMPT_ID, TEST_OFFSETS_1_BYTES);
+  }
+
+  @Test
+  public void testFetchingDirectlyFromRemoteStorage() {
+    offsetsFetcherUnderTest = new DefaultPartitionOffsetsFetcher(
+        localShuffleFs,
+        remoteShuffleFs,
+        cleanupScheduler,
+        driverEndpointRef,
+        128,
+        128,
+        false);
+    offsetsFetcherUnderTest.startCleaningIndexFiles();
+    verifyCorrectOffsets();
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isFalse();
+  }
+
+  @Test
+  public void testFetchingToDisk() {
+    offsetsFetcherUnderTest = new DefaultPartitionOffsetsFetcher(
+        localShuffleFs,
+        remoteShuffleFs,
+        cleanupScheduler,
+        driverEndpointRef,
+        128,
+        128,
+        true);
+    offsetsFetcherUnderTest.startCleaningIndexFiles();
+    verifyCorrectOffsets();
+    assertThat(localShuffleFs.indexFileReadCounts().get(ALL_IDS))
+        .isEqualTo(TEST_OFFSETS_1.length - 1);
+    assertThat(remoteShuffleFs.indexFileReadCounts().get(ALL_IDS)).isEqualTo(1);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isTrue();
+    assertThat(localShuffleFs.readAllIndexFileBytes(SHUFFLE_ID, MAP_ID, ATTEMPT_ID))
+        .containsExactly(TEST_OFFSETS_1_BYTES);
+  }
+
+  @Test
+  public void testCleanupLocalFiles() {
+    offsetsFetcherUnderTest = new DefaultPartitionOffsetsFetcher(
+        localShuffleFs,
+        remoteShuffleFs,
+        cleanupScheduler,
+        driverEndpointRef,
+        128,
+        128,
+        true);
+    offsetsFetcherUnderTest.startCleaningIndexFiles();
+    offsetsFetcherUnderTest.fetchPartitionOffsets(SHUFFLE_ID, MAP_ID, ATTEMPT_ID, 0);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isTrue();
+    when(driverEndpointRef.isShuffleRegistered(SHUFFLE_ID)).thenReturn(true).thenReturn(false);
+    cleanupScheduler.tick(30, TimeUnit.SECONDS);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isTrue();
+    cleanupScheduler.tick(30, TimeUnit.SECONDS);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isFalse();
+  }
+
+  @Test
+  public void testCleaningLocalFilesCrashesAndContinues() {
+    offsetsFetcherUnderTest = new DefaultPartitionOffsetsFetcher(
+        localShuffleFs,
+        remoteShuffleFs,
+        cleanupScheduler,
+        driverEndpointRef,
+        128,
+        128,
+        true);
+    offsetsFetcherUnderTest.startCleaningIndexFiles();
+    offsetsFetcherUnderTest.fetchPartitionOffsets(SHUFFLE_ID, MAP_ID, ATTEMPT_ID, 0);
+    when(driverEndpointRef.isShuffleRegistered(SHUFFLE_ID))
+        .thenThrow(RuntimeException.class)
+        .thenReturn(false);
+    cleanupScheduler.tick(30, TimeUnit.SECONDS);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isTrue();
+    cleanupScheduler.tick(30, TimeUnit.SECONDS);
+    assertThat(localShuffleFs.doesLocalIndexFileExist(SHUFFLE_ID, MAP_ID, ATTEMPT_ID)).isFalse();
+  }
+
+  private void verifyCorrectOffsets() {
+    for (int i = 0; i < TEST_OFFSETS_1.length - 1; i++) {
+      PartitionOffsets expected = PartitionOffsets.of(TEST_OFFSETS_1[i], TEST_OFFSETS_1[i + 1]);
+      PartitionOffsets actual = offsetsFetcherUnderTest.fetchPartitionOffsets(
+          SHUFFLE_ID, MAP_ID, ATTEMPT_ID, i);
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleUploadCoordinatorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/MergingShuffleUploadCoordinatorTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.client.TestClock;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.util.SizedInput;
+
+import org.assertj.guava.api.MultimapAssert;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+public final class MergingShuffleUploadCoordinatorTest {
+
+  private static final long BATCH_SIZE_BYTES = 1000L;
+  private static final long BATCH_AGE_MILLIS = 500L;
+  private static final int MAX_BUFFERED_INPUTS = 100;
+  private static final long POLLING_INTERVAL_MILLIS = 1000L;
+
+  @Mock
+  private ShuffleDriverEndpointRef driverEndpointRef;
+
+  private MergingShuffleUploadCoordinator coordinatorUnderTest;
+  private TestShuffleFileBatchUploader shuffleFileBatchUploader;
+  private TestClock clock;
+  private DeterministicScheduler uploadCoodinatorExecutor;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    this.clock = new TestClock();
+    this.uploadCoodinatorExecutor = new DeterministicScheduler();
+    this.shuffleFileBatchUploader = new TestShuffleFileBatchUploader();
+    this.coordinatorUnderTest = new MergingShuffleUploadCoordinator(
+        BATCH_SIZE_BYTES,
+        BATCH_AGE_MILLIS,
+        MAX_BUFFERED_INPUTS,
+        POLLING_INTERVAL_MILLIS,
+        driverEndpointRef,
+        MoreExecutors.listeningDecorator(uploadCoodinatorExecutor),
+        clock,
+        shuffleFileBatchUploader);
+    coordinatorUnderTest.start();
+    when(driverEndpointRef.isShuffleRegistered(anyInt())).thenReturn(true);
+  }
+
+  @Test
+  public void whenLargeShuffleFileAdded_uploadsImmediately() {
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        0, 0, 0L, BATCH_SIZE_BYTES));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).hasSize(1);
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).containsKeys(0);
+    List<ShuffleMapInputBatch> batches = ImmutableList.copyOf(
+        shuffleFileBatchUploader.submittedBatches.get(0));
+    assertThat(batches).hasSize(1);
+    assertThat(batches.get(0).inputBatch()).hasSize(1);
+    assertThat(batches.get(0).mapOutputIds())
+        .containsExactly(new MapOutputId(0, 0, 0L));
+    assertThat(batches.get(0).totalDataSizeInBytes()).isEqualTo(BATCH_SIZE_BYTES);
+  }
+
+  @Test
+  public void whenMultipleShuffleFilesAreAdded_doesNotUploadUntilBatchIsBigEnough() {
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        0, 0, 0L, BATCH_SIZE_BYTES / 3L));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        0, 2, 0L, BATCH_SIZE_BYTES / 3L));
+    // Test that buffering another input in a different shuffle id doesn't trigger an upload for
+    // the previous shuffle id.
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        1, 0, 0L, BATCH_SIZE_BYTES / 2L));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        0, 1, 0L, BATCH_SIZE_BYTES));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).hasSize(1);
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).containsKeys(0);
+    List<ShuffleMapInputBatch> batches = ImmutableList.copyOf(
+        shuffleFileBatchUploader.submittedBatches.get(0));
+    assertThat(batches).hasSize(1);
+    assertThat(batches.get(0).inputBatch()).hasSize(3);
+    assertThat(batches.get(0).mapOutputIds())
+        .containsExactlyInAnyOrder(
+            new MapOutputId(0, 0, 0L),
+            new MapOutputId(0, 1, 0L),
+            new MapOutputId(0, 2, 0L));
+  }
+
+  @Test
+  public void whenBufferedInputsAreSaturated_uploadsAllInputs() {
+    for (int shuffleId = 0; shuffleId < MAX_BUFFERED_INPUTS; shuffleId++) {
+      coordinatorUnderTest.addShuffleMapInputForUpload(newInput(shuffleId, 0, 0L, 1L));
+    }
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(
+        MAX_BUFFERED_INPUTS, 0, 0L, 1L));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).hasSize(MAX_BUFFERED_INPUTS + 1);
+    assertThat(shuffleFileBatchUploader.submittedBatches.asMap())
+        .allSatisfy((key, value) -> assertThat(value).hasSize(1));
+    assertThat(shuffleFileBatchUploader.submittedBatches.values()
+        .stream()
+        .flatMap(batch -> Arrays.stream(batch.mapOutputIds()))
+        .collect(Collectors.toList()))
+        .containsExactlyInAnyOrder(
+            IntStream.rangeClosed(0, MAX_BUFFERED_INPUTS)
+                .mapToObj(shuffleId -> new MapOutputId(shuffleId, 0, 0L))
+                .toArray(MapOutputId[]::new));
+  }
+
+  @Test
+  public void whenInputBatchIsOld_uploadsImmediately() {
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(0, 0, 0L, 1L));
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    clock.addMillis(BATCH_AGE_MILLIS + 1);
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).hasSize(1);
+    assertThat(shuffleFileBatchUploader.submittedBatches.values()).hasSize(1);
+    assertThat(
+        Iterables.getOnlyElement(shuffleFileBatchUploader.submittedBatches.values()).mapOutputIds())
+        .containsExactly(new MapOutputId(0, 0, 0L));
+  }
+
+  @Test
+  public void whenShufflesAreNoLongerRegistered_doesNotUpload() {
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(0, 0, 0L, BATCH_SIZE_BYTES));
+    when(driverEndpointRef.isShuffleRegistered(0)).thenReturn(false);
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(1, 0, 0L, 1L));
+    tickAndRunCoordinator();
+    clock.addMillis(BATCH_AGE_MILLIS + 1);
+    when(driverEndpointRef.isShuffleRegistered(1)).thenReturn(false);
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+  }
+
+  @Test
+  public void whenExceptionIsThrownInCoordinator_doesNotCancelFuturePollingRounds() {
+    coordinatorUnderTest.addShuffleMapInputForUpload(newInput(0, 0, 0L, BATCH_SIZE_BYTES));
+    when(driverEndpointRef.isShuffleRegistered(0))
+        .thenThrow(IllegalStateException.class)
+        .thenReturn(true);
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).isEmpty();
+    tickAndRunCoordinator();
+    multimapAssertThat(shuffleFileBatchUploader.submittedBatches).hasSize(1);
+  }
+
+  private void tickAndRunCoordinator() {
+    uploadCoodinatorExecutor.tick(POLLING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+    uploadCoodinatorExecutor.runUntilIdle();
+  }
+
+  private static <K, V> MultimapAssert<K, V> multimapAssertThat(Multimap<K, V> map) {
+    return org.assertj.guava.api.Assertions.assertThat(map);
+  }
+
+  private static ShuffleMapInput newInput(
+      int shuffleId, int mapId, long attemptId, long dataSize) {
+    return new ShuffleMapInput(
+        new MapOutputId(shuffleId, mapId, attemptId),
+        new MockSizedInput(dataSize),
+        new MockSizedInput(dataSize));
+  }
+
+  private static final class MockSizedInput implements SizedInput {
+
+    private final long size;
+
+    MockSizedInput(long size) {
+      this.size = size;
+    }
+
+    @Override
+    public long getStreamSizeInBytes() {
+      return size;
+    }
+
+    @Override
+    public InputStream openStream() throws IOException {
+      throw new IOException("This test should not be opening streams.");
+    }
+  }
+
+  private static final class TestShuffleFileBatchUploader implements ShuffleFileBatchUploader {
+
+    private final Multimap<Integer, ShuffleMapInputBatch> submittedBatches = HashMultimap.create();
+
+    @Override
+    public void submitBatchUpload(int shuffleId, ShuffleMapInputBatch batch) {
+      submittedBatches.put(shuffleId, batch);
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleFileBatchUploaderTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/ShuffleFileBatchUploaderTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.io.ByteArraySizedInput;
+import org.apache.spark.palantir.shuffle.async.merger.FileMerger;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metrics.slf4j.Slf4jMergingShuffleClientMetrics;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class ShuffleFileBatchUploaderTest {
+
+  private static final String APP_ID = "test-app";
+  private static final byte[] FIRST_PART_DATA_BYTES = new byte[]{0, 6, 14, 2};
+  private static final byte[] FIRST_PART_INDEX_BYTES = new byte[]{0, 2};
+  private static final byte[] SECOND_PART_DATA_BYTES = new byte[]{};
+  private static final byte[] SECOND_PART_INDEX_BYTES = new byte[]{};
+  private static final byte[] THIRD_PART_DATA_BYTES = new byte[]{9, 10, 23, 5, 102};
+  private static final byte[] THIRD_PART_INDEX_BYTES = new byte[]{0, 3};
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Mock
+  private ShuffleDriverEndpointRef driverEndpointRef;
+
+  private ShuffleFileBatchUploader uploaderUnderTest;
+  private MergingShuffleFiles shuffleFiles;
+  private DeterministicScheduler uploadExecService;
+  private ShuffleMapInputBatch batchToUpload;
+
+  @Before
+  public void before() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    this.shuffleFiles = TestMergingShuffleFiles.fromTempFolder(tempFolder);
+    this.uploadExecService = new DeterministicScheduler();
+    this.uploaderUnderTest = new DefaultShuffleFileBatchUploader(
+        APP_ID,
+        driverEndpointRef,
+        shuffleFiles,
+        MoreExecutors.listeningDecorator(uploadExecService),
+        new Slf4jMergingShuffleClientMetrics("app-name"),
+        Clock.systemUTC());
+    this.batchToUpload = new ShuffleMapInputBatch()
+        .addInput(
+            new ShuffleMapInput(
+                new MapOutputId(0, 0, 0L),
+                new ByteArraySizedInput(FIRST_PART_DATA_BYTES),
+                new ByteArraySizedInput(FIRST_PART_INDEX_BYTES)),
+            System.currentTimeMillis())
+        .addInput(
+            new ShuffleMapInput(
+                new MapOutputId(0, 1, 0L),
+                new ByteArraySizedInput(SECOND_PART_DATA_BYTES),
+                new ByteArraySizedInput(SECOND_PART_INDEX_BYTES)),
+            System.currentTimeMillis())
+        .addInput(
+            new ShuffleMapInput(
+                new MapOutputId(0, 2, 0L),
+                new ByteArraySizedInput(THIRD_PART_DATA_BYTES),
+                new ByteArraySizedInput(THIRD_PART_INDEX_BYTES)),
+            System.currentTimeMillis());
+  }
+
+  @Test
+  public void testMergedUpload_cancelsIfShuffleNotRegistered() {
+    when(driverEndpointRef.isShuffleRegistered(0)).thenReturn(false);
+    uploaderUnderTest.submitBatchUpload(0, batchToUpload);
+    uploadExecService.runUntilIdle();
+    verify(driverEndpointRef, never()).registerMergedMapOutput(any(), anyLong());
+  }
+
+  @Test
+  public void testMergedUpload() throws IOException {
+    when(driverEndpointRef.isShuffleRegistered(0)).thenReturn(true);
+    when(driverEndpointRef.getNextMergeId()).thenReturn(0L);
+    uploaderUnderTest.submitBatchUpload(0, batchToUpload);
+    uploadExecService.runUntilIdle();
+    verify(driverEndpointRef).registerMergedMapOutput(Arrays.asList(
+        batchToUpload.mapOutputIds()), 0L);
+    TestMapOutputStreamProvider dataStreamProvider = new TestMapOutputStreamProvider(tempFolder);
+    try (InputStream mergedInput = shuffleFiles.openRemoteMergedDataFile(0);
+         DataInputStream dataMergedInput = new DataInputStream(mergedInput)) {
+      FileMerger.fetchAndSplitMergedInput(dataMergedInput, dataStreamProvider);
+    }
+    assertThat(dataStreamProvider.downloadedFiles).hasSize(3);
+
+    TestMapOutputStreamProvider indexStreamProvider = new TestMapOutputStreamProvider(tempFolder);
+    try (InputStream mergedInput = shuffleFiles.openRemoteMergedIndexFile(0);
+         DataInputStream dataMergedInput = new DataInputStream(mergedInput)) {
+      FileMerger.fetchAndSplitMergedInput(dataMergedInput, indexStreamProvider);
+    }
+    assertThat(indexStreamProvider.downloadedFiles).hasSize(3);
+
+    checkDownloadedDataFiles(dataStreamProvider);
+    checkDownloadedIndexFiles(indexStreamProvider);
+  }
+
+  private void checkDownloadedDataFiles(TestMapOutputStreamProvider dataStreamProvider) {
+    dataStreamProvider.downloadedFiles.forEach((mapOutputId, file) -> {
+      assertThat(mapOutputId).isIn(Arrays.asList(batchToUpload.mapOutputIds()));
+      ShuffleMapInput originalInput = Arrays.stream(batchToUpload.inputBatch())
+          .filter(input -> input.mapOutputId().equals(mapOutputId))
+          .findFirst()
+          .orElseThrow(() -> new IllegalStateException("Original map input is missing."));
+      byte[] originalInputBytes;
+      try (InputStream originalInputStream = originalInput.dataSizedInput().openStream()) {
+        originalInputBytes = ByteStreams.toByteArray(originalInputStream);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      byte[] downloadedBytes;
+      try {
+        downloadedBytes = Files.toByteArray(file);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      assertThat(downloadedBytes).containsExactly(originalInputBytes);
+    });
+  }
+
+  private void checkDownloadedIndexFiles(TestMapOutputStreamProvider indexStreamProvider) {
+    indexStreamProvider.downloadedFiles.forEach((mapOutputId, file) -> {
+      assertThat(mapOutputId).isIn(Arrays.asList(batchToUpload.mapOutputIds()));
+      ShuffleMapInput originalInput = Arrays.stream(batchToUpload.inputBatch())
+          .filter(input -> input.mapOutputId().equals(mapOutputId))
+          .findFirst()
+          .orElseThrow(() -> new IllegalStateException("Original map input is missing."));
+      byte[] originalInputBytes;
+      try (InputStream originalInputStream = originalInput.indexSizedInput().openStream()) {
+        originalInputBytes = ByteStreams.toByteArray(originalInputStream);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      byte[] downloadedBytes;
+      try {
+        downloadedBytes = Files.toByteArray(file);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      assertThat(downloadedBytes).containsExactly(originalInputBytes);
+    });
+  }
+
+  private static final class TestMapOutputStreamProvider
+      implements FileMerger.MapOutputStreamProvider {
+    private final TemporaryFolder downloadTempFolder;
+    private final Map<MapOutputId, File> downloadedFiles;
+
+    private TestMapOutputStreamProvider(TemporaryFolder downloadTempFolder) {
+      this.downloadTempFolder = downloadTempFolder;
+      this.downloadedFiles = new HashMap<>();
+    }
+
+    @Override
+    public Optional<FileMerger.OutputStreamSupplier> getMapOutputStreamIfNotExists(
+        int shuffleId, int mapId, long attemptId) throws IOException {
+      File outputFile = downloadTempFolder.newFile();
+      downloadedFiles.put(new MapOutputId(shuffleId, mapId, attemptId), outputFile);
+      return Optional.of(() -> new FileOutputStream(outputFile));
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/TestMergingShuffleFiles.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/client/merging/TestMergingShuffleFiles.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.client.merging;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableFileInput;
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+import org.junit.rules.TemporaryFolder;
+
+public final class TestMergingShuffleFiles implements MergingShuffleFiles {
+
+  private final File localFolder;
+  private final File remoteFolder;
+
+  private TestMergingShuffleFiles(File localFolder, File remoteFolder) {
+    this.localFolder = localFolder;
+    this.remoteFolder = remoteFolder;
+  }
+
+  public static MergingShuffleFiles fromTempFolder(TemporaryFolder tempFolder) throws IOException {
+    File localFolder = tempFolder.newFolder("local-files");
+    File remoteFolder = tempFolder.newFolder("remote-files");
+    return new TestMergingShuffleFiles(localFolder, remoteFolder);
+  }
+
+  @Override
+  public SeekableInput getLocalBackupIndexFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableFileInput(resolveLocal(shuffleId, mapId, attemptId, "index"));
+  }
+
+  @Override
+  public SeekableInput getLocalBackupDataFile(int shuffleId, int mapId, long attemptId) {
+    return new SeekableFileInput(resolveLocal(shuffleId, mapId, attemptId, "data"));
+  }
+
+  @Override
+  public OutputStream createLocalBackupIndexFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    return new FileOutputStream(resolveLocal(shuffleId, mapId, attemptId, "index"));
+  }
+
+  @Override
+  public OutputStream createLocalBackupDataFile(
+      int shuffleId, int mapId, long attemptId) throws IOException {
+    return new FileOutputStream(resolveLocal(shuffleId, mapId, attemptId, "data"));
+  }
+
+  @Override
+  public boolean doesLocalBackupDataFileExist(int shuffleId, int mapId, long attemptId) {
+    return resolveLocal(shuffleId, mapId, attemptId, "data").isFile();
+  }
+
+  @Override
+  public boolean doesLocalBackupIndexFileExist(int shuffleId, int mapId, long attemptId) {
+    return resolveLocal(shuffleId, mapId, attemptId, "index").isFile();
+  }
+
+  @Override
+  public InputStream openRemoteMergedIndexFile(long mergeId) throws IOException {
+    return new FileInputStream(resolveRemote(mergeId, "index"));
+  }
+
+  @Override
+  public InputStream openRemoteMergedDataFile(long mergeId) throws IOException {
+    return new FileInputStream(resolveRemote(mergeId, "data"));
+  }
+
+  @Override
+  public OutputStream createRemoteMergedIndexFile(long mergeId) throws IOException {
+    return new FileOutputStream(resolveRemote(mergeId, "index"));
+  }
+
+  @Override
+  public OutputStream createRemoteMergedDataFile(long mergeId) throws IOException {
+    return new FileOutputStream(resolveRemote(mergeId, "data"));
+  }
+
+  private File resolveLocal(int shuffleId, int mapId, long attemptId, String extension) {
+    return localFolder.toPath().resolve(
+        String.format("%d-%d-%d.%s", shuffleId, mapId, attemptId, extension)).toFile();
+  }
+
+  private File resolveRemote(long mergeId, String extension) {
+    return remoteFolder
+        .toPath()
+        .resolve(String.format("merged-%d.%s", mergeId, extension)).toFile();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/ByteArraySizedInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/ByteArraySizedInput.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.spark.palantir.shuffle.async.util.SizedInput;
+
+public final class ByteArraySizedInput implements SizedInput {
+
+  private final byte[] bytes;
+
+  public ByteArraySizedInput(byte[] bytes) {
+    this.bytes = bytes;
+  }
+
+  @Override
+  public long getStreamSizeInBytes() {
+    return bytes.length;
+  }
+
+  @Override
+  public InputStream openStream() throws IOException {
+    return new ByteArrayInputStream(bytes);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponentsEteTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponentsEteTest.java
@@ -178,7 +178,7 @@ public final class HadoopAsyncShuffleExecutorComponentsEteTest {
         shuffleFileLocator, MAPPER_LOCATION);
     this.clock = new TestClock();
     when(metricsFactory.create(eq(sparkConf), any())).thenReturn(metrics);
-    when(metrics.s3FetcherIteratorMetrics()).thenReturn(hadoopFetcherIteratorMetrics);
+    when(metrics.hadoopFetcherIteratorMetrics()).thenReturn(hadoopFetcherIteratorMetrics);
     when(metrics.basicShuffleClientMetrics()).thenReturn(basicShuffleClientMetrics);
     when(metrics.mergingShuffleClientMetrics()).thenReturn(mergingShuffleClientMetrics);
     when(sparkEnv.blockManager()).thenReturn(blockManager);

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponentsEteTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponentsEteTest.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.api.java.Optional;
+import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleUploadDriverEndpoint;
+import org.apache.spark.palantir.shuffle.async.InProcessShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.api.SparkShuffleApiConstants;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleStorageStrategy;
+import org.apache.spark.palantir.shuffle.async.client.TestClock;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker;
+import org.apache.spark.palantir.shuffle.async.metrics.BasicShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.MergingShuffleClientMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetrics;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopAsyncShuffleMetricsFactory;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+import org.apache.spark.rpc.RpcEndpointRef;
+import org.apache.spark.rpc.RpcEnv;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+import org.apache.spark.storage.BlockManager;
+import org.apache.spark.storage.BlockManagerId;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public final class HadoopAsyncShuffleExecutorComponentsEteTest {
+
+  private static final BlockManagerId MAPPER_LOCATION = BlockManagerId.apply(
+      "localhost", 1234);
+
+  private static final byte[][] PARTITIONED_DATA = new byte[][]{
+      new byte[]{0, 4, -1, -10},
+      new byte[]{},
+      new byte[]{15, 2, 7, 23, 5, 11}
+  };
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][]{
+        new Object[]{ShuffleStorageStrategy.BASIC},
+        new Object[]{ShuffleStorageStrategy.MERGING}
+    };
+  }
+
+  private final ShuffleStorageStrategy storageStrategy;
+
+  @Mock
+  private SparkEnv sparkEnv;
+
+  @Mock
+  private RpcEnv rpcEnv;
+
+  @Mock
+  private SerializerManager serializerManager;
+
+  @Mock
+  private CompressionCodec compressionCodec;
+
+  @Mock
+  private HadoopAsyncShuffleMetricsFactory metricsFactory;
+
+  @Mock
+  private HadoopAsyncShuffleMetrics metrics;
+
+  @Mock
+  private HadoopFetcherIteratorMetrics hadoopFetcherIteratorMetrics;
+
+  @Mock
+  private BasicShuffleClientMetrics basicShuffleClientMetrics;
+
+  @Mock
+  private MergingShuffleClientMetrics mergingShuffleClientMetrics;
+
+  @Mock
+  private BlockManager blockManager;
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private ExecutorService downloadExecutorService;
+  private DeterministicScheduler uploadExecutorService;
+  private DeterministicScheduler uploadCoordinatorExecutorService;
+  private ShuffleFileLocator shuffleFileLocator;
+  private SparkConf sparkConf;
+  private File localShuffleDir;
+  private File remoteShuffleDir;
+  private ShuffleExecutorComponents executorComponentsUnderTest;
+  private TestClock clock;
+  private RpcEndpointRef shuffleDriverEndpointRef;
+  private ShuffleStorageStateTracker shuffleStorageStateTracker;
+
+  public HadoopAsyncShuffleExecutorComponentsEteTest(ShuffleStorageStrategy storageStrategy) {
+    this.storageStrategy = storageStrategy;
+  }
+
+  @Before
+  public void before() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    this.uploadExecutorService = new DeterministicScheduler();
+    this.downloadExecutorService = Executors.newSingleThreadExecutor(
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-download-%d").build());
+    this.uploadCoordinatorExecutorService = new DeterministicScheduler();
+    this.localShuffleDir = tempFolder.newFolder("local-shuffles");
+    this.remoteShuffleDir = tempFolder.newFolder("remote-shuffles");
+    this.sparkConf = new SparkConf()
+        .set(AsyncShuffleDataIoSparkConfigs.BASE_URI(),
+            String.format("file://%s", remoteShuffleDir.getAbsolutePath()))
+        .set(AsyncShuffleDataIoSparkConfigs.STORAGE_STRATEGY(), storageStrategy.value())
+        .set(SparkShuffleApiConstants.SHUFFLE_PLUGIN_APP_NAME_CONF, "spark-app")
+        .set("spark.local.dir", tempFolder.newFolder().getAbsolutePath());
+    this.shuffleFileLocator = new TestShuffleFileLocator(localShuffleDir);
+    ShuffleExecutorComponents delegateTestComponents = new TestShuffleExecutorComponents(
+        shuffleFileLocator, MAPPER_LOCATION);
+    this.clock = new TestClock();
+    when(metricsFactory.create(eq(sparkConf), any())).thenReturn(metrics);
+    when(metrics.s3FetcherIteratorMetrics()).thenReturn(hadoopFetcherIteratorMetrics);
+    when(metrics.basicShuffleClientMetrics()).thenReturn(basicShuffleClientMetrics);
+    when(metrics.mergingShuffleClientMetrics()).thenReturn(mergingShuffleClientMetrics);
+    when(sparkEnv.blockManager()).thenReturn(blockManager);
+    when(blockManager.blockManagerId()).thenReturn(MAPPER_LOCATION);
+    this.executorComponentsUnderTest = new HadoopAsyncShuffleExecutorComponents(
+        sparkConf,
+        delegateTestComponents,
+        java.util.Optional.of(clock),
+        () -> sparkEnv,
+        () -> shuffleFileLocator,
+        () -> compressionCodec,
+        java.util.Optional.of(uploadExecutorService),
+        java.util.Optional.of(downloadExecutorService),
+        java.util.Optional.of(uploadCoordinatorExecutorService),
+        java.util.Optional.of(() -> metricsFactory));
+    this.shuffleStorageStateTracker = new ShuffleStorageStateTracker();
+    this.shuffleDriverEndpointRef = new InProcessShuffleDriverEndpointRef(
+        sparkConf,
+        new AsyncShuffleUploadDriverEndpoint(rpcEnv, shuffleStorageStateTracker),
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("test-driver-endpoint-%d")
+                .build()));
+    when(sparkEnv.rpcEnv()).thenReturn(rpcEnv);
+    when(rpcEnv.setupEndpointRef(any(), eq(AsyncShuffleUploadDriverEndpoint.NAME())))
+        .thenReturn(shuffleDriverEndpointRef);
+    when(sparkEnv.serializerManager()).thenReturn(serializerManager);
+    when(serializerManager.wrapForEncryption(any(InputStream.class)))
+        .thenAnswer(AdditionalAnswers.returnsFirstArg());
+    when(serializerManager.wrapForEncryption(any(OutputStream.class)))
+        .thenAnswer(AdditionalAnswers.returnsFirstArg());
+    when(compressionCodec.compressedInputStream(any()))
+        .thenAnswer(AdditionalAnswers.returnsFirstArg());
+    when(compressionCodec.compressedOutputStream(any()))
+        .thenAnswer(AdditionalAnswers.returnsFirstArg());
+    executorComponentsUnderTest.initializeExecutor(
+        "test-app", "exec-0", ImmutableMap.of());
+  }
+
+  @Test
+  public void testWriteAndRead() throws IOException {
+    writePartitionedData();
+    readAndCheckPartitions(1, 2);
+    readAndCheckPartitions(0);
+    readAndCheckPartitions(1);
+    verify(hadoopFetcherIteratorMetrics, never()).markFetchFromRemoteSucceeded(
+        anyInt(), anyInt(), anyInt(), anyLong());
+  }
+
+  @Test
+  public void testWrite_whenLocalFileIsDeleted_fallsBackToRemoteFiles() throws IOException {
+    writePartitionedData();
+    Files.delete(shuffleFileLocator.getDataFile(0, 0).toPath());
+    shuffleStorageStateTracker.blacklistExecutor(MAPPER_LOCATION);
+    readAndCheckPartitions(1, 2);
+    readAndCheckPartitions(0);
+    readAndCheckPartitions(1);
+    verify(hadoopFetcherIteratorMetrics, atLeastOnce()).markFetchFromRemoteSucceeded(
+        anyInt(), anyInt(), anyInt(), anyLong());
+  }
+
+  private void writePartitionedData() throws IOException {
+    shuffleStorageStateTracker.registerShuffle(0);
+    ShuffleMapOutputWriter mapOutputWriter = executorComponentsUnderTest.createMapOutputWriter(
+        0, 0, 0, PARTITIONED_DATA.length);
+    for (int partition = 0; partition < PARTITIONED_DATA.length; partition++) {
+      byte[] partitionData = PARTITIONED_DATA[partition];
+      ShufflePartitionWriter partWriter = mapOutputWriter.getPartitionWriter(partition);
+      try (OutputStream partStream = partWriter.openStream()) {
+        ByteStreams.copy(new ByteArrayInputStream(partitionData), partStream);
+      }
+      assertThat(partWriter.getNumBytesWritten()).isEqualTo(partitionData.length);
+    }
+    mapOutputWriter.commitAllPartitions();
+    assertThat(shuffleStorageStateTracker.getShuffleStorageState(
+        new MapOutputId(0, 0, 0))).isNotNull();
+    assertThat(shuffleStorageStateTracker.getShuffleStorageStates(0)).isNotNull();
+    clock.addMillis(Long.MAX_VALUE / 2);
+    uploadCoordinatorExecutorService.tick(1, TimeUnit.MINUTES);
+    uploadCoordinatorExecutorService.runUntilIdle();
+    uploadExecutorService.runUntilIdle();
+  }
+
+  private void readAndCheckPartitions(Integer... partitions) throws IOException {
+    List<ShuffleBlockInfo> blocksToFetch = Arrays.stream(partitions)
+        .map(partId -> new ShuffleBlockInfo(
+            0,
+            0,
+            partId,
+            (long) PARTITIONED_DATA[partId].length,
+            0L,
+            Optional.of(MAPPER_LOCATION)))
+        .collect(Collectors.toList());
+    Set<List<Byte>> partBytes =
+        ImmutableSet.copyOf(
+            StreamSupport.stream(executorComponentsUnderTest
+                .getPartitionReaders(blocksToFetch)
+                .spliterator(), false)
+                .map(partStream -> {
+                  byte[] partByteArray;
+                  try (InputStream closingPartStream = partStream) {
+                    partByteArray = ByteStreams.toByteArray(closingPartStream);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                  return toList(partByteArray);
+                }).collect(Collectors.toList()));
+    Set<List<Byte>> expectedPartitions = Arrays.stream(partitions)
+        .map(part -> toList(PARTITIONED_DATA[part]))
+        .collect(Collectors.toSet());
+    assertThat(partBytes).isEqualTo(expectedPartitions);
+  }
+
+  private static List<Byte> toList(byte[] byteArray) {
+    List<Byte> byteList = new ArrayList<>(byteArray.length);
+    for (byte byteElement : byteArray) {
+      byteList.add(byteElement);
+    }
+    return byteList;
+  }
+
+  private static final class TestShuffleFileLocator implements ShuffleFileLocator {
+    private final File shuffleDir;
+
+    private TestShuffleFileLocator(File shuffleDir) {
+      this.shuffleDir = shuffleDir;
+    }
+
+    @Override
+    public File getDataFile(int shuffleId, int mapId) {
+      return resolveShuffleDir(shuffleId, mapId).resolve("shuffle.data").toFile();
+    }
+
+    @Override
+    public File getIndexFile(int shuffleId, int mapId) {
+      return resolveShuffleDir(shuffleId, mapId).resolve("shuffle.index").toFile();
+    }
+
+    private Path resolveShuffleDir(int shuffleId, int mapId) {
+      return shuffleDir
+          .toPath()
+          .resolve(Integer.toString(shuffleId))
+          .resolve(Integer.toString(mapId));
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/SeekableByteArrayInput.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/SeekableByteArrayInput.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+
+import org.apache.spark.palantir.shuffle.async.util.streams.SeekableInput;
+
+public final class SeekableByteArrayInput implements SeekableInput {
+
+  private final byte[] array;
+
+  public SeekableByteArrayInput(byte[] array) {
+    this.array = array;
+  }
+
+  @Override
+  public InputStream open() {
+    return new ByteArrayInputStream(array);
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition, long _len) throws IOException {
+    return seekToAndOpen(startPosition);
+  }
+
+  @Override
+  public InputStream seekToAndOpen(long startPosition) throws IOException {
+    SeekableByteChannel arrayAsChannel = new SeekableInMemoryByteChannel(array);
+    arrayAsChannel.position(startPosition);
+    return Channels.newInputStream(arrayAsChannel);
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/TestShuffleExecutorComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/TestShuffleExecutorComponents.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import com.google.common.collect.Queues;
+import com.google.common.io.CountingOutputStream;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIoException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Queue;
+
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.palantir.shuffle.async.FetchFailedExceptionThrower;
+import org.apache.spark.shuffle.api.MapOutputWriterCommitMessage;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockId;
+
+/**
+ * Mirrors the default shuffle executor components but strips away many of the Spark-specific
+ * components - particularly the IndexShuffleBlockResolver.
+ */
+public final class TestShuffleExecutorComponents implements ShuffleExecutorComponents {
+
+  private final ShuffleFileLocator shuffleFileLocator;
+  private final BlockManagerId mapperLocation;
+
+  public TestShuffleExecutorComponents(
+      ShuffleFileLocator shuffleFileLocator, BlockManagerId mapperLocation) {
+    this.shuffleFileLocator = shuffleFileLocator;
+    this.mapperLocation = mapperLocation;
+  }
+
+  @Override
+  public void initializeExecutor(
+      String _appId, String _execId, Map<String, String> _extraConfigs) {
+  }
+
+  @Override
+  public ShuffleMapOutputWriter createMapOutputWriter(
+      int shuffleId, int mapId, long _mapTaskAttemptId, int _numPartitions) {
+    return new TestShuffleMapOutputWriter(shuffleFileLocator, mapperLocation, shuffleId, mapId);
+  }
+
+  @Override
+  public Iterable<ShuffleBlockInputStream> getPartitionReaders(
+      Iterable<ShuffleBlockInfo> blockMetadata) {
+    return () -> {
+      Iterator<ShuffleBlockInfo> blockMetadataIt = blockMetadata.iterator();
+      return new Iterator<ShuffleBlockInputStream>() {
+
+        @Override
+        public boolean hasNext() {
+          return blockMetadataIt.hasNext();
+        }
+
+        @Override
+        public ShuffleBlockInputStream next() {
+          ShuffleBlockInfo block = blockMetadataIt.next();
+          File dataFile = shuffleFileLocator.getDataFile(block.getShuffleId(), block.getMapId());
+          File indexFile = shuffleFileLocator.getIndexFile(
+              block.getShuffleId(),
+              block.getMapId());
+          if (!dataFile.isFile() || !indexFile.isFile()) {
+            FetchFailedExceptionThrower.throwFetchFailedException(
+                block.getShuffleId(),
+                block.getMapId(),
+                block.getReduceId(),
+                mapperLocation,
+                "Test fetch failed.",
+                null);
+          }
+          long dataOffset;
+          long nextOffset;
+
+          try (SeekableByteChannel indexFileInput = Files.newByteChannel(indexFile.toPath())) {
+            indexFileInput.position(block.getReduceId() * 8L);
+            DataInputStream indexDataIn =
+                new DataInputStream(Channels.newInputStream(indexFileInput));
+            dataOffset = indexDataIn.readLong();
+            nextOffset = indexDataIn.readLong();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+
+          try {
+            SeekableByteChannel dataIn = Files.newByteChannel(dataFile.toPath());
+            dataIn.position(dataOffset);
+            return new ShuffleBlockInputStream(
+                new ShuffleBlockId(block.getShuffleId(), block.getMapId(), block.getReduceId()),
+                new LimitedInputStream(Channels.newInputStream(dataIn), nextOffset - dataOffset));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      };
+    };
+  }
+
+  private static final class TestShuffleMapOutputWriter implements ShuffleMapOutputWriter {
+    private final ShuffleFileLocator shuffleFileLocator;
+    private final BlockManagerId mapperLocation;
+    private final int shuffleId;
+    private final int mapId;
+    private final ByteArrayOutputStream partitionBytesOut;
+    private final Queue<Long> partitionLengths;
+
+    TestShuffleMapOutputWriter(
+        ShuffleFileLocator shuffleFileLocator,
+        BlockManagerId mapperLocation,
+        int shuffleId,
+        int mapId) {
+      this.shuffleFileLocator = shuffleFileLocator;
+      this.mapperLocation = mapperLocation;
+      this.shuffleId = shuffleId;
+      this.mapId = mapId;
+      this.partitionBytesOut = new ByteArrayOutputStream();
+      this.partitionLengths = Queues.newArrayDeque();
+    }
+
+    @Override
+    public ShufflePartitionWriter getPartitionWriter(int _partitionId) {
+      return new TestShufflePartitionWriter(partitionBytesOut, partitionLengths);
+    }
+
+    @Override
+    public MapOutputWriterCommitMessage commitAllPartitions() throws IOException {
+      File dataFile = shuffleFileLocator.getDataFile(shuffleId, mapId);
+      File indexFile = shuffleFileLocator.getIndexFile(shuffleId, mapId);
+      if (dataFile.exists()) {
+        throw new SafeIllegalStateException(
+            "Data file already exists.", SafeArg.of("dataFile", dataFile.getAbsolutePath()));
+      }
+      if (!dataFile.getParentFile().isDirectory() && !dataFile.getParentFile().mkdirs()) {
+        throw new SafeIoException(
+            "Failed to create the data directory.",
+            SafeArg.of("dataDir", dataFile.getParentFile().getAbsolutePath()));
+      }
+      Files.write(dataFile.toPath(), partitionBytesOut.toByteArray());
+      try (DataOutputStream indexOut = new DataOutputStream(new FileOutputStream(indexFile))) {
+        // We take in lengths of each block, need to convert it to offsets.
+        long offset = 0L;
+        indexOut.writeLong(offset);
+        for (long length : partitionLengths) {
+          offset += length;
+          indexOut.writeLong(offset);
+        }
+      }
+      return MapOutputWriterCommitMessage.of(
+          partitionLengths.stream().mapToLong(Long::valueOf).toArray(),
+          mapperLocation);
+    }
+
+    @Override
+    public void abort(Throwable _error) {
+    }
+  }
+
+  private static final class TestShufflePartitionWriter implements ShufflePartitionWriter {
+
+    private final CountingOutputStream countingPartitionBytesOut;
+    private final Queue<Long> partitionLengths;
+
+    TestShufflePartitionWriter(
+        ByteArrayOutputStream partitionBytesOut, Queue<Long> partitionLengths) {
+      this.countingPartitionBytesOut = new CountingOutputStream(partitionBytesOut);
+      this.partitionLengths = partitionLengths;
+    }
+
+    @Override
+    public OutputStream openStream() {
+      return new FilterOutputStream(countingPartitionBytesOut) {
+        @Override
+        public void close() throws IOException {
+          flush();
+          partitionLengths.add(countingPartitionBytesOut.getCount());
+        }
+      };
+    }
+
+    @Override
+    public long getNumBytesWritten() {
+      return countingPartitionBytesOut.getCount();
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
@@ -97,7 +97,7 @@ public final class DefaultHadoopFetcherIteratorTest {
   @Test
   public void testFetchFails() {
     fetcherIterator.fetchDataFromHadoop();
-    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+    inputStreamFuture.setException(new Exception("Could not fetch from remote storage."));
     assertThatThrownBy(() -> fetcherIterator.next())
         .isInstanceOf(FetchFailedException.class)
         .hasMessageContaining("Exception thrown when fetching data from remote storage.");
@@ -114,7 +114,7 @@ public final class DefaultHadoopFetcherIteratorTest {
   @Test
   public void testFetchedFailedStreamsInCleanup() {
     fetcherIterator.fetchDataFromHadoop();
-    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+    inputStreamFuture.setException(new Exception("Could not fetch from remote storage."));
     fetcherIterator.cleanup();
   }
 
@@ -147,7 +147,7 @@ public final class DefaultHadoopFetcherIteratorTest {
     fetcherIterator.fetchDataFromHadoop();
 
     inputStreamFuture1.set(() -> inputStream);
-    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+    inputStreamFuture.setException(new Exception("Could not fetch from remote storage."));
 
     fetcherIterator.cleanup();
     assertThat(inputStreamFuture2).isCancelled();

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.apache.spark.api.java.Optional;
+import org.apache.spark.palantir.shuffle.async.client.ShuffleClient;
+import org.apache.spark.palantir.shuffle.async.metrics.HadoopFetcherIteratorMetrics;
+import org.apache.spark.shuffle.FetchFailedException;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class DefaultHadoopFetcherIteratorTest {
+
+  @Mock
+  private ShuffleClient shuffleClient;
+  @Mock
+  private HadoopFetcherIteratorMetrics metrics;
+  @Mock
+  private ShuffleBlockInputStream inputStream;
+
+  private static final int SHUFFLE_ID = 0;
+  private static final int MAP_ID = 10;
+  private static final int REDUCE_ID = 4;
+  private static final long ATTEMPT_ID = 3;
+  private static final long BLOCK_LENGTH = 10;
+  private static final ShuffleBlockId SHUFFLE_BLOCK_ID =
+      ShuffleBlockId.apply(SHUFFLE_ID, MAP_ID, REDUCE_ID);
+  private static final BlockManagerId BLOCK_MANAGER_ID = BlockManagerId.apply("host", 1234);
+  private static final ShuffleBlockInfo SHUFFLE_BLOCK_INFO =
+      new ShuffleBlockInfo(
+          SHUFFLE_ID, MAP_ID, REDUCE_ID, BLOCK_LENGTH, ATTEMPT_ID, Optional.of(BLOCK_MANAGER_ID));
+
+  private DefaultHadoopFetcherIterator fetcherIterator;
+  private SettableFuture<Supplier<InputStream>> inputStreamFuture;
+  private Set<ShuffleBlockInfo> shuffleBlocksToFetch;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    inputStreamFuture = SettableFuture.create();
+    when(shuffleClient.getBlockData(
+        SHUFFLE_ID, MAP_ID, REDUCE_ID, ATTEMPT_ID))
+        .thenReturn(inputStreamFuture);
+    shuffleBlocksToFetch = new HashSet<>();
+    shuffleBlocksToFetch.add(SHUFFLE_BLOCK_INFO);
+    fetcherIterator = new DefaultHadoopFetcherIterator(
+        shuffleClient, shuffleBlocksToFetch, metrics);
+  }
+
+  @Test
+  public void testGetsBlock() {
+    fetcherIterator.fetchDataFromS3();
+    inputStreamFuture.set(() -> inputStream);
+    ShuffleBlockInputStream actualInputStream = fetcherIterator.next();
+    verify(shuffleClient).getBlockData(
+        SHUFFLE_ID, MAP_ID, REDUCE_ID, ATTEMPT_ID);
+    assertThat(actualInputStream.getBlockId()).isEqualTo(SHUFFLE_BLOCK_ID);
+
+    // there's nothing else left
+    assertThatThrownBy(() -> fetcherIterator.next())
+        .hasMessageContaining("Next should not be called because iterator is empty");
+  }
+
+  @Test
+  public void testFetchFails() {
+    fetcherIterator.fetchDataFromS3();
+    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+    assertThatThrownBy(() -> fetcherIterator.next())
+        .isInstanceOf(FetchFailedException.class)
+        .hasMessageContaining("Exception thrown when fetching data from remote storage.");
+  }
+
+  @Test
+  public void testFuturesCancelledWhenStopped() {
+    fetcherIterator.fetchDataFromS3();
+    // stop the fetcher iterator
+    fetcherIterator.cleanup();
+    assertThat(inputStreamFuture.isCancelled()).isTrue();
+  }
+
+  @Test
+  public void testFetchedFailedStreamsInCleanup() {
+    fetcherIterator.fetchDataFromS3();
+    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+    fetcherIterator.cleanup();
+  }
+
+  @Test
+  public void testClosingMultipleThings() {
+    ShuffleBlockInfo shuffleBlock1 = new ShuffleBlockInfo(
+        SHUFFLE_ID,
+        MAP_ID,
+        1,
+        BLOCK_LENGTH,
+        0,
+        Optional.of(BLOCK_MANAGER_ID));
+    ShuffleBlockInfo shuffleBlock2 = new ShuffleBlockInfo(
+        SHUFFLE_ID,
+        MAP_ID,
+        2,
+        BLOCK_LENGTH,
+        0,
+        Optional.of(BLOCK_MANAGER_ID));
+    SettableFuture<Supplier<InputStream>> inputStreamFuture1 = SettableFuture.create();
+    SettableFuture<Supplier<InputStream>> inputStreamFuture2 = SettableFuture.create();
+    shuffleBlocksToFetch.add(shuffleBlock1);
+    shuffleBlocksToFetch.add(shuffleBlock2);
+    when(shuffleClient.getBlockData(
+        SHUFFLE_ID, MAP_ID, 1, 0))
+        .thenReturn(inputStreamFuture1);
+    when(shuffleClient.getBlockData(
+        SHUFFLE_ID, MAP_ID, 2, 0))
+        .thenReturn(inputStreamFuture2);
+    fetcherIterator.fetchDataFromS3();
+
+    inputStreamFuture1.set(() -> inputStream);
+    inputStreamFuture.setException(new Exception("Could not fetch from S3"));
+
+    fetcherIterator.cleanup();
+    assertThat(inputStreamFuture2).isCancelled();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/DefaultHadoopFetcherIteratorTest.java
@@ -82,7 +82,7 @@ public final class DefaultHadoopFetcherIteratorTest {
 
   @Test
   public void testGetsBlock() {
-    fetcherIterator.fetchDataFromS3();
+    fetcherIterator.fetchDataFromHadoop();
     inputStreamFuture.set(() -> inputStream);
     ShuffleBlockInputStream actualInputStream = fetcherIterator.next();
     verify(shuffleClient).getBlockData(
@@ -96,7 +96,7 @@ public final class DefaultHadoopFetcherIteratorTest {
 
   @Test
   public void testFetchFails() {
-    fetcherIterator.fetchDataFromS3();
+    fetcherIterator.fetchDataFromHadoop();
     inputStreamFuture.setException(new Exception("Could not fetch from S3"));
     assertThatThrownBy(() -> fetcherIterator.next())
         .isInstanceOf(FetchFailedException.class)
@@ -105,7 +105,7 @@ public final class DefaultHadoopFetcherIteratorTest {
 
   @Test
   public void testFuturesCancelledWhenStopped() {
-    fetcherIterator.fetchDataFromS3();
+    fetcherIterator.fetchDataFromHadoop();
     // stop the fetcher iterator
     fetcherIterator.cleanup();
     assertThat(inputStreamFuture.isCancelled()).isTrue();
@@ -113,7 +113,7 @@ public final class DefaultHadoopFetcherIteratorTest {
 
   @Test
   public void testFetchedFailedStreamsInCleanup() {
-    fetcherIterator.fetchDataFromS3();
+    fetcherIterator.fetchDataFromHadoop();
     inputStreamFuture.setException(new Exception("Could not fetch from S3"));
     fetcherIterator.cleanup();
   }
@@ -144,7 +144,7 @@ public final class DefaultHadoopFetcherIteratorTest {
     when(shuffleClient.getBlockData(
         SHUFFLE_ID, MAP_ID, 2, 0))
         .thenReturn(inputStreamFuture2);
-    fetcherIterator.fetchDataFromS3();
+    fetcherIterator.fetchDataFromHadoop();
 
     inputStreamFuture1.set(() -> inputStream);
     inputStreamFuture.setException(new Exception("Could not fetch from S3"));

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
@@ -91,7 +91,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
 
   @Test
   public void testRetrievesFromExecutorOnly() {
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList().addStream(BLOCK_INFO_1),
         ImmutableSet.of());
     assertThat(iteratorUnderTest.hasNext()).isTrue();
@@ -101,7 +101,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
 
   @Test
   public void testRetrievesFromRemoteOnly() {
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList(),
         ImmutableSet.of(BLOCK_INFO_1));
     assertThat(iteratorUnderTest.hasNext()).isTrue();
@@ -111,7 +111,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
 
   @Test
   public void testEmpty() {
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList(),
         ImmutableSet.of());
     assertThat(iteratorUnderTest.hasNext()).isFalse();
@@ -119,7 +119,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
 
   @Test
   public void testExecutorThenRemote() {
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList().addStream(BLOCK_INFO_1),
         ImmutableSet.of(BLOCK_INFO_2));
     assertThat(iteratorUnderTest.hasNext()).isTrue();
@@ -134,7 +134,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
   @Test
   public void testExecutorFailsAndBlocksDoesntExist() {
     when(driverEndpointRef.getShuffleStorageStates(0)).thenReturn(ImmutableMap.of());
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList()
             .addThrownFetchFailed(BLOCK_INFO_1),
         ImmutableSet.of(),
@@ -151,7 +151,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         new MapOutputId(BLOCK_INFO_1.getShuffleId(), BLOCK_INFO_1.getMapId(),
             BLOCK_INFO_1.getMapTaskAttemptId()),
         new OnExecutorOnly(BlockManagerId.apply("host", 1234))));
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList()
             .addThrownFetchFailed(BLOCK_INFO_1),
         ImmutableSet.of(),
@@ -171,7 +171,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         new MapOutputId(BLOCK_INFO_2.getShuffleId(), BLOCK_INFO_2.getMapId(),
             BLOCK_INFO_2.getMapTaskAttemptId()),
         new OnRemoteOnly(Option.empty())));
-    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+    ExecutorThenHadoopFetcherIterator iteratorUnderTest = getIteratorUnderTest(
         new FetchFailedThrowingStreamList()
             .addThrownFetchFailed(BLOCK_INFO_1)
             .addThrownFetchFailed(BLOCK_INFO_2),
@@ -188,12 +188,12 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         BLOCK_INFO_1.getShuffleLocation().get());
   }
 
-  private ExecutorThenS3FetcherIterator getIteratorUnderTest(
+  private ExecutorThenHadoopFetcherIterator getIteratorUnderTest(
       FetchFailedThrowingStreamList streamsFromExecutors,
       Set<ShuffleBlockInfo> initialRemoteBlocksToFetch,
       TestHadoopFetcherIteratorFactory s3FetcherIteratorFactory) {
     this.testS3FetcherIteratorFactory = s3FetcherIteratorFactory;
-    return new ExecutorThenS3FetcherIterator(
+    return new ExecutorThenHadoopFetcherIterator(
         0,
         streamsFromExecutors.iterator(),
         ImmutableSet.copyOf(streamsFromExecutors.blockInfos()),
@@ -205,7 +205,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         driverEndpointRef);
   }
 
-  private ExecutorThenS3FetcherIterator getIteratorUnderTest(
+  private ExecutorThenHadoopFetcherIterator getIteratorUnderTest(
       FetchFailedThrowingStreamList streamsFromExecutors,
       Set<ShuffleBlockInfo> remoteStorageFetchFailedBlocks) {
     testS3FetcherIteratorFactory = new TestHadoopFetcherIteratorFactory(

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.palantir.shuffle.async.FetchFailedExceptionThrower;
+import org.apache.spark.palantir.shuffle.async.ShuffleDriverEndpointRef;
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId;
+import org.apache.spark.palantir.shuffle.async.metadata.OnExecutorOnly;
+import org.apache.spark.palantir.shuffle.async.metadata.OnRemoteOnly;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.shuffle.FetchFailedException;
+import org.apache.spark.shuffle.api.ShuffleBlockInfo;
+import org.apache.spark.shuffle.api.ShuffleBlockInputStream;
+import org.apache.spark.storage.BlockId;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockId;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import scala.Option;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class ExecutorThenHadoopFetcherIteratorTest {
+
+  private static final BlockManagerId BLOCK_MANAGER_ID = BlockManagerId.apply("host", 1234);
+  private static final ShuffleBlockId BLOCK_1 = ShuffleBlockId.apply(0, 1, 1);
+  private static final ShuffleBlockInfo BLOCK_INFO_1 =
+      new ShuffleBlockInfo(
+          BLOCK_1.shuffleId(), BLOCK_1.mapId(), BLOCK_1.reduceId(), 10, 1,
+          org.apache.spark.api.java.Optional.of(BLOCK_MANAGER_ID));
+
+  private static final ShuffleBlockId BLOCK_2 = ShuffleBlockId.apply(0, 2, 1);
+  private static final ShuffleBlockInfo BLOCK_INFO_2 =
+      new ShuffleBlockInfo(
+          BLOCK_2.shuffleId(), BLOCK_2.mapId(), BLOCK_2.reduceId(), 10, 1,
+          org.apache.spark.api.java.Optional.of(BLOCK_MANAGER_ID));
+
+  @Mock
+  private SerializerManager serializerManager;
+  @Mock
+  private CompressionCodec compressionCodec;
+  @Mock
+  private ShuffleDriverEndpointRef driverEndpointRef;
+
+  private TestHadoopFetcherIteratorFactory testS3FetcherIteratorFactory;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    testS3FetcherIteratorFactory = null;
+  }
+
+  @Test
+  public void testRetrievesFromExecutorOnly() {
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList().addStream(BLOCK_INFO_1),
+        ImmutableSet.of());
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_1);
+    assertThat(iteratorUnderTest.hasNext()).isFalse();
+  }
+
+  @Test
+  public void testRetrievesFromRemoteOnly() {
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList(),
+        ImmutableSet.of(BLOCK_INFO_1));
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_1);
+    assertThat(iteratorUnderTest.hasNext()).isFalse();
+  }
+
+  @Test
+  public void testEmpty() {
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList(),
+        ImmutableSet.of());
+    assertThat(iteratorUnderTest.hasNext()).isFalse();
+  }
+
+  @Test
+  public void testExecutorThenRemote() {
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList().addStream(BLOCK_INFO_1),
+        ImmutableSet.of(BLOCK_INFO_2));
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_1);
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_2);
+    assertThat(iteratorUnderTest.hasNext()).isFalse();
+    assertThat(testS3FetcherIteratorFactory.getS3FetcherIterator().returnedBlockIds())
+        .containsExactly(BLOCK_2);
+  }
+
+  @Test
+  public void testExecutorFailsAndBlocksDoesntExist() {
+    when(driverEndpointRef.getShuffleStorageStates(0)).thenReturn(ImmutableMap.of());
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList()
+            .addThrownFetchFailed(BLOCK_INFO_1),
+        ImmutableSet.of(),
+        new TestHadoopFetcherIteratorFactory(Collections.emptySet()));
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThatThrownBy(iteratorUnderTest::next).isInstanceOf(FetchFailedException.class);
+    verify(driverEndpointRef, times(1)).blacklistExecutor(
+        BLOCK_INFO_1.getShuffleLocation().get());
+  }
+
+  @Test
+  public void testExecutorFailsAndBlocksNotOnRemote() {
+    when(driverEndpointRef.getShuffleStorageStates(0)).thenReturn(ImmutableMap.of(
+        new MapOutputId(BLOCK_INFO_1.getShuffleId(), BLOCK_INFO_1.getMapId(),
+            BLOCK_INFO_1.getMapTaskAttemptId()),
+        new OnExecutorOnly(BlockManagerId.apply("host", 1234))));
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList()
+            .addThrownFetchFailed(BLOCK_INFO_1),
+        ImmutableSet.of(),
+        new TestHadoopFetcherIteratorFactory(Collections.emptySet()));
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThatThrownBy(iteratorUnderTest::next).isInstanceOf(FetchFailedException.class);
+    verify(driverEndpointRef, times(1)).blacklistExecutor(
+        BLOCK_INFO_1.getShuffleLocation().get());
+  }
+
+  @Test
+  public void testExecutorFailsAndBlocksOnRemote() {
+    when(driverEndpointRef.getShuffleStorageStates(0)).thenReturn(ImmutableMap.of(
+        new MapOutputId(BLOCK_INFO_1.getShuffleId(), BLOCK_INFO_1.getMapId(),
+            BLOCK_INFO_1.getMapTaskAttemptId()),
+        new OnRemoteOnly(Option.empty()),
+        new MapOutputId(BLOCK_INFO_2.getShuffleId(), BLOCK_INFO_2.getMapId(),
+            BLOCK_INFO_2.getMapTaskAttemptId()),
+        new OnRemoteOnly(Option.empty())));
+    ExecutorThenS3FetcherIterator iteratorUnderTest = getIteratorUnderTest(
+        new FetchFailedThrowingStreamList()
+            .addThrownFetchFailed(BLOCK_INFO_1)
+            .addThrownFetchFailed(BLOCK_INFO_2),
+        ImmutableSet.of(BLOCK_INFO_2),
+        new TestHadoopFetcherIteratorFactory(ImmutableSet.of(BLOCK_INFO_1, BLOCK_INFO_2)));
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_2);
+    assertThat(iteratorUnderTest.hasNext()).isTrue();
+    assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_1);
+    assertThat(iteratorUnderTest.hasNext()).isFalse();
+    assertThat(testS3FetcherIteratorFactory.getS3FetcherIterator().returnedBlockIds())
+        .containsExactly(BLOCK_1, BLOCK_2);
+    verify(driverEndpointRef, times(1)).blacklistExecutor(
+        BLOCK_INFO_1.getShuffleLocation().get());
+  }
+
+  private ExecutorThenS3FetcherIterator getIteratorUnderTest(
+      FetchFailedThrowingStreamList streamsFromExecutors,
+      Set<ShuffleBlockInfo> initialRemoteBlocksToFetch,
+      TestHadoopFetcherIteratorFactory s3FetcherIteratorFactory) {
+    this.testS3FetcherIteratorFactory = s3FetcherIteratorFactory;
+    return new ExecutorThenS3FetcherIterator(
+        0,
+        streamsFromExecutors.iterator(),
+        ImmutableSet.copyOf(streamsFromExecutors.blockInfos()),
+        false,
+        serializerManager,
+        compressionCodec,
+        ImmutableSet.copyOf(initialRemoteBlocksToFetch),
+        s3FetcherIteratorFactory,
+        driverEndpointRef);
+  }
+
+  private ExecutorThenS3FetcherIterator getIteratorUnderTest(
+      FetchFailedThrowingStreamList streamsFromExecutors,
+      Set<ShuffleBlockInfo> remoteStorageFetchFailedBlocks) {
+    testS3FetcherIteratorFactory = new TestHadoopFetcherIteratorFactory(
+        remoteStorageFetchFailedBlocks);
+    return getIteratorUnderTest(
+        streamsFromExecutors,
+        remoteStorageFetchFailedBlocks,
+        testS3FetcherIteratorFactory);
+  }
+
+  private static ShuffleBlockInputStream toBlockInputStream(ShuffleBlockInfo block) {
+    return new ShuffleBlockInputStream(
+        ShuffleBlockId.apply(block.getShuffleId(), block.getMapId(), block.getReduceId()),
+        new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4, 5}));
+  }
+
+  private static ShuffleBlockInputStream toThrownFetchFailed(ShuffleBlockInfo block) {
+    return FetchFailedExceptionThrower.throwFetchFailedException(
+        block.getShuffleId(),
+        block.getMapId(),
+        block.getReduceId(),
+        block.getShuffleLocation().orNull(),
+        "Manually triggered fetch failed.",
+        null);
+  }
+
+  private static Supplier<ShuffleBlockInputStream> toBlockInputStreamSupplier(
+      ShuffleBlockInfo block) {
+    return () -> toBlockInputStream(block);
+  }
+
+  private static Supplier<ShuffleBlockInputStream> toThrowingFetchFailedSupplier(
+      ShuffleBlockInfo block) {
+    return () -> toThrownFetchFailed(block);
+  }
+
+  private static final class FetchFailedThrowingStreamList
+      implements Iterable<ShuffleBlockInputStream> {
+
+    private final List<ShuffleBlockInfo> blockInfos = new ArrayList<>();
+    private final List<Supplier<ShuffleBlockInputStream>> maybeThrowingStreams = new ArrayList<>();
+
+    public FetchFailedThrowingStreamList addStream(ShuffleBlockInfo blockInfo) {
+      maybeThrowingStreams.add(toBlockInputStreamSupplier(blockInfo));
+      blockInfos.add(blockInfo);
+      return this;
+    }
+
+    public FetchFailedThrowingStreamList addThrownFetchFailed(ShuffleBlockInfo blockInfo) {
+      maybeThrowingStreams.add(toThrowingFetchFailedSupplier(blockInfo));
+      blockInfos.add(blockInfo);
+      return this;
+    }
+
+    @Override
+    public Iterator<ShuffleBlockInputStream> iterator() {
+      return Iterators.transform(maybeThrowingStreams.iterator(), Supplier::get);
+    }
+
+    public List<ShuffleBlockInfo> blockInfos() {
+      return blockInfos;
+    }
+  }
+
+  private static final class TestHadoopFetcherIteratorFactory
+      implements HadoopFetcherIteratorFactory {
+
+    private final Collection<ShuffleBlockInfo> expectedBlocks;
+    private TestHadoopFetcherIterator s3FetcherIterator;
+
+    TestHadoopFetcherIteratorFactory(Collection<ShuffleBlockInfo> expectedBlocks) {
+      this.expectedBlocks = expectedBlocks;
+    }
+
+    @Override
+    public HadoopFetcherIterator createFetcherIteratorForBlocks(
+        Collection<ShuffleBlockInfo> blocks) {
+      assertThat(expectedBlocks).containsExactlyInAnyOrder(
+          blocks.toArray(new ShuffleBlockInfo[blocks.size()]));
+      s3FetcherIterator = new TestHadoopFetcherIterator(new HashSet<>(blocks));
+      return s3FetcherIterator;
+    }
+
+    public TestHadoopFetcherIterator getS3FetcherIterator() {
+      return s3FetcherIterator;
+    }
+  }
+
+  private static final class TestHadoopFetcherIterator implements HadoopFetcherIterator {
+
+    private final Set<ShuffleBlockInfo> remoteFetchFailedBlocks;
+    private final Set<BlockId> returnedBlockIds = new HashSet<>();
+    private final Set<ShuffleBlockInfo> initializedBlocks = new HashSet<>();
+    private Iterator<ShuffleBlockInputStream> backingIterator;
+
+    TestHadoopFetcherIterator(Set<ShuffleBlockInfo> remoteBlocksToFetch) {
+      this.remoteFetchFailedBlocks = remoteBlocksToFetch;
+      this.initializedBlocks.addAll(remoteFetchFailedBlocks);
+      this.backingIterator = ImmutableList.copyOf(initializedBlocks)
+          .stream()
+          .map(block -> toBlockInputStream(block))
+          .iterator();
+    }
+
+    @Override
+    public void cleanup() {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return backingIterator.hasNext();
+    }
+
+    @Override
+    public ShuffleBlockInputStream next() {
+      ShuffleBlockInputStream next = backingIterator.next();
+      returnedBlockIds.add(next.getBlockId());
+      return next;
+    }
+
+    public Set<BlockId> returnedBlockIds() {
+      return returnedBlockIds;
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/reader/ExecutorThenHadoopFetcherIteratorTest.java
@@ -81,12 +81,12 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
   @Mock
   private ShuffleDriverEndpointRef driverEndpointRef;
 
-  private TestHadoopFetcherIteratorFactory testS3FetcherIteratorFactory;
+  private TestHadoopFetcherIteratorFactory testHadoopFetcherIteratorFactory;
 
   @Before
   public void before() {
     MockitoAnnotations.initMocks(this);
-    testS3FetcherIteratorFactory = null;
+    testHadoopFetcherIteratorFactory = null;
   }
 
   @Test
@@ -127,7 +127,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
     assertThat(iteratorUnderTest.hasNext()).isTrue();
     assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_2);
     assertThat(iteratorUnderTest.hasNext()).isFalse();
-    assertThat(testS3FetcherIteratorFactory.getS3FetcherIterator().returnedBlockIds())
+    assertThat(testHadoopFetcherIteratorFactory.getHadoopFetcherIterator().returnedBlockIds())
         .containsExactly(BLOCK_2);
   }
 
@@ -182,7 +182,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
     assertThat(iteratorUnderTest.hasNext()).isTrue();
     assertThat(iteratorUnderTest.next().getBlockId()).isEqualTo(BLOCK_1);
     assertThat(iteratorUnderTest.hasNext()).isFalse();
-    assertThat(testS3FetcherIteratorFactory.getS3FetcherIterator().returnedBlockIds())
+    assertThat(testHadoopFetcherIteratorFactory.getHadoopFetcherIterator().returnedBlockIds())
         .containsExactly(BLOCK_1, BLOCK_2);
     verify(driverEndpointRef, times(1)).blacklistExecutor(
         BLOCK_INFO_1.getShuffleLocation().get());
@@ -191,8 +191,8 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
   private ExecutorThenHadoopFetcherIterator getIteratorUnderTest(
       FetchFailedThrowingStreamList streamsFromExecutors,
       Set<ShuffleBlockInfo> initialRemoteBlocksToFetch,
-      TestHadoopFetcherIteratorFactory s3FetcherIteratorFactory) {
-    this.testS3FetcherIteratorFactory = s3FetcherIteratorFactory;
+      TestHadoopFetcherIteratorFactory hadoopFetcherIteratorFactory) {
+    this.testHadoopFetcherIteratorFactory = hadoopFetcherIteratorFactory;
     return new ExecutorThenHadoopFetcherIterator(
         0,
         streamsFromExecutors.iterator(),
@@ -201,19 +201,19 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         serializerManager,
         compressionCodec,
         ImmutableSet.copyOf(initialRemoteBlocksToFetch),
-        s3FetcherIteratorFactory,
+        hadoopFetcherIteratorFactory,
         driverEndpointRef);
   }
 
   private ExecutorThenHadoopFetcherIterator getIteratorUnderTest(
       FetchFailedThrowingStreamList streamsFromExecutors,
       Set<ShuffleBlockInfo> remoteStorageFetchFailedBlocks) {
-    testS3FetcherIteratorFactory = new TestHadoopFetcherIteratorFactory(
+    testHadoopFetcherIteratorFactory = new TestHadoopFetcherIteratorFactory(
         remoteStorageFetchFailedBlocks);
     return getIteratorUnderTest(
         streamsFromExecutors,
         remoteStorageFetchFailedBlocks,
-        testS3FetcherIteratorFactory);
+        testHadoopFetcherIteratorFactory);
   }
 
   private static ShuffleBlockInputStream toBlockInputStream(ShuffleBlockInfo block) {
@@ -274,7 +274,7 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
       implements HadoopFetcherIteratorFactory {
 
     private final Collection<ShuffleBlockInfo> expectedBlocks;
-    private TestHadoopFetcherIterator s3FetcherIterator;
+    private TestHadoopFetcherIterator hadoopFetcherIterator;
 
     TestHadoopFetcherIteratorFactory(Collection<ShuffleBlockInfo> expectedBlocks) {
       this.expectedBlocks = expectedBlocks;
@@ -285,12 +285,12 @@ public final class ExecutorThenHadoopFetcherIteratorTest {
         Collection<ShuffleBlockInfo> blocks) {
       assertThat(expectedBlocks).containsExactlyInAnyOrder(
           blocks.toArray(new ShuffleBlockInfo[blocks.size()]));
-      s3FetcherIterator = new TestHadoopFetcherIterator(new HashSet<>(blocks));
-      return s3FetcherIterator;
+      hadoopFetcherIterator = new TestHadoopFetcherIterator(new HashSet<>(blocks));
+      return hadoopFetcherIterator;
     }
 
-    public TestHadoopFetcherIterator getS3FetcherIterator() {
-      return s3FetcherIterator;
+    public TestHadoopFetcherIterator getHadoopFetcherIterator() {
+      return hadoopFetcherIterator;
     }
   }
 

--- a/async-shuffle-upload/async-shuffle-upload-immutables/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-immutables/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.11</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-async-shuffle-upload-immutables_2.11</artifactId>
+  <properties>
+    <sbt.project.name>async-shuffle-upload-immutables</sbt.project.name>
+  </properties>
+  <packaging>jar</packaging>
+  <name>Spark Project Async Shuffle Upload Immutables</name>
+  <url>http://spark.apache.org/</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+  </build>
+</project>

--- a/async-shuffle-upload/async-shuffle-upload-immutables/src/main/java/org/apache/spark/palantir/shuffle/async/immutables/ImmutablesStyle.java
+++ b/async-shuffle-upload/async-shuffle-upload-immutables/src/main/java/org/apache/spark/palantir/shuffle/async/immutables/ImmutablesStyle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.immutables;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(
+    visibility = Value.Style.ImplementationVisibility.PACKAGE,
+    overshadowImplementation = true,
+    jdkOnly = true,
+    get = {"get*", "is*"})
+public @interface ImmutablesStyle {}

--- a/async-shuffle-upload/async-shuffle-upload-scala-test-utils/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-scala-test-utils/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.11</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-async-shuffle-upload-scala-test-utils_2.11</artifactId>
+  <packaging>jar</packaging>
+  <name>Spark Project Async Shuffle Upload Scala Test Utils</name>
+  <url>http://spark.apache.org/</url>
+  <properties>
+    <sbt.project.name>async-shuffle-upload-scala-test-utils</sbt.project.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-api_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-scala_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <!--
+      This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
+      them will yield errors.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <argLine>-ea -Xmx4g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/async-shuffle-upload/async-shuffle-upload-scala-test-utils/src/main/scala/org/apache/spark/palantir/shuffle/async/InProcessShuffleDriverEndpointRef.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala-test-utils/src/main/scala/org/apache/spark/palantir/shuffle/async/InProcessShuffleDriverEndpointRef.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import java.util.concurrent.ExecutorService
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+
+import com.google.common.util.concurrent.SettableFuture
+
+import org.apache.spark.SparkConf
+import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEndpointRef, RpcTimeout}
+
+class InProcessShuffleDriverEndpointRef(
+    conf: SparkConf,
+    shuffleUploadDriverEndpoint: AsyncShuffleUploadDriverEndpoint,
+    askExecutor: ExecutorService) extends RpcEndpointRef(conf) {
+
+  private implicit val executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService(askExecutor)
+
+  override def address: RpcAddress = RpcAddress("localhost", 0)
+
+  override def name: String = "test-in-process-driver-endpoint"
+
+  override def send(message: Any): Unit = shuffleUploadDriverEndpoint.receive()(message)
+
+  override def ask[T]
+      (message: Any, timeout: RpcTimeout)(implicit evidence$1: ClassTag[T]): Future[T] = {
+    Future[T] {
+      val result = SettableFuture.create[T]()
+      shuffleUploadDriverEndpoint.receiveAndReply(new RpcCallContext {
+        override def reply(response: Any): Unit = result.set(response.asInstanceOf[T])
+
+        override def sendFailure(e: Throwable): Unit = result.setException(e)
+
+        override def senderAddress: RpcAddress = address
+      })(message)
+      result.get()
+    }
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-scala/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.11</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spark-async-shuffle-upload-scala_2.11</artifactId>
+  <packaging>jar</packaging>
+  <name>Spark Project Async Shuffle Upload Scala</name>
+  <url>http://spark.apache.org/</url>
+  <properties>
+    <sbt.project.name>async-shuffle-upload-scala</sbt.project.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-api_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-java8-compat_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <!--
+      This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
+      them will yield errors.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <argLine>-ea -Xmx4g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
@@ -197,7 +197,7 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val PREFER_DOWNLOAD_FROM_HADOOP_DEPRECATED =
     ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.s3")
-      .doc("Deprecated variant of preferring downloading blocks from remote storage..")
+      .doc("Deprecated variant of preferring downloading blocks from remote storage.")
       .booleanConf
       .createWithDefault(false)
 

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
@@ -195,11 +195,17 @@ object AsyncShuffleDataIoSparkConfigs {
       .booleanConf
       .createWithDefault(false)
 
-  val PREFER_DOWNLOAD_FROM_S3 = ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.s3")
-    .doc("Prefer download from s3 over download from another executor if the shuffle file" +
-      " exists on both.")
-    .booleanConf
-    .createWithDefault(false)
+  val PREFER_DOWNLOAD_FROM_HADOOP_DEPRECATED =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.s3")
+      .doc("Deprecated variant of preferring downloading blocks from remote storage..")
+      .booleanConf
+      .createWithDefault(false)
+
+  val PREFER_DOWNLOAD_FROM_HADOOP =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.hadoop")
+      .doc("Prefer download from remote storage over download from another executor if the" +
+        " shuffle file exists on both.")
+      .fallbackConf(PREFER_DOWNLOAD_FROM_HADOOP_DEPRECATED)
 
   val S3A_UPLOAD_MULTIPART_TYPE =
     ConfigBuilder("spark.shuffle.hadoop.async.io.upload.multipart.buffer.type")

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import java.util.concurrent.TimeUnit
+
+import scala.util.Try
+
+import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.palantir.shuffle.async.api.SparkShuffleApiConstants
+
+object AsyncShuffleDataIoSparkConfigs {
+  val BASE_URI = ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_BASE_URI_CONF)
+    .doc("Base URI for the backup files. Should be able to be loaded by a Hadoop file system.")
+    .stringConf
+    .createOptional
+
+  val APP_NAME_DEPRECATED =
+    ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_PLUGIN_APP_NAME_CONF_DEPRECATED)
+      .doc("Deprecated configuration value for the application name.")
+      .stringConf
+      .createOptional
+
+  val APP_NAME = ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_PLUGIN_APP_NAME_CONF)
+    .doc("Application name to use for tagging shuffle files.")
+    .fallbackConf(APP_NAME_DEPRECATED)
+
+  val S3A_CREDS_FILE_DEPRECATED =
+    ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_S3A_CREDS_FILE_CONF_DEPRECATED)
+      .doc("Deprecated version of configuration pointing to s3 credentials.")
+      .stringConf
+      .createOptional
+
+  val S3A_CREDS_FILE = ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_S3A_CREDS_FILE_CONF)
+    .doc("File pointing to the Amazon AWS credentials when backing up shuffles to S3.")
+    .fallbackConf(S3A_CREDS_FILE_DEPRECATED)
+
+  val S3A_ENDPOINT = ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_S3A_ENDPOINT_CONF)
+    .doc("If the shuffle client is configured for s3a, this specifies the s3a endpoint")
+    .stringConf
+    .createOptional
+
+  val DEFAULT_DOWNLOAD_PARALLELISM = 10
+
+  val DOWNLOAD_PARALLELISM = ConfigBuilder("spark.shuffle.hadoop.async.download.parallelism")
+    .doc("Number of threads in the thread pool that download backup shuffle files.")
+    .intConf
+    .createWithDefault(DEFAULT_DOWNLOAD_PARALLELISM)
+
+
+  val DEFAULT_UPLOAD_PARALLELISM = 5
+
+  val UPLOAD_PARALLELISM = ConfigBuilder("spark.shuffle.hadoop.async.upload.parallelism")
+    .doc("Number of threads in the thread pool that uploads backup shuffle files.")
+    .intConf
+    .createWithDefault(DEFAULT_UPLOAD_PARALLELISM)
+
+  val STORAGE_STRATEGY = ConfigBuilder("spark.shuffle.hadoop.async.storage.strategy")
+    .doc("Strategy to use for uploading shuffle files to the backing store.")
+    .stringConf
+    .checkValues(Set("basic", "merging"))
+    .createWithDefault("basic")
+
+  val DEFAULT_READ_LOCAL_DISK_PARALLELISM = 5
+
+  val READ_LOCAL_DISK_PARALLELISM =
+    ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.local.read.parallelism")
+      .doc("When using the \"merging\" storage strategy, files are downloaded to local disk" +
+        " before map output data is shipped back to the shuffle reader. This configuration" +
+        " controls the parallelism for the local disk reads after files are downloaded.")
+      .intConf
+      .createWithDefault(DEFAULT_READ_LOCAL_DISK_PARALLELISM)
+
+  // Default merged batch size of 10MB
+  val DEFAULT_MERGING_STORAGE_BATCH_SIZE_BYTES = 10 * 1024 * 1024
+
+  val MERGED_BATCH_SIZE = ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.batch.size")
+    .doc("Approximate target size for the combined shuffle files when using the merging storage" +
+      " strategy. The merging storage strategy combines shuffle files before uploading them to" +
+      " the backing store - so this configuration sets a target size for the combined files" +
+      " before they are uploaded. Note that large shuffle files may cause the uploaded blob" +
+      " to exceed this threshold.")
+    .bytesConf(ByteUnit.BYTE)
+    .createWithDefault(DEFAULT_MERGING_STORAGE_BATCH_SIZE_BYTES)
+
+  val DEFAULT_MERGING_MAX_BUFFERED_INPUTS = 2048
+
+  val MERGING_MAX_BUFFERED_INPUTS =
+    ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.buffer.max")
+      .doc("Number of inputs that can be buffered on the executor before the shuffle uploader" +
+        " forces all files to be uploaded to the backing store. This is to prevent the merging" +
+        " buffer from growing without bound.")
+      .intConf
+      .createWithDefault(DEFAULT_MERGING_MAX_BUFFERED_INPUTS)
+
+  // 5 second default uploading polling period
+  val DEFAULT_UPLOAD_POLLING_PERIOD_MILLIS = 5 * 1000
+
+  val UPLOAD_POLLING_PERIOD =
+    ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.upload.period")
+      .doc("Interval at which the executors will check for uploading shuffle data.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(DEFAULT_UPLOAD_POLLING_PERIOD_MILLIS)
+
+  val DEFAULT_MERGED_BATCH_MAXIMUM_BUFFERED_AGE_MINUTES = 5
+
+  val MERGED_BATCH_MAXIMUM_BUFFERED_AGE =
+    ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.buffer.age")
+      .doc("Amount of time the executor will wait before uploading all the files for a batch.")
+      .timeConf(TimeUnit.MINUTES)
+      .createWithDefault(DEFAULT_MERGED_BATCH_MAXIMUM_BUFFERED_AGE_MINUTES)
+
+  val DEFAULT_STREAM_BUFFER_SIZE_BYTES = 128 * 1024
+
+  val STREAM_BUFFER_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.buffer.size")
+      .doc("Size of buffers when reading and writing data from storage, both remote and on local" +
+        " disk.")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(validator = bytes => {
+        Try {
+          Math.toIntExact(bytes)
+          true
+        } getOrElse false
+      }, errorMsg = s"Buffer size must be less than ${Integer.MAX_VALUE}")
+      .createWithDefault(DEFAULT_STREAM_BUFFER_SIZE_BYTES)
+
+  val LOCAL_FILE_STREAM_BUFFER_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.disk.buffer.size")
+      .doc("Size of buffers when reading and writing data on local disk")
+      .fallbackConf(STREAM_BUFFER_SIZE)
+
+  val DOWNLOAD_SHUFFLE_BLOCK_BUFFER_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.download.buffer.size")
+      .doc("Size of buffers to use when downloading shuffle blocks from remote storage down to" +
+        " local disk.")
+      .fallbackConf(STREAM_BUFFER_SIZE)
+
+  val DOWNLOAD_SHUFFLE_BLOCKS_IN_MEMORY_MAX_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.download.block.memory.max")
+      .doc("The maximum amount of memory in bytes that a block can have for it to be downloaded" +
+        " to memory. If a shuffle block were to be downloaded that is larger than this value, it" +
+        " will be downloaded to disk instead.")
+      .fallbackConf(org.apache.spark.internal.config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)
+
+  val DEFAULT_DRIVER_REF_CACHE_MAX_SIZE = 1024
+
+  val DRIVER_REF_CACHE_MAX_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.driverref.cache.size")
+      .doc("Maximum size of the cache used by each executor to avoid calling the driver in" +
+        " excess amounts.")
+      .intConf
+      .createWithDefault(DEFAULT_DRIVER_REF_CACHE_MAX_SIZE)
+
+  // Default of 1 minute for the driver ref cache's expiration period.
+  val DEFAULT_DRIVER_REF_CACHE_EXPIRATION_PERIOD_MILLIS = 60000
+
+  val DRIVER_REF_CACHE_EXPIRATION_PERIOD =
+    ConfigBuilder("spark.shuffle.hadoop.driverref.cache.expiration.period")
+      .doc("Duration results from communicating with the driver will be cached on the executor" +
+        " before being invalidated.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(DEFAULT_DRIVER_REF_CACHE_EXPIRATION_PERIOD_MILLIS)
+
+  val METRICS_FACTORY_CLASS_DEPRECATED = ConfigBuilder(
+    SparkShuffleApiConstants.METRICS_FACTORY_CLASS_CONF_DEPRECATED)
+    .doc("Deprecated config value for the metrics factory class.")
+    .stringConf
+    .createWithDefault(
+      "org.apache.spark.palantir.shuffle.async.metrics.slf4j.Slf4JHadoopAsyncShuffleMetricsFactory")
+
+  val METRICS_FACTORY_CLASS = ConfigBuilder(SparkShuffleApiConstants.METRICS_FACTORY_CLASS_CONF)
+    .doc("Implementation of the metrics system when using the plugin.")
+    .fallbackConf(METRICS_FACTORY_CLASS_DEPRECATED)
+
+  val CACHE_INDEX_FILES_LOCALLY =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.basic.cache.index.enable")
+      .doc("Cache the index files locally on the executor disk")
+      .booleanConf
+      .createWithDefault(false)
+
+  val PREFER_DOWNLOAD_FROM_S3 = ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.s3")
+    .doc("Prefer download from s3 over download from another executor if the shuffle file" +
+      " exists on both.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val S3A_UPLOAD_MULTIPART_TYPE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.upload.multipart.buffer.type")
+      .doc("The type of multipart to use. See hadoop config `fs.s3a.fast.upload.buffer`")
+      .stringConf
+      .createWithDefault("disk")
+
+  val S3A_UPLOAD_MULTIPART_SIZE =
+    ConfigBuilder("spark.shuffle.hadoop.async.io.upload.multipart.size")
+      .doc("The size of each multipart upload. See hadoop config `fs.s3a.multipart.size`")
+      .stringConf
+      .createWithDefault("100M")
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
@@ -53,4 +53,9 @@ final class AsyncShuffleUploadDriverEndpoint(
 
 object AsyncShuffleUploadDriverEndpoint {
   val NAME = "async-shuffle-driver-endpoint"
+
+  def create(rpcEnv: RpcEnv, shuffleStorageStateTracker: ShuffleStorageStateTracker)
+      : AsyncShuffleUploadDriverEndpoint = {
+    new AsyncShuffleUploadDriverEndpoint(rpcEnv, shuffleStorageStateTracker)
+  }
 }

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
@@ -20,6 +20,10 @@ package org.apache.spark.palantir.shuffle.async
 import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 
+/**
+ * Communication hook on the driver for receiving queries from executors and delegating them to the
+ * {@link ShuffleStorageStateTracker}.
+ */
 final class AsyncShuffleUploadDriverEndpoint(
     override val rpcEnv: RpcEnv,
     shuffleStorageStateTracker: ShuffleStorageStateTracker) extends ThreadSafeRpcEndpoint {

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadDriverEndpoint.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker
+import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
+
+final class AsyncShuffleUploadDriverEndpoint(
+    override val rpcEnv: RpcEnv,
+    shuffleStorageStateTracker: ShuffleStorageStateTracker) extends ThreadSafeRpcEndpoint {
+
+  override def receiveAndReply(context: RpcCallContext)
+      : PartialFunction[Any, Unit] = {
+    case IsShuffleRegistered(shuffleId) =>
+      context.reply(shuffleStorageStateTracker.isShuffleRegistered(shuffleId))
+    case GetNextMergeId => context.reply(shuffleStorageStateTracker.getNextMergeId)
+    case GetShuffleStorageStates(shuffleId) =>
+      context.reply(shuffleStorageStateTracker.getShuffleStorageStates(shuffleId))
+    case GetShuffleStorageState(mapOutputId) =>
+      context.reply(shuffleStorageStateTracker.getShuffleStorageState(mapOutputId))
+  }
+
+  override def receive(): PartialFunction[Any, Unit] = {
+    case RegisterLocallyWrittenMapOutput(executorLocation, mapOutputId) =>
+      shuffleStorageStateTracker.registerLocallyWrittenMapOutput(executorLocation, mapOutputId)
+    case RegisterMergedMapOutput(mapOutputIds, mergeId) =>
+      mapOutputIds.foreach(shuffleStorageStateTracker.registerMergedBackedUpMapOutput(_, mergeId))
+    case RegisterUnmergedMapOutput(mapOutputId) =>
+      shuffleStorageStateTracker.registerUnmergedBackedUpMapOutput(mapOutputId)
+    case BlacklistExecutor(blockManagerId) =>
+      shuffleStorageStateTracker.blacklistExecutor(blockManagerId)
+  }
+}
+
+object AsyncShuffleUploadDriverEndpoint {
+  val NAME = "async-shuffle-driver-endpoint"
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadRpcMessages.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleUploadRpcMessages.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import org.apache.spark.palantir.shuffle.async.metadata.MapOutputId
+import org.apache.spark.storage.BlockManagerId
+
+sealed trait AsyncShuffleUploadRpcMessage
+
+case class IsShuffleRegistered(shuffleId: Int) extends AsyncShuffleUploadRpcMessage
+
+case object GetNextMergeId extends AsyncShuffleUploadRpcMessage
+
+case class RegisterLocallyWrittenMapOutput(
+    executorLocation: BlockManagerId, mapOutput: MapOutputId) extends AsyncShuffleUploadRpcMessage
+
+case class RegisterUnmergedMapOutput(mapOutput: MapOutputId) extends AsyncShuffleUploadRpcMessage
+
+case class RegisterMergedMapOutput(mapOutputs: Seq[MapOutputId], mergeId: Long)
+  extends AsyncShuffleUploadRpcMessage
+
+case class GetShuffleStorageState(mapOutputId: MapOutputId) extends AsyncShuffleUploadRpcMessage
+
+case class GetShuffleStorageStates(shuffleId: Int) extends AsyncShuffleUploadRpcMessage
+
+case class BlacklistExecutor(blockManagerId: BlockManagerId) extends AsyncShuffleUploadRpcMessage
+

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/FetchFailedExceptionThrower.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/FetchFailedExceptionThrower.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.storage.BlockManagerId
+
+object FetchFailedExceptionThrower {
+
+  /**
+   * A workaround for the fact that {@link FetchFailedException} is a checked exception and hence
+   * it cannot be thrown by any Java method that does not declare it in the method signature.
+   */
+  def throwFetchFailedException[T](
+      shuffleId: Int,
+      mapId: Int,
+      reduceId: Int,
+      bmId: BlockManagerId,
+      errorMessage: String,
+      cause: Throwable): T = {
+    throw new FetchFailedException(
+      bmId, shuffleId, mapId, reduceId, errorMessage, cause)
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/JavaSparkConf.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/JavaSparkConf.scala
@@ -20,6 +20,12 @@ package org.apache.spark.palantir.shuffle.async
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.ConfigEntry
 
+/**
+ * A wrapper around  {@link SparkConf} that allows access to getting configurations with stronogly
+ * typed fields that are backed by ConfigEntrys.
+ * <p>
+ * As the name would suggest, this is primarily intended for use in Java code.
+ */
 case class JavaSparkConf(conf: SparkConf) {
 
   def getInt(key: ConfigEntry[Int]): Int = conf.get(key)

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/JavaSparkConf.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/JavaSparkConf.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.ConfigEntry
+
+case class JavaSparkConf(conf: SparkConf) {
+
+  def getInt(key: ConfigEntry[Int]): Int = conf.get(key)
+
+  def getLong(key: ConfigEntry[Long]): Long = conf.get(key)
+
+  def getBoolean(key: ConfigEntry[Boolean]): Boolean = conf.get(key)
+
+  def get[T](key: ConfigEntry[T]): T = conf.get(key)
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/ShuffleDriverEndpointRef.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/ShuffleDriverEndpointRef.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.palantir.shuffle.async.metadata.{MapOutputId, ShuffleStorageState}
+import org.apache.spark.rpc.RpcEndpointRef
+import org.apache.spark.storage.BlockManagerId
+
+trait ShuffleDriverEndpointRef {
+  def isShuffleRegistered(shuffleId: Int): Boolean
+
+  def getNextMergeId: Long
+
+  def registerLocallyWrittenMapOutput(mapOutputId: MapOutputId): Unit
+
+  def registerMergedMapOutput(mapOutputIds: java.util.List[MapOutputId], mergeId: Long): Unit
+
+  def registerUnmergedMapOutput(mapOutputId: MapOutputId): Unit
+
+  def getShuffleStorageState(mapOutputId: MapOutputId): ShuffleStorageState
+
+  def getShuffleStorageStates(shuffleId: Int): java.util.Map[MapOutputId, ShuffleStorageState]
+
+
+  def blacklistExecutor(blockManagerId: BlockManagerId)
+}
+
+final class JavaShuffleDriverEndpointRef(
+    shuffleDriverEndpointRef: RpcEndpointRef,
+    executorLocation: BlockManagerId) extends ShuffleDriverEndpointRef {
+
+  override def isShuffleRegistered(shuffleId: Int): Boolean = {
+    shuffleDriverEndpointRef.askSync[Boolean](IsShuffleRegistered(shuffleId))
+  }
+
+  override def getNextMergeId: Long = {
+    shuffleDriverEndpointRef.askSync[Long](GetNextMergeId)
+  }
+
+  override def registerMergedMapOutput(
+      mapOutputIds: java.util.List[MapOutputId], mergeId: Long): Unit = {
+    shuffleDriverEndpointRef.send(RegisterMergedMapOutput(mapOutputIds.asScala, mergeId))
+  }
+
+  override def registerUnmergedMapOutput(mapOutputId: MapOutputId): Unit = {
+    shuffleDriverEndpointRef.send(RegisterUnmergedMapOutput(mapOutputId))
+  }
+
+  override def blacklistExecutor(blockManagerId: BlockManagerId): Unit = {
+    // Don't call localShuffleStorageStates, since we should never be blacklisting ourselves...
+    shuffleDriverEndpointRef.send(BlacklistExecutor(blockManagerId))
+  }
+
+  override def getShuffleStorageState(mapOutputId: MapOutputId): ShuffleStorageState = {
+    shuffleDriverEndpointRef.askSync[ShuffleStorageState](GetShuffleStorageState(mapOutputId))
+  }
+
+  override def getShuffleStorageStates(shuffleId: Int)
+      : java.util.Map[MapOutputId, ShuffleStorageState] = {
+    shuffleDriverEndpointRef.askSync[java.util.Map[MapOutputId, ShuffleStorageState]](
+      GetShuffleStorageStates(shuffleId))
+  }
+
+  override def registerLocallyWrittenMapOutput(mapOutputId: MapOutputId): Unit = {
+    shuffleDriverEndpointRef.send(RegisterLocallyWrittenMapOutput(executorLocation, mapOutputId))
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/ShuffleDriverEndpointRef.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/ShuffleDriverEndpointRef.scala
@@ -23,6 +23,10 @@ import org.apache.spark.palantir.shuffle.async.metadata.{MapOutputId, ShuffleSto
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.storage.BlockManagerId
 
+/**
+ * Represents a hook to the driver to query about the metadata of shuffle files, primarily their
+ * states and possible merge ids.
+ */
 trait ShuffleDriverEndpointRef {
   def isShuffleRegistered(shuffleId: Int): Boolean
 

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/MapOutputId.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/MapOutputId.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metadata
+
+case class MapOutputId(shuffleId: Int, mapId: Int, mapAttemptId: Long)

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/ShuffleStorageState.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/ShuffleStorageState.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metadata
+
+import java.lang.{Long => JLong}
+import java.util.{Optional => JOptional}
+
+import scala.compat.java8.OptionConverters._
+
+import org.apache.spark.storage.BlockManagerId
+
+sealed trait ShuffleStorageState {
+  def visit[T](visitor: ShuffleStorageStateVisitor[T]): T = {
+    this match {
+      case Unregistered => visitor.unregistered()
+      case OnExecutorOnly(executorLocation) => visitor.onExecutorOnly(executorLocation)
+      case OnExecutorAndRemote(executorLocation, mergeId) =>
+        visitor.onExecutorAndRemote(executorLocation, mergeId.map(long2Long).asJava)
+      case OnRemoteOnly(mergeId) => visitor.onRemoteOnly(mergeId.map(long2Long).asJava)
+    }
+  }
+}
+
+sealed trait StoredOnExecutor extends ShuffleStorageState {
+  def executorLocation: BlockManagerId
+}
+
+sealed trait StoredOnRemote extends ShuffleStorageState {
+  def mergeId: Option[Long]
+
+  def getMergeId: JOptional[JLong] = mergeId.map(long2Long).asJava
+}
+
+case object Unregistered extends ShuffleStorageState
+
+case class OnExecutorOnly(executorLocation: BlockManagerId)
+  extends ShuffleStorageState with StoredOnExecutor
+
+case class OnExecutorAndRemote(executorLocation: BlockManagerId, mergeId: Option[Long] = None)
+    extends StoredOnExecutor with StoredOnRemote
+
+object OnExecutorAndRemote {
+  def apply(executorLocation: BlockManagerId, mergeId: Long): OnExecutorAndRemote = {
+    OnExecutorAndRemote(executorLocation, Some(mergeId))
+  }
+}
+
+case class OnRemoteOnly(mergeId: Option[Long] = None) extends StoredOnRemote
+
+object OnRemoteOnly {
+  def apply(mergeId: Long): OnRemoteOnly = OnRemoteOnly(Some(mergeId))
+}
+
+/**
+ * For Java interpretation of the state. Otherwise, one should use Scala pattern matching.
+ */
+trait ShuffleStorageStateVisitor[T] {
+
+  def unregistered(): T
+
+  def onExecutorOnly(executorLocation: BlockManagerId): T
+
+  def onExecutorAndRemote(executorLocation: BlockManagerId, mergeId: JOptional[JLong]): T
+
+  def onRemoteOnly(mergeId: JOptional[JLong]): T
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/ShuffleStorageStateTracker.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/metadata/ShuffleStorageStateTracker.scala
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.metadata
+
+import java.lang.{Integer => JInt}
+import java.util.{Map => JMap}
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.compat.java8.FunctionConverters._
+
+import com.google.common.collect.{ImmutableMap, Maps}
+import com.palantir.logsafe.SafeArg
+import com.palantir.logsafe.exceptions.SafeIllegalStateException
+
+import org.apache.spark.storage.BlockManagerId
+
+class ShuffleStorageStateTracker {
+
+  import ShuffleStorageStateTracker._
+
+  private val states = Maps.newConcurrentMap[JInt, JMap[MapOutputId, ShuffleStorageState]]
+  private val nextMergeId = new AtomicLong(0L)
+
+  def getNextMergeId: Long = nextMergeId.getAndIncrement()
+
+  def registerShuffle(shuffleId: Int): Unit = {
+    states.putIfAbsent(shuffleId, Maps.newConcurrentMap[MapOutputId, ShuffleStorageState])
+  }
+
+  def unregisterShuffle(shuffleId: Int): Unit = {
+    states.remove(shuffleId)
+  }
+
+  def registerLocallyWrittenMapOutput(
+      executorLocation: BlockManagerId,
+      mapOutputId: MapOutputId): Unit = {
+    updateStorageState(
+      mapOutputId,
+      OnExecutorOnly(executorLocation),
+      prev => {
+        throw new SafeIllegalStateException(
+          "Map output should only be registered as locally written as an initial state.",
+          mapOutputIdArg(mapOutputId),
+          invalidPrevStateArg(prev)
+        )
+      })
+  }
+
+  def registerUnmergedBackedUpMapOutput(mapOutputId: MapOutputId): Unit = {
+    updateStorageState(
+      mapOutputId,
+      defaultStateFunc = {
+        throw mapOutputNotWrittenLocallyBeforeBackedUp(mapOutputId)
+      },
+      nextStateFunc = {
+        case OnExecutorOnly(executorLocation) => OnExecutorAndRemote(executorLocation)
+        case invalidPrevState: ShuffleStorageState =>
+          throw mapOutputNotWrittenLocallyBeforeBackedUp(mapOutputId, Some(invalidPrevState))
+      })
+  }
+
+  def registerMergedBackedUpMapOutput(mapOutputId: MapOutputId, mergeId: Long): Unit = {
+    updateStorageState(
+      mapOutputId,
+      defaultStateFunc = {
+        throw mapOutputNotWrittenLocallyBeforeBackedUp(mapOutputId)
+      },
+      nextStateFunc = {
+        case OnExecutorOnly(executorLocation) => OnExecutorAndRemote(executorLocation, mergeId)
+        case invalidPrevState: ShuffleStorageState =>
+          throw mapOutputNotWrittenLocallyBeforeBackedUp(mapOutputId, Some(invalidPrevState))
+      })
+  }
+
+  def markLocalMapOutputAsDeleted(mapOutputId: MapOutputId): Unit = {
+    updateStorageState(
+      mapOutputId,
+      defaultStateFunc = {
+        throw mapOutputNotBackedUpBeforeDeletedLocally(mapOutputId)
+      },
+      nextStateFunc = {
+        case OnExecutorAndRemote(_, mergeId) => OnRemoteOnly(mergeId)
+        case invalidPrevState: ShuffleStorageState =>
+          throw mapOutputNotBackedUpBeforeDeletedLocally(mapOutputId, Some(invalidPrevState))
+      })
+  }
+
+  def isShuffleRegistered(shuffleId: Int): Boolean = states.containsKey(shuffleId)
+
+  def getShuffleStorageState(mapOutputId: MapOutputId): ShuffleStorageState = {
+    states.getOrDefault(mapOutputId.shuffleId, NO_MAP_OUTPUTS)
+      .getOrDefault(mapOutputId, Unregistered)
+  }
+
+  def getShuffleStorageStates(shuffleId: Int): JMap[MapOutputId, ShuffleStorageState] = {
+    ImmutableMap.copyOf(states.getOrDefault(shuffleId, NO_MAP_OUTPUTS))
+  }
+
+  def blacklistExecutor(blacklistedLocation: BlockManagerId): Unit = {
+    states.replaceAll(
+      asJavaBiFunction { (_: JInt, mapOutputs: JMap[MapOutputId, ShuffleStorageState]) =>
+        mapOutputs.replaceAll(
+          asJavaBiFunction { (_, state) =>
+            state match {
+              case storedOnExecutor: StoredOnExecutor
+                  if storedOnExecutor.executorLocation == blacklistedLocation =>
+                getNextStateWhenLocationRemoved(storedOnExecutor)
+              case other: ShuffleStorageState => other
+            }
+          })
+        mapOutputs
+      })
+  }
+
+  private def getNextStateWhenLocationRemoved(prevState: StoredOnExecutor): ShuffleStorageState = {
+    prevState match {
+      case OnExecutorOnly(_) => Unregistered
+      case OnExecutorAndRemote(_, mergeId) => OnRemoteOnly(mergeId)
+    }
+  }
+
+  private def updateStorageState(
+      mapOutputId: MapOutputId,
+      defaultStateFunc: => ShuffleStorageState,
+      nextStateFunc: ShuffleStorageState => ShuffleStorageState): Unit = {
+    states.computeIfPresent(
+      mapOutputId.shuffleId,
+      asJavaBiFunction { (_, mapOutputs: JMap[MapOutputId, ShuffleStorageState]) =>
+        mapOutputs.compute(
+          mapOutputId,
+          asJavaBiFunction { (_, prevState) =>
+            Option(prevState)
+              .map(nextStateFunc)
+              .getOrElse(defaultStateFunc)
+          })
+        mapOutputs
+      })
+  }
+}
+
+private object ShuffleStorageStateTracker {
+  private val NO_MAP_OUTPUTS = ImmutableMap.of[MapOutputId, ShuffleStorageState]()
+
+  def mapOutputNotWrittenLocallyBeforeBackedUp(
+      mapOutputId: MapOutputId,
+      invalidPrevState: Option[ShuffleStorageState] = None): SafeIllegalStateException = {
+    val errMsg = "Map output should not be initially marked as backed up; should be registered" +
+      " as being on the executor only first."
+    invalidPrevState.map { prev =>
+      new SafeIllegalStateException(
+        errMsg,
+        mapOutputIdArg(mapOutputId),
+        invalidPrevStateArg(prev))
+    }.getOrElse(new SafeIllegalStateException(errMsg, mapOutputIdArg(mapOutputId)))
+  }
+
+  def mapOutputNotBackedUpBeforeDeletedLocally(
+      mapOutputId: MapOutputId,
+      invalidPrevState: Option[ShuffleStorageState] = None): SafeIllegalStateException = {
+    val errMsg = "Map output should not be marked as deleted before it was marked as being" +
+      " backed up."
+    invalidPrevState.map { prev =>
+      new SafeIllegalStateException(
+        errMsg,
+        mapOutputIdArg(mapOutputId),
+        invalidPrevStateArg(prev))
+    }.getOrElse(new SafeIllegalStateException(errMsg, mapOutputIdArg(mapOutputId)))
+  }
+
+  def mapOutputIdArg(mapOutputId: MapOutputId): SafeArg[MapOutputId] = {
+    SafeArg.of("mapOutputId", mapOutputId)
+  }
+
+  def invalidPrevStateArg(invalidPrevState: ShuffleStorageState): SafeArg[ShuffleStorageState] = {
+    SafeArg.of("invalidPrevState", invalidPrevState)
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/test/scala/org/apache/spark/palantir/ShuffleStorageStateTrackerTest.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/test/scala/org/apache/spark/palantir/ShuffleStorageStateTrackerTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir
+
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.palantir.ShuffleStorageStateTrackerTest._
+import org.apache.spark.palantir.shuffle.async.metadata.{MapOutputId, OnExecutorAndRemote, OnExecutorOnly, OnRemoteOnly, ShuffleStorageStateTracker, Unregistered}
+import org.apache.spark.palantir.test.util.BlockManagerIdFactory
+
+@RunWith(classOf[JUnitRunner])
+class ShuffleStorageStateTrackerTest extends SparkFunSuite with BeforeAndAfter with Matchers {
+
+  private var trackerUnderTest: ShuffleStorageStateTracker = _
+
+  before {
+    trackerUnderTest = new ShuffleStorageStateTracker()
+  }
+
+  test("Initial state is always unregistered.") {
+    trackerUnderTest.getShuffleStorageState(MapOutputId(1, 2, 3)) shouldBe Unregistered
+  }
+
+  test("Register shuffle -> initial state for map outputs is unregistered.") {
+    trackerUnderTest.registerShuffle(0)
+    trackerUnderTest.getShuffleStorageState(MapOutputId(0, 1, 2)) shouldBe Unregistered
+  }
+
+  test("Unregistered -> registered locally -> registered backed up -> executor blacklisted") {
+    trackerUnderTest.registerShuffle(0)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_1, MAP_OUTPUT_ID_1)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_2, MAP_OUTPUT_ID_2)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe OnExecutorOnly(BM_ID_1)
+    trackerUnderTest.registerUnmergedBackedUpMapOutput(MAP_OUTPUT_ID_1)
+    trackerUnderTest.registerUnmergedBackedUpMapOutput(MAP_OUTPUT_ID_2)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe OnExecutorAndRemote(BM_ID_1)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_2) shouldBe OnExecutorAndRemote(BM_ID_2)
+    trackerUnderTest.blacklistExecutor(BM_ID_1)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe OnRemoteOnly()
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_2) shouldBe OnExecutorAndRemote(BM_ID_2)
+  }
+
+  test("Unregistered -> registered locally -> executor blacklisted") {
+    trackerUnderTest.registerShuffle(0)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_1, MAP_OUTPUT_ID_1)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_2, MAP_OUTPUT_ID_2)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe OnExecutorOnly(BM_ID_1)
+    trackerUnderTest.blacklistExecutor(BM_ID_1)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe Unregistered
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_2) shouldBe OnExecutorOnly(BM_ID_2)
+  }
+
+  test("Unregistered -> registered locally -> registered backed up -> delete local file") {
+    trackerUnderTest.registerShuffle(0)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_1, MAP_OUTPUT_ID_1)
+    trackerUnderTest.registerLocallyWrittenMapOutput(BM_ID_2, MAP_OUTPUT_ID_2)
+    trackerUnderTest.registerUnmergedBackedUpMapOutput(MAP_OUTPUT_ID_1)
+    trackerUnderTest.registerUnmergedBackedUpMapOutput(MAP_OUTPUT_ID_2)
+    trackerUnderTest.markLocalMapOutputAsDeleted(MAP_OUTPUT_ID_1)
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_1) shouldBe OnRemoteOnly()
+    trackerUnderTest.getShuffleStorageState(MAP_OUTPUT_ID_2) shouldBe OnExecutorAndRemote(BM_ID_2)
+  }
+}
+
+private object ShuffleStorageStateTrackerTest {
+  private val BLOCK_MANAGER_ID_PORT = 7077
+  private val BM_ID_1 = BlockManagerIdFactory.createBlockManagerId("host1", BLOCK_MANAGER_ID_PORT)
+  private val BM_ID_2 = BlockManagerIdFactory.createBlockManagerId("host2", BLOCK_MANAGER_ID_PORT)
+  private val MAP_OUTPUT_ID_1 = MapOutputId(0, 0, 0)
+  private val MAP_OUTPUT_ID_2 = MapOutputId(0, 1, 1)
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/test/scala/org/apache/spark/palantir/test/util/BlockManagerIdFactory.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/test/scala/org/apache/spark/palantir/test/util/BlockManagerIdFactory.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.test.util
+
+import org.apache.spark.storage.BlockManagerId
+
+// To get around Scala's package protection.
+object BlockManagerIdFactory {
+
+  def createBlockManagerId(host: String, port: Int): BlockManagerId = {
+    BlockManagerId(host, port)
+  }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -388,14 +388,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.palantir.safe-logging</groupId>
-      <artifactId>safe-logging</artifactId>
-      <version>1.5.1</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-crypto</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-crypto</artifactId>
+      <groupId>com.palantir.safe-logging</groupId>
+      <artifactId>safe-logging</artifactId>
     </dependency>
 
   </dependencies>

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -787,7 +787,7 @@ package object config {
       .createWithDefault(false)
 
   private[spark] val SHUFFLE_IO_PLUGIN_CLASS =
-    ConfigBuilder("spark.shuffle.sort.io.storage.plugin.class")
+    ConfigBuilder("spark.shuffle.sort.io.storage.plugin.class.v2")
       .doc("Name of the class to use for shuffle IO.")
       .stringConf
       .createWithDefault(classOf[LocalDiskShuffleDataIO].getName)

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -185,7 +185,7 @@ parquet-jackson-1.12.0-palantir.6.jar
 protobuf-java-2.5.0.jar
 py4j-0.10.8.1.jar
 pyrolite-4.13.jar
-safe-logging-1.5.1.jar
+safe-logging-1.13.0.jar
 scala-compiler-2.11.12.jar
 scala-library-2.11.12.jar
 scala-parser-combinators_2.11-1.1.0.jar

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -563,6 +563,61 @@ cloud = Module(
     sbt_test_goals=["hadoop-cloud/test"]
 )
 
+asyncShuffleUploadImmutables = Module(
+    name="async-shuffle-upload-immutables",
+    dependencies=[],
+    source_file_regexes=[
+        "async-shuffle-upload/async-shuffle-upload-immutables/",
+    ],
+    sbt_test_goals=[
+        "async-shuffle-upload-immutables/test",
+    ],
+)
+
+asyncShuffleUploadApi = Module(
+    name="async-shuffle-upload-api",
+    dependencies=[asyncShuffleUploadImmutables],
+    source_file_regexes=[
+        "async-shuffle-upload/async-shuffle-upload-api/",
+    ],
+    sbt_test_goals=[
+        "async-shuffle-upload-api/test",
+    ],
+)
+
+asyncShuffleUploadScala = Module(
+    name="async-shuffle-upload-scala",
+    dependencies=[asyncShuffleUploadApi],
+    source_file_regexes=[
+        "async-shuffle-upload/async-shuffle-upload-scala/",
+    ],
+    sbt_test_goals=[
+        "async-shuffle-upload-scala/test",
+    ],
+)
+
+asyncShuffleUploadScalaTestUtils = Module(
+    name="async-shuffle-upload-scala-test-utils",
+    dependencies=[asyncShuffleUploadApi, asyncShuffleUploadScala],
+    source_file_regexes=[
+        "async-shuffle-upload/async-shuffle-upload-scala-test-utils/",
+    ],
+    sbt_test_goals=[
+        "async-shuffle-upload-scala-test-utils/test",
+    ],
+)
+
+asyncShuffleUploadCore = Module(
+    name="async-shuffle-upload-core",
+    dependencies=[asyncShuffleUploadApi, asyncShuffleUploadScala, asyncShuffleUploadScalaTestUtils],
+    source_file_regexes=[
+        "async-shuffle-upload/async-shuffle-upload-core/",
+    ],
+    sbt_test_goals=[
+        "async-shuffle-upload-core/test",
+    ],
+)
+
 # The root module is a dummy module which is used to run all of the tests.
 # No other modules should directly depend on this module.
 root = Module(

--- a/dists/hadoop-palantir-bom/pom.xml
+++ b/dists/hadoop-palantir-bom/pom.xml
@@ -149,6 +149,23 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <!-- async shuffle upload modules -->
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-async-shuffle-upload-api_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-async-shuffle-upload-scala_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/dists/hadoop-palantir-bom/pom.xml
+++ b/dists/hadoop-palantir-bom/pom.xml
@@ -158,6 +158,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
+                <artifactId>spark-async-shuffle-upload-core_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
                 <artifactId>spark-async-shuffle-upload-immutables_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dists/hadoop-palantir/pom.xml
+++ b/dists/hadoop-palantir/pom.xml
@@ -106,6 +106,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-core_2.11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-async-shuffle-upload-immutables_2.11</artifactId>
     </dependency>
     <dependency>

--- a/dists/hadoop-palantir/pom.xml
+++ b/dists/hadoop-palantir/pom.xml
@@ -98,5 +98,19 @@
       <groupId>com.palantir.spark.influx</groupId>
       <artifactId>spark-influx-sink</artifactId>
     </dependency>
+
+    <!-- async shuffle upload modules -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-api_2.11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-immutables_2.11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-async-shuffle-upload-scala_2.11</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
   ~ this work for additional information regarding copyright ownership.
   ~ The ASF licenses this file to You under the Apache License, Version 2.0
   ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
+  ~ the License.  You may obtain a copy of the License at ~
   ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
@@ -114,6 +113,13 @@
     <module>sql/hive</module>
     <module>streaming</module>
     <module>tools</module>
+
+    <!-- Async shuffle upload modules-->
+    <module>async-shuffle-upload/async-shuffle-upload-api</module>
+    <module>async-shuffle-upload/async-shuffle-upload-core</module>
+    <module>async-shuffle-upload/async-shuffle-upload-immutables</module>
+    <module>async-shuffle-upload/async-shuffle-upload-scala</module>
+    <module>async-shuffle-upload/async-shuffle-upload-scala-test-utils</module>
     <!-- See additional modules enabled by profiles below -->
   </modules>
 
@@ -216,6 +222,9 @@
     ./python/run-tests.py and ./python/setup.py too.
     -->
     <arrow.version>0.12.0</arrow.version>
+
+    <!-- Async shuffle upload plugin dependency versions -->
+    <safe-logging.version>1.13.0</safe-logging.version>
 
     <test.java.home>${java.home}</test.java.home>
     <test.exclude.tags></test.exclude.tags>
@@ -2310,6 +2319,63 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.palantir.safe-logging</groupId>
+        <artifactId>safe-logging</artifactId>
+        <version>${safe-logging.version}</version>
+      </dependency>
+
+      <!-- Dependencies required for the async shuffle upload plugin. -->
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>2.8.3</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>builder</artifactId>
+        <version>2.8.3</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.palantir.safe-logging</groupId>
+        <artifactId>preconditions</artifactId>
+        <version>${safe-logging.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.15.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-java8-compat_${scala.binary.version}</artifactId>
+        <version>0.9.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jodah</groupId>
+        <artifactId>net.jodah.failsafe</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <version>2.2.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-guava</artifactId>
+        <version>3.2.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock</artifactId>
+        <scope>test</scope>
+        <version>2.12.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -48,12 +48,18 @@ object BuildCommons {
   val streamingProjects@Seq(streaming, streamingKafka010) =
     Seq("streaming", "streaming-kafka-0-10").map(ProjectRef(buildLocation, _))
 
+  val asyncShuffleUploadProjects@Seq(
+    asyncShuffleUploadApi, asyncShuffleUploadImmutables, asyncShuffleUploadScala, asyncShuffleUploadScalaTestUtils, asyncShuffleUploadCore) = Seq(
+    "async-shuffle-upload-api", "async-shuffle-upload-immutables", "async-shuffle-upload-scala",
+    "async-shuffle-upload-scala-test-utils", "async-shuffle-upload-core").map(ProjectRef(buildLocation, _))
+
   val allProjects@Seq(
     core, graphx, mllib, mllibLocal, repl, networkCommon, networkShuffle, launcher, unsafe, tags, sketch, kvstore, _*
   ) = Seq(
     "core", "graphx", "mllib", "mllib-local", "repl", "network-common", "network-shuffle", "launcher", "unsafe",
     "tags", "sketch", "kvstore"
-  ).map(ProjectRef(buildLocation, _)) ++ sqlProjects ++ streamingProjects
+  ).map(ProjectRef(buildLocation, _)) ++ sqlProjects ++ streamingProjects ++ asyncShuffleUploadProjects
+
 
   val optionallyEnabledProjects@Seq(kubernetes, mesos, yarn,
     sparkGangliaLgpl, streamingKinesisAsl,
@@ -336,10 +342,10 @@ object SparkBuild extends PomBuild {
   (allProjects ++ optionallyEnabledProjects).foreach(enable(TestSettings.settings))
 
   val mimaProjects = allProjects.filterNot { x =>
-    Seq(
+    (Seq(
       spark, hive, hiveThriftServer, catalyst, repl, networkCommon, networkShuffle, networkYarn,
       unsafe, tags, tokenProviderKafka010, sqlKafka010, kvstore, avro
-    ).contains(x)
+    ) ++ asyncShuffleUploadProjects).contains(x)
   }
 
   mimaProjects.foreach { x =>


### PR DESCRIPTION
Open-sources the async shuffle upload plugin we have built and tested internally. A static, older version of this used to reside in https://github.com/palantir/async-shuffle-upload.

The plugin cross-compiles against Spark core in the same Maven reactor. This ensures that when Spark's shuffle plugin APIs evolve, we can ensure our plugin compiles against the changes immediately. This also ensures that when we use [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions), we consistently depend on a plugin that is compatible with the Spark version that is also pulled in by the application.

This migration attempts to maintain the project structure and functionality of its internal counterpart. As such, some design decisions may be artifacts from the internal version. They can be adjusted here, or otherwise can be adjusted in follow-ups. Particularly, there shouldn't be a need for a separate Scala module, both for core and for test utilities. But we maintain the separate module for ease of initial review and consistency with the original work.

The open source version here inherits style guidelines from Spark as opposed to [Baseline](https://github.com/palantir/gradle-baseline). As such:

* Imports are grouped via Spark's style guidelines
* Maximum line length is 100, down from 120
* Indentation is down to 2 spaces for base, down from 4
* Continuation indentation is down to 4 spaces, down from 8

Finally, we had to use the Guava dependency that Spark specifically pulls in and shades, so some code is less streamlined and does not take advantage of newer Guava APIs.