### PR TITLE
Use runtimeClasspath instead of runtimeElements

### DIFF
--- a/spark-docker-image-generator/src/main/java/org/apache/spark/deploy/kubernetes/docker/gradle/SparkDockerPlugin.java
+++ b/spark-docker-image-generator/src/main/java/org/apache/spark/deploy/kubernetes/docker/gradle/SparkDockerPlugin.java
@@ -56,7 +56,7 @@ public final class SparkDockerPlugin implements Plugin<Project> {
                 project.getConfigurations().maybeCreate(SPARK_DOCKER_RUNTIME_CONFIGURATION_NAME);
         File dockerFile = new File(dockerBuildDirectory, "Dockerfile");
         project.getPluginManager().withPlugin("java", plugin -> {
-            Configuration runtimeConfiguration = project.getConfigurations().findByName("runtimeElements");
+            Configuration runtimeConfiguration = project.getConfigurations().findByName("runtimeClasspath");
             if (runtimeConfiguration == null) {
                 log.warn("No runtime configuration was found for a reference configuration for building"
                         + " your Spark application's docker images.");


### PR DESCRIPTION
Follow up to #630. 

`runtimeElements` isn't the correct configuration to use here. `runtimeElements` is intended to be used by consumers to create their runtime classpath. For internal uses, we should be using `runtimeClasspath`. This matches the behavior of our internal packaging plugin where we use `runtimeClasspath` to build distributions.