### PR TITLE
Upgrade ASM to 7.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -205,7 +205,7 @@ univocity-parsers-2.7.3.jar
 validation-api-1.1.0.Final.jar
 wildfly-openssl-1.0.7.Final.jar
 woodstox-core-5.0.3.jar
-xbean-asm7-shaded-4.13.jar
+xbean-asm7-shaded-4.14.jar
 xmlenc-0.52.jar
 xz-1.8.jar
 zjsonpatch-0.3.0.jar

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -205,7 +205,7 @@ univocity-parsers-2.7.3.jar
 validation-api-1.1.0.Final.jar
 wildfly-openssl-1.0.7.Final.jar
 woodstox-core-5.0.3.jar
-xbean-asm7-shaded-4.14.jar
+xbean-asm7-shaded-4.15.jar
 xmlenc-0.52.jar
 xz-1.8.jar
 zjsonpatch-0.3.0.jar

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -205,7 +205,7 @@ univocity-parsers-2.7.3.jar
 validation-api-1.1.0.Final.jar
 wildfly-openssl-1.0.7.Final.jar
 woodstox-core-5.0.3.jar
-xbean-asm7-shaded-4.12.jar
+xbean-asm7-shaded-4.13.jar
 xmlenc-0.52.jar
 xz-1.8.jar
 zjsonpatch-0.3.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2711,12 +2711,12 @@
             <dependency>
               <groupId>org.ow2.asm</groupId>
               <artifactId>asm</artifactId>
-              <version>7.0</version>
+              <version>7.1</version>
             </dependency>
             <dependency>
               <groupId>org.ow2.asm</groupId>
               <artifactId>asm-commons</artifactId>
-              <version>7.0</version>
+              <version>7.1</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm7-shaded</artifactId>
-        <version>4.14</version>
+        <version>4.15</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope
@@ -2711,12 +2711,12 @@
             <dependency>
               <groupId>org.ow2.asm</groupId>
               <artifactId>asm</artifactId>
-              <version>7.1</version>
+              <version>7.2</version>
             </dependency>
             <dependency>
               <groupId>org.ow2.asm</groupId>
               <artifactId>asm-commons</artifactId>
-              <version>7.1</version>
+              <version>7.2</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm7-shaded</artifactId>
-        <version>4.13</version>
+        <version>4.14</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm7-shaded</artifactId>
-        <version>4.12</version>
+        <version>4.13</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,9 +33,9 @@ addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "7.0"
+libraryDependencies += "org.ow2.asm"  % "asm" % "7.1"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "7.0"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "7.1"
 
 // sbt 1.0.0 support: https://github.com/ihji/sbt-antlr4/issues/14
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,9 +33,9 @@ addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "7.1"
+libraryDependencies += "org.ow2.asm"  % "asm" % "7.2"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "7.1"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "7.2"
 
 // sbt 1.0.0 support: https://github.com/ihji/sbt-antlr4/issues/14
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.12")


### PR DESCRIPTION
Closes #696. Upgrade ASM to 7.2 to support Java 14 (https://github.com/palantir/spark/issues/696 / [SPARK-29729](https://issues.apache.org/jira/browse/SPARK-29729)). Taking parent commits to reduce conflicts.

* [[SPARK-27493][BUILD]](https://issues.apache.org/jira/browse/SPARK-27493) Upgrade ASM to 7.1 
* [[SPARK-28111][BUILD]](https://issues.apache.org/jira/browse/SPARK-28111) Upgrade `xbean-asm7-shaded` to 4.14
* [[SPARK-27493][BUILD][FOLLOWUP]](https://issues.apache.org/jira/browse/SPARK-27493) Upgrade ASM to 7.1 in plugins.sbt 
* [[SPARK-27493][BUILD][FOLLOWUP]](https://issues.apache.org/jira/browse/SPARK-27493) Upgrade ASM to 7.1 in Maven plugins
17eb356 
* [[SPARK-29729][BUILD]](https://issues.apache.org/jira/browse/SPARK-29729) Upgrade ASM to 7.2 