### PR TITLE
Downgrade R in Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: palantirtechnologies/circle-spark-base:0.2.2
+    - image: palantirtechnologies/circle-spark-base:0.2.3
   resource_class: xlarge
   environment: &defaults-environment
     TERM: dumb
@@ -129,7 +129,7 @@ jobs:
     <<: *defaults
     # Some part of the maven setup fails if there's no R, so we need to use the R image here
     docker:
-      - image: palantirtechnologies/circle-spark-r:0.2.2
+      - image: palantirtechnologies/circle-spark-r:0.2.3
     steps:
       # Saves us from recompiling every time...
       - restore_cache:
@@ -296,7 +296,7 @@ jobs:
     # depends on build-sbt, but we only need the assembly jars
     <<: *defaults
     docker:
-      - image: palantirtechnologies/circle-spark-python:0.2.2
+      - image: palantirtechnologies/circle-spark-python:0.2.3
     parallelism: 2
     steps:
       - *checkout-code
@@ -321,7 +321,7 @@ jobs:
     # depends on build-sbt, but we only need the assembly jars
     <<: *defaults
     docker:
-      - image: palantirtechnologies/circle-spark-r:0.2.2
+      - image: palantirtechnologies/circle-spark-r:0.2.3
     steps:
       - *checkout-code
       - attach_workspace:
@@ -434,7 +434,7 @@ jobs:
     <<: *defaults
     # Some part of the maven setup fails if there's no R, so we need to use the R image here
     docker:
-      - image: palantirtechnologies/circle-spark-r:0.2.2
+      - image: palantirtechnologies/circle-spark-r:0.2.3
     steps:
       - *checkout-code
       - restore_cache:
@@ -454,7 +454,7 @@ jobs:
   deploy-gradle:
     <<: *defaults
     docker:
-      - image: palantirtechnologies/circle-spark-r:0.2.2
+      - image: palantirtechnologies/circle-spark-r:0.2.3
     steps:
       - *checkout-code
       - *restore-gradle-wrapper-cache
@@ -466,7 +466,7 @@ jobs:
     <<: *defaults
     # Some part of the maven setup fails if there's no R, so we need to use the R image here
     docker:
-      - image: palantirtechnologies/circle-spark-r:0.2.2
+      - image: palantirtechnologies/circle-spark-r:0.2.3
     steps:
       # This cache contains the whole project after version was set and mvn package was called
       # Restoring first (and instead of checkout) as mvn versions:set mutates real source code...

--- a/dev/docker-images/Makefile
+++ b/dev/docker-images/Makefile
@@ -17,7 +17,7 @@
 
 .PHONY: all publish base python r
 
-VERSION=0.2.2
+VERSION=0.2.3
 BASE_IMAGE_NAME = "palantirtechnologies/circle-spark-base:${VERSION}"
 PYTHON_IMAGE_NAME = "palantirtechnologies/circle-spark-python:${VERSION}"
 R_IMAGE_NAME = "palantirtechnologies/circle-spark-r:${VERSION}"

--- a/dev/docker-images/base/Dockerfile
+++ b/dev/docker-images/base/Dockerfile
@@ -111,7 +111,7 @@ WORKDIR $CIRCLE_HOME
 # Install miniconda, we are using it to test conda support and a bunch of tests expect CONDA_BIN to be set
 ENV CONDA_ROOT=$CIRCLE_HOME/miniconda
 ENV CONDA_BIN=$CIRCLE_HOME/miniconda/bin/conda
-ENV MINICONDA2_VERSION=4.5.11
+ENV MINICONDA2_VERSION=4.7.12.1
 
 RUN curl -sO https://repo.anaconda.com/miniconda/Miniconda2-${MINICONDA2_VERSION}-Linux-x86_64.sh \
   && bash Miniconda2-${MINICONDA2_VERSION}-Linux-x86_64.sh -b -p ${CONDA_ROOT} \

--- a/dev/docker-images/python/Dockerfile
+++ b/dev/docker-images/python/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-instal
 # A version I've tested earlier that I know it breaks with is 1.14.1
 RUN mkdir -p $(pyenv root)/versions \
   && ln -s $CONDA_ROOT $(pyenv root)/versions/our-miniconda \
-  && $CONDA_BIN create -y -n python2 -c anaconda -c conda-forge python==2.7.15 numpy=1.14.0 pyarrow==0.12.1 pandas nomkl \
+  && $CONDA_BIN create -y -n python2 -c anaconda -c conda-forge python==2.7.18 numpy=1.14.0 pyarrow==0.12.1 pandas nomkl \
   && $CONDA_BIN create -y -n python3 -c anaconda -c conda-forge python=3.6 numpy=1.14.0 pyarrow==0.12.1 pandas nomkl \
   && $CONDA_BIN clean --all
 

--- a/dev/docker-images/python/Dockerfile
+++ b/dev/docker-images/python/Dockerfile
@@ -18,10 +18,8 @@
 FROM palantirtechnologies/circle-spark-base:0.2.3
 
 # Install pyenv
-ENV PATH="$CIRCLE_HOME/.pyenv/bin:$PATH"
-RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-  && cat >>.bashrc <<<'eval "$($HOME/.pyenv/bin/pyenv init -)"' \
-  && cat >>.bashrc <<<'eval "$($HOME/.pyenv/bin/pyenv virtualenv-init -)"'
+RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+ENV PATH="$CIRCLE_HOME/.pyenv/shims:$CIRCLE_HOME/.pyenv/bin:$PATH"
 
 # Must install numpy 1.11 or else a bunch of tests break due to different output formatting on e.g. nparray
 # A version I've tested earlier that I know it breaks with is 1.14.1
@@ -34,8 +32,12 @@ RUN mkdir -p $(pyenv root)/versions \
 RUN pyenv global our-miniconda/envs/python2 our-miniconda/envs/python3 \
   && pyenv rehash
 
-# Expose pyenv globally
-ENV PATH=$CIRCLE_HOME/.pyenv/shims:$PATH
-
 RUN PYENV_VERSION=our-miniconda/envs/python2 $CIRCLE_HOME/.pyenv/shims/pip install unishark "unittest-xml-reporting<3"
 RUN PYENV_VERSION=our-miniconda/envs/python3 $CIRCLE_HOME/.pyenv/shims/pip install unishark unittest-xml-reporting
+
+# Conda 'activate' should take precedence over pyenv's (pyenv/pyenv-virtualenv#270).
+# In run-pip-tests, we do 'source activate /path'. Conda's activate is fine with that, but not pyenv's.
+RUN mkdir $CIRCLE_HOME/.bin
+RUN ln -s $CONDA_ROOT/bin/activate $CIRCLE_HOME/.bin/activate
+RUN ln -s $CONDA_ROOT/bin/deactivate $CIRCLE_HOME/.bin/deactivate
+ENV PATH="$CIRCLE_HOME/.bin:$PATH"

--- a/dev/docker-images/python/Dockerfile
+++ b/dev/docker-images/python/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM palantirtechnologies/circle-spark-base
+FROM palantirtechnologies/circle-spark-base:0.2.3
 
 # Install pyenv
 ENV PATH="$CIRCLE_HOME/.pyenv/bin:$PATH"

--- a/dev/docker-images/r/Dockerfile
+++ b/dev/docker-images/r/Dockerfile
@@ -19,12 +19,27 @@ FROM palantirtechnologies/circle-spark-base
 
 USER root
 
-### Install R
-RUN apt-get update \
-  && apt-get install r-base r-base-dev qpdf \
-  && rm -rf /var/lib/apt/lists/* \
-  && chmod 777 /usr/local/lib/R/site-library \
-  && /usr/lib/R/bin/R -e "install.packages(c('devtools'), repos='http://cran.us.r-project.org', lib='/usr/local/lib/R/site-library'); devtools::install_github('r-lib/testthat@v2.0.0', lib='/usr/local/lib/R/site-library'); install.packages(c('knitr', 'rmarkdown', 'e1071', 'survival', 'roxygen2', 'lintr'), repos='http://cran.us.r-project.org', lib='/usr/local/lib/R/site-library')"
-ENV R_HOME=/usr/lib/R
+# We install r-base-dev via apt-get, and then r-base via Conda. We can't do both via apt-get, because we need older R
+# versions and CRAN's Ubuntu channels don't satisfy old dependencies. We can't do both via Conda, because "official"
+# channels (anaconda and forge) don't have dev builds of R. Hence this suboptimal split. The versions don't even match.
+
+# Install r-base-dev to get shared libraries to compile R packages
+# Also install qpdf (rendering of SparkR docs), and third-party dependencies libcurl and libgit
+RUN apt-get update && apt-get install r-base-dev qpdf libcurl4-openssl-dev libgit2-dev
+# Install R via Conda so we can control the R version
+RUN $CONDA_BIN install --yes r-base=3.4.3 gxx_linux-64
+ENV R_HOME=$CONDA_ROOT/lib/R
+
+# Need gxx_linux-64 binaries on the path to compile R packages
+ENV PATH="$CONDA_ROOT/bin:$PATH"
+
+# Install SparkR dependencies (find list in R/pkg/DESCRIPTION)
+# Need to provide path to pkgconfig otherwise the installer gets confused between the system pkgconfig and the Conda pkgconfig
+RUN R -e "install.packages(c('knitr', 'rmarkdown', 'e1071', 'survival'), repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
+
+# Install build dependencies
+# Need to install 'curl' separately
+RUN R -e "install.packages('curl', repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
+RUN R -e "install.packages(c('devtools', 'roxygen2', 'lintr', 'testthat'), repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
 
 USER circleci

--- a/dev/docker-images/r/Dockerfile
+++ b/dev/docker-images/r/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM palantirtechnologies/circle-spark-base
+FROM palantirtechnologies/circle-spark-base:0.2.3
 
 USER root
 

--- a/dev/docker-images/r/Dockerfile
+++ b/dev/docker-images/r/Dockerfile
@@ -17,29 +17,15 @@
 
 FROM palantirtechnologies/circle-spark-base:0.2.3
 
+# Install R and SparkR dependencies
+RUN $CONDA_BIN install --yes --channel r \
+    r-base=3.4.3 r-knitr r-rmarkdown r-e1071 r-survival r-testthat r-lintr r-roxygen2 r-devtools
+
+# Install qpdf (used for SparkR documentation, required in R tests)
 USER root
-
-# We install r-base-dev via apt-get, and then r-base via Conda. We can't do both via apt-get, because we need older R
-# versions and CRAN's Ubuntu channels don't satisfy old dependencies. We can't do both via Conda, because "official"
-# channels (anaconda and forge) don't have dev builds of R. Hence this suboptimal split. The versions don't even match.
-
-# Install r-base-dev to get shared libraries to compile R packages
-# Also install qpdf (rendering of SparkR docs), and third-party dependencies libcurl and libgit
-RUN apt-get update && apt-get install r-base-dev qpdf libcurl4-openssl-dev libgit2-dev
-# Install R via Conda so we can control the R version
-RUN $CONDA_BIN install --yes r-base=3.4.3 gxx_linux-64
-ENV R_HOME=$CONDA_ROOT/lib/R
-
-# Need gxx_linux-64 binaries on the path to compile R packages
-ENV PATH="$CONDA_ROOT/bin:$PATH"
-
-# Install SparkR dependencies (find list in R/pkg/DESCRIPTION)
-# Need to provide path to pkgconfig otherwise the installer gets confused between the system pkgconfig and the Conda pkgconfig
-RUN R -e "install.packages(c('knitr', 'rmarkdown', 'e1071', 'survival'), repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
-
-# Install build dependencies
-# Need to install 'curl' separately
-RUN R -e "install.packages('curl', repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
-RUN R -e "install.packages(c('devtools', 'roxygen2', 'lintr', 'testthat'), repos='https://cloud.r-project.org', configure.vars='PKG_CONFIG_PATH=$CONDA_ROOT/lib/pkgconfig')"
-
+RUN apt-get update && apt-get install qpdf
 USER circleci
+
+# Add conda-installed R to path
+ENV PATH="$CONDA_ROOT/bin:$PATH"
+ENV R_HOME=$CONDA_ROOT/lib/R


### PR DESCRIPTION
**Problem.** In [#677](https://github.com/palantir/spark/commit/acb7d0490fbccc8bd0aa05c2beccf280df8776b0#diff-863475bc56a12bdc0fe1522bb06a0d61R18) we upgraded our Docker images to Ubuntu 20. As result of that we started picking up a higher R version (3.6), whereas we previously used 3.2 (latest available for Ubuntu 14).

Because 3.5 and 3.6 are major releases with serialization breaks, we started compiling a SparkR that is incompatible with the R versions we have to support internally (as low as 3.3). This caused errors like the one below (workspace serialization break in 3.5):
```
cannot read workspace version 3 written by R 3.6.3; need R 3.5.0 or newer
```
Or the one below (courtesy of the data serialization break in 3.6):
```
Error in rbind(info, getNamespaceInfo(env, "S3methods")) :
  number of columns of matrices must match (see arg 2)
```

More info on [this RStudio issue](https://community.rstudio.com/t/error-listing-packages-error-in-readrds-pfile-cannot-read-workspace-version-3-written-by-r-3-6-0/40570) and release announcements for [3.5](https://blog.revolutionanalytics.com/2018/04/r-350.html) and [3.6](https://blog.revolutionanalytics.com/2019/05/whats-new-in-r-360.html).

**Change.** This change ensures that we compile SparkR using R 3.4. We have to support 3.3 internally, but [3.4](https://www.r-statistics.com/2017/04/r-3-4-0-is-released-with-new-speed-upgrades-and-bug-fixes/) had no breaks. We also have to support 3.5, and I assume 3.4 is good because 3.2 was - I don't believe we internally read 3.2 workspaces with 3.6 and vice versa.

I switched to installing R via Conda instead of Apt. CRAN has channels hosting older R versions, but those channels don't host R's dependencies.