### PR TITLE
Infer Pandas string columns in Arrow conversion on Python 2

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -550,9 +550,10 @@ class SparkSession(object):
                 arrow_schema = temp_batch.schema
             else:
                 arrow_schema = pa.Schema.from_pandas(pdf, preserve_index=False)
-                # TODO(rshkv): Remove when we stop supporting Python 2 (#678)
-                if sys.version < '3':
-                    arrow_schema = _infer_binary_columns_as_arrow_string(arrow_schema, pdf)
+
+            # TODO(rshkv): Remove when we stop supporting Python 2 (#678)
+            if sys.version < '3' and LooseVersion(pa.__version__) >= LooseVersion("0.10.0"):
+                arrow_schema = _infer_binary_columns_as_arrow_string(arrow_schema, pdf)
 
             struct = StructType()
             for name, field in zip(schema, arrow_schema):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -550,10 +550,9 @@ class SparkSession(object):
                 arrow_schema = temp_batch.schema
             else:
                 arrow_schema = pa.Schema.from_pandas(pdf, preserve_index=False)
-
-            # TODO(rshkv): Remove when we stop supporting Python 2 (#678)
-            if sys.version < '3':
-                arrow_schema = _infer_binary_columns_as_arrow_string(arrow_schema, pdf)
+                # TODO(rshkv): Remove when we stop supporting Python 2 (#678)
+                if sys.version < '3':
+                    arrow_schema = _infer_binary_columns_as_arrow_string(arrow_schema, pdf)
 
             struct = StructType()
             for name, field in zip(schema, arrow_schema):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -532,7 +532,8 @@ class SparkSession(object):
         """
         from distutils.version import LooseVersion
         from pyspark.serializers import ArrowStreamPandasSerializer
-        from pyspark.sql.types import from_arrow_type, to_arrow_type, TimestampType
+        from pyspark.sql.types import from_arrow_type, to_arrow_type, TimestampType, \
+            _infer_binary_columns_as_arrow_string
         from pyspark.sql.utils import require_minimum_pandas_version, \
             require_minimum_pyarrow_version
 
@@ -549,6 +550,11 @@ class SparkSession(object):
                 arrow_schema = temp_batch.schema
             else:
                 arrow_schema = pa.Schema.from_pandas(pdf, preserve_index=False)
+
+            # TODO(rshkv): Remove when we stop supporting Python 2 (#678)
+            if sys.version < '3':
+                arrow_schema = _infer_binary_columns_as_arrow_string(arrow_schema, pdf)
+
             struct = StructType()
             for name, field in zip(schema, arrow_schema):
                 struct.add(name, from_arrow_type(field.type), nullable=field.nullable)

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -351,6 +351,29 @@ class ArrowTests(ReusedSQLTestCase):
         self.assertEqual(pdf_col_names, df.columns)
         self.assertEqual(pdf_col_names, df_arrow.columns)
 
+    def test_createDataFrame_with_str_col(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": ["x"]})
+
+        df, df_arrow = self._createDataFrame_toggle(pdf)
+        self.assertEqual(df.schema, df_arrow.schema)
+
+    def test_createDataFrame_with_str_array_col(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": [["x"]]})
+
+        with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):
+            df, df_arrow = self._createDataFrame_toggle(pdf)
+            self.assertEqual(df.schema, df_arrow.schema)
+
+    def test_createDataFrame_with_str_struct_col(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": [{"x": "x"}]})
+
+        with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):
+            df, df_arrow = self._createDataFrame_toggle(pdf)
+            self.assertEqual(df.schema, df_arrow.schema)
+
     def test_createDataFrame_fallback_enabled(self):
         with QuietTest(self.sc):
             with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1618,10 +1618,6 @@ def to_arrow_type(dt):
     elif type(dt) == ArrayType:
         if type(dt.elementType) in [StructType, TimestampType]:
             raise TypeError("Unsupported type in conversion to Arrow: " + str(dt))
-        # TODO(rshkv): Support binary type when we move off Python 2 (#678)
-        if sys.version < '3' and type(dt.elementType) == BinaryType:
-            raise TypeError("Unsupported type in conversion to Arrow: " + str(dt) +
-                            "\nPlease use Python3 for support of BinaryType in arrays.")
         arrow_type = pa.list_(to_arrow_type(dt.elementType))
     elif type(dt) == StructType:
         if any(type(field.dataType) == StructType for field in dt):
@@ -1680,6 +1676,12 @@ def from_arrow_type(at):
     elif types.is_list(at):
         if types.is_timestamp(at.value_type):
             raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
+
+        # TODO(rshkv): Support binary type when we move off Python 2 (#678)
+        if sys.version < '3' and types.is_binary(at.value_type):
+            raise TypeError("Unsupported type in conversion from Arrow: " + str(at) +
+                            "\nPlease use Python3 for support of BinaryType in arrays.")
+
         spark_type = ArrayType(from_arrow_type(at.value_type))
     elif types.is_struct(at):
         # TODO: remove version check once minimum pyarrow version is 0.10.0


### PR DESCRIPTION
### Problem
Python 2 strings are stored as binary (as opposed to unicode in Python 3). That means when serializing a Pandas dataframe, Arrow can't tell if columns are string or actually binary, so it assumes binary.

```ipython
In [1]: pandas_df = pd.DataFrame(data={"string_col": ["a", "b", "c"], "nested_string_col": [["a"], ["b"], ["c"]]})

In [2]: spark.createDataFrame(pandas_df).printSchema()
root
 |-- nested_string_col: array (nullable = true)  
 |    |-- element: binary (containsNull = true) # oops 
 |-- string_col: binary (nullable = true) # oops
```
### Why We Care
This is only an issue when using `createDataFrame(pandas_df)` with the `spark.sql.execution.arrow.enabled` flag. We have two internal products that serialize Pandas data frames. And the one with the arrows enables this flag by default.

If used with pyarrow <0.10, Arrow serialization fails anyway courtesy of this check [(GHE)](https://github.com/palantir/spark/blob/acb7d0490fbccc8bd0aa05c2beccf280df8776b0/python/pyspark/sql/types.py#L1608-L1611). This is why unexpected binary columns haven't surprised us until recently, when we upgraded to >0.10.

Note that this is irrelevant for `@pandas_udf` which requires you to provide a schema. If the schema says `string`, Arrow serialization will do the right thing and not give you binary.

### Proposed Changes
We give pyarrow a chance to infer the right column type, and then we nudge it a little depending on what it thinks the type is. There are three different cases:
1. If pyarrow says the column is `binary`, we use Pandas' type inference to check if it isn't actually `string` instead. And if is, we tell Arrow to serialize as `string` type. We only do this for Python 2.
2. For `array<binary>`, we throw an error falling back to non-Arrow serialization which doesn't confuse binary and string. Again, only Python 2.
3. For `struct`  containing `binary`, we don't do anything because Arrow doesn't support it anyway. This will change when we bump to 0.15.1. I added a test to remind us.

### Why Not Take This From Upstream
Upstream upgraded their arrow / pyarrow for the Spark 3 release which won't support Python 2. They don't have to deal with it. But we want a higher pyarrow version before we can move off Python 2.

### How This Patch Was Tested
I added three unit tests for `createDataFrame` with `string`, `array<string>`, and `struct<string, string>` as input. Each verifies that the schema is the same regardless of whether Arrow serialization was used. I also verified manually that `pandas_udf` still works for `array<string>` and `array<binary>` outputs for pyarrow 0.8.0 and 0.12.1.

```
In [1]: pandas_df = pd.DataFrame({"string_col": ["a", "b", "c"]})

In [2]: spark.createDataFrame(pandas_df).printSchema()
root
 |-- string_col: string (nullable = true)


In [3]: pandas_df = pd.DataFrame({"string_col": ["a", "b", "c"], "nested_string_col": [["a"], ["b"], ["c"]]})

In [4]: spark.createDataFrame(pandas_df).printSchema()
/Volumes/git/spark/python/pyspark/sql/session.py:758: UserWarning: createDataFrame attempted Arrow optimization because 'spark.sql.execution.arrow.enabled' is set to true; however, failed by the reason below:
  Unsupported type in conversion from Arrow: list<item: binary>
Please use Python3 for support of BinaryType in arrays.
Attempting non-optimization as 'spark.sql.execution.arrow.fallback.enabled' is set to true.
  warnings.warn(msg)
root
 |-- nested_string_col: array (nullable = true)
 |    |-- element: string (containsNull = true) # nice
 |-- string_col: string (nullable = true) # nice
```