### PR TITLE
Change AQE default minPartitionNum to defaultParallelism

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -299,11 +299,12 @@ object SQLConf {
 
   val SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS =
     buildConf("spark.sql.adaptive.minNumPostShufflePartitions")
-      .doc("The advisory minimum number of post-shuffle partitions used in adaptive execution.")
+      .doc("The advisory minimum number of post-shuffle partitions used in adaptive execution. " +
+        "If not set, the default value is the default parallelism of the Spark cluster.")
       .intConf
       .checkValue(_ > 0, "The minimum shuffle partition number " +
         "must be a positive integer.")
-      .createWithDefault(1)
+      .createOptional
 
   val SHUFFLE_MAX_NUM_POSTSHUFFLE_PARTITIONS =
     buildConf("spark.sql.adaptive.maxNumPostShufflePartitions")
@@ -1829,9 +1830,6 @@ class SQLConf extends Serializable with Logging {
     getConf(NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN)
 
   def reducePostShufflePartitionsEnabled: Boolean = getConf(REDUCE_POST_SHUFFLE_PARTITIONS_ENABLED)
-
-  def minNumPostShufflePartitions: Int =
-    getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)
 
   def maxNumPostShufflePartitions: Int =
     getConf(SHUFFLE_MAX_NUM_POSTSHUFFLE_PARTITIONS).getOrElse(numShufflePartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -90,7 +90,7 @@ case class AdaptiveSparkPlanExec(
   // optimizations should be stage-independent.
   @transient private val queryStageOptimizerRules: Seq[Rule[SparkPlan]] = Seq(
     ReuseAdaptiveSubquery(conf, subqueryCache),
-    ReduceNumShufflePartitions(conf),
+    ReduceNumShufflePartitions(queryExecution.sparkSession),
     CollapseCodegenStages(conf)
   )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
@@ -525,7 +525,7 @@ class ReduceNumShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterA
     }
   }
 
-  // TODO(rshkv): Remove after taking SPARK-31124
+  // TODO(rshkv): Remove after taking SPARK-31124 (#676)
   test("number of reducers is lower-bound by default parallelism without configured minimum") {
     val test = { spark: SparkSession =>
       val df =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReduceNumShufflePartitionsSuite.scala
@@ -55,7 +55,7 @@ class ReduceNumShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterA
       bytesByPartitionIdArray: Array[Array[Long]],
       expectedPartitionStartIndices: Seq[Int],
       targetSize: Long,
-      mixNumPartitions: Int = 1): Unit = {
+      minNumPartitions: Int = 1): Unit = {
     val mapOutputStatistics = bytesByPartitionIdArray.zipWithIndex.map {
       case (bytesByPartitionId, index) =>
         new MapOutputStatistics(index, bytesByPartitionId)
@@ -63,7 +63,7 @@ class ReduceNumShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterA
     val estimatedPartitionStartIndices = ReduceNumShufflePartitions.estimatePartitionStartIndices(
       mapOutputStatistics,
       targetSize,
-      mixNumPartitions)
+      minNumPartitions)
     assert(estimatedPartitionStartIndices === expectedPartitionStartIndices)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -98,6 +98,7 @@ class AdaptiveQueryExecSuite
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.REDUCE_POST_SHUFFLE_PARTITIONS_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
+      SQLConf.SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS.key -> "1",
       SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key -> "150") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a where value = '1'")


### PR DESCRIPTION
Applying changes from [SPARK-31124](https://issues.apache.org/jira/browse/SPARK-31124) / [apache/spark#27879](https://github.com/apache/spark/pull/27879).

## What changes were proposed in this pull request?

Authoritative description on [apache/spark#27879](https://github.com/apache/spark/pull/27879). 

**Summary:**    When coalescing partitions in AQE, the minimum is no longer 1 but _default parallelism_. The default parallelism is `spark.default.parallelism` when set or the number of available CPUs at any given point in time. This ensures that we don't lose parallelism by applying AQE.

**Why didn't you just take the upstream commit?**    The AQE framework was refactored in [SPARK-31037](https://issues.apache.org/jira/browse/SPARK-31037), which in turn relies on changes we haven't picked yet. And the sum of those was more than I felt comfortable with taking in one batch. So yes this is lame. We can just revert this later.

**How was this patch tested?**    I wrote a unit test which ensures that the partition number is the default parallelism value where it would otherwise be 1.