### PR TITLE
Downgrade Conscrypt to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2363,7 +2363,7 @@
       <dependency>
         <groupId>org.conscrypt</groupId>
         <artifactId>conscrypt-openjdk-uber</artifactId>
-        <version>2.2.1</version>
+        <version>1.4.2</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
2.2.1 turned out incompatible with CentOS 6. See internal discussion [here (PDS-123673)](https://support-jira.palantir.tech/browse/PDS-123673). The version was introduced [in this commit](https://github.com/palantir/spark/commit/9903e967d14d76051f30039c69085edfbd6e463d#diff-5f65bfca19c58b207a93a69331f96785).