### PR TITLE
Upgrade hadoop to take HADOOP-12760

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,10 @@ step_templates:
   restore-home-sbt-cache: &restore-home-sbt-cache
     restore_cache:
       keys:
-        - v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+        - v3-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
   restore-build-sbt-cache: &restore-build-sbt-cache
     restore_cache:
-      key: v2-build-sbt-{{ .Branch }}-{{ .Revision }}
+      key: v3-build-sbt-{{ .Branch }}-{{ .Revision }}
   link-in-build-sbt-cache: &link-in-build-sbt-cache
     run:
       name: Hard link cache contents into current build directory
@@ -245,7 +245,7 @@ jobs:
           path: /tmp/build-apache-spark.log
           destination: build-apache-spark.log
       - save_cache:
-          key: v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
+          key: v3-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
           paths: ~/.sbt
       # Also hard link all the things so we can save it as a cache and restore it in future builds
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ step_templates:
         - v2-home-sbt-{{ checksum "build/sbt" }}-{{ checksum "project/target/streams/$global/update/$global/streams/update_cache_2.10/inputs" }}
   restore-build-sbt-cache: &restore-build-sbt-cache
     restore_cache:
-      key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
+      key: v2-build-sbt-{{ .Branch }}-{{ .Revision }}
   link-in-build-sbt-cache: &link-in-build-sbt-cache
     run:
       name: Hard link cache contents into current build directory
@@ -217,9 +217,9 @@ jobs:
       # Saves us from recompiling every time...
       #- restore_cache:
           #keys:
-            #- v1-build-sbt-{{ .Branch }}-{{ .Revision }}
-            #- v1-build-sbt-{{ .Branch }}-
-            #- v1-build-sbt-master-
+            #- v2-build-sbt-{{ .Branch }}-{{ .Revision }}
+            #- v2-build-sbt-{{ .Branch }}-
+            #- v2-build-sbt-master-
       - *checkout-code
       - run:
           name: Hard link cache contents into current build directory
@@ -255,7 +255,7 @@ jobs:
             --exclude '***/*.jar' --include 'target/***'
             --include '**/' --exclude '*' . "$BUILD_SBT_CACHE/"
       - save_cache:
-          key: v1-build-sbt-{{ .Branch }}-{{ .Revision }}
+          key: v2-build-sbt-{{ .Branch }}-{{ .Revision }}
           paths:
             - "~/build-sbt-cache"
       # Also save all the assembly jars directories to the workspace - need them for spark submitting

--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,11 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.version>3.6.0</maven.version>
+    <maven.version>3.6.3</maven.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <hadoop.version>2.9.2-palantir.6</hadoop.version>
+    <hadoop.version>2.9.2-palantir.8</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.4.7</zookeeper.version>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/typesafe/sbt-plugins"))(
   Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,8 @@
+resolvers += Resolver.url(
+  "bintray-typesafe-sbt-plugins",
+  url("http://dl.bintray.com/typesafe/sbt-plugins"))(
+  Resolver.ivyStylePatterns)
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
backporting an hadoop fix to get the in process launcher work with jdk 9+
## What changes were proposed in this pull request?
Upgrade hadoop to 2.9.2-palantir.8. Changelog: https://github.com/palantir/hadoop/blob/branch-2.9.2/palantir/CHANGELOG.md#292-palantir8

## How was this patch tested?
N/A

