### PR TITLE
Allow client side encryption of shuffle files

### DIFF
--- a/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
+++ b/async-shuffle-upload/async-shuffle-upload-api/src/main/java/org/apache/spark/palantir/shuffle/async/api/SparkShuffleApiConstants.java
@@ -28,6 +28,13 @@ public final class SparkShuffleApiConstants {
   public static final String SHUFFLE_PLUGIN_APP_NAME_CONF_DEPRECATED =
       "spark.plugin.shuffle.async.appName";
 
+  public static final String SHUFFLE_PLUGIN_ENCRYPTION_ENABLED =
+      "spark.plugin.shuffle.async.encryption.enabled";
+  public static final String SHUFFLE_PLUGIN_ENCRYPTION_KEY_ALGORITHM =
+      "spark.plugin.shuffle.async.encryption.key.algorithm";
+  public static final String SHUFFLE_PLUGIN_ENCRYPTION_KEY_SIZE =
+      "spark.plugin.shuffle.async.encryption.key.size";
+
   public static final String SHUFFLE_S3A_CREDS_FILE_CONF =
       "spark.shuffle.hadoop.async.s3a.credsFile";
   public static final String SHUFFLE_S3A_CREDS_FILE_CONF_DEPRECATED =

--- a/async-shuffle-upload/async-shuffle-upload-core/pom.xml
+++ b/async-shuffle-upload/async-shuffle-upload-core/pom.xml
@@ -68,6 +68,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.palantir.hadoop-crypto2</groupId>
+      <artifactId>hadoop-crypto</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/client/BaseHadoopShuffleClientConfiguration.java
@@ -87,8 +87,8 @@ public interface BaseHadoopShuffleClientConfiguration {
     Optional<String> credentialsFilename =
         OptionConverters.toJava(sparkConf.get(AsyncShuffleDataIoSparkConfigs.S3A_CREDS_FILE()));
 
-    Preconditions.checkNotNull(
-        credentialsFilename,
+    Preconditions.checkArgument(
+        credentialsFilename != null && credentialsFilename.isPresent(),
         "Expected spark config to be set",
         SafeArg.of("config", AsyncShuffleDataIoSparkConfigs.S3A_CREDS_FILE().key()));
     try {
@@ -107,6 +107,16 @@ public interface BaseHadoopShuffleClientConfiguration {
   @Value.Derived
   default JavaSparkConf javaSparkConf() {
     return new JavaSparkConf(sparkConf());
+  }
+
+  @Value.Derived
+  default boolean encryptionEnabled() {
+    return javaSparkConf().getBoolean(AsyncShuffleDataIoSparkConfigs.ENCRYPTION_ENABLED());
+  }
+
+  @Value.Derived
+  default String encryptionKeyAlgorithm() {
+    return javaSparkConf().get(AsyncShuffleDataIoSparkConfigs.ENCRYPTION_KEY_ALGORITHM());
   }
 
   @Value.Derived

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleExecutorComponents.java
@@ -146,6 +146,7 @@ public final class HadoopAsyncShuffleExecutorComponents implements ShuffleExecut
         .customUploadCoordinatorExecutorService(customUploadCoordinatorExecutorService)
         .sparkConf(sparkConf)
         .metrics(resolvedMetrics)
+        .extraConfigs(extraConfigs)
         .build();
     resolvedMetrics.markUsingAsyncShuffleUploadPlugin();
     this.maybeReadSupport = maybeClient.map(client ->

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/keys/KeyPairExtraConfigKeys.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/keys/KeyPairExtraConfigKeys.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.keys;
+
+public final class KeyPairExtraConfigKeys {
+  public static String PUBLIC_KEY = "spark.plugin.shuffle.async.encryption.key.public";
+  public static String PRIVATE_KEY = "spark.plugin.shuffle.async.encryption.key.private";
+
+  private KeyPairExtraConfigKeys() {
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/keys/KeyPairs.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/main/java/org/apache/spark/palantir/shuffle/async/util/keys/KeyPairs.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.util.keys;
+
+import com.google.common.base.Throwables;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public final class KeyPairs {
+  private KeyPairs() {
+  }
+
+  public static KeyPair generateKeyPair(String algorithm, int keysize) {
+    try {
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
+      keyPairGenerator.initialize(keysize);
+      return keyPairGenerator.generateKeyPair();
+    } catch (NoSuchAlgorithmException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  public static String serializeKey(Key key) {
+    return Base64.getEncoder().encodeToString(key.getEncoded());
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponentsTest.java
+++ b/async-shuffle-upload/async-shuffle-upload-core/src/test/java/org/apache/spark/palantir/shuffle/async/io/HadoopAsyncShuffleDriverComponentsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.palantir.shuffle.async.io;
+
+import com.palantir.crypto2.keys.KeyPairs;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.palantir.shuffle.async.AsyncShuffleDataIoSparkConfigs;
+import org.apache.spark.palantir.shuffle.async.JavaSparkConf;
+import org.apache.spark.palantir.shuffle.async.metadata.ShuffleStorageStateTracker;
+import org.apache.spark.palantir.shuffle.async.util.keys.KeyPairExtraConfigKeys;
+import org.apache.spark.rpc.RpcEnv;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public final class HadoopAsyncShuffleDriverComponentsTest {
+  @Mock
+  private SparkEnv sparkEnv;
+
+  @Mock
+  private RpcEnv rpcEnv;
+
+  @Mock
+  private ShuffleDriverComponents delegate;
+
+  @Mock
+  private ShuffleStorageStateTracker shuffleStorageStateTracker;
+
+  @Before
+  public void before() throws IOException {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testGenerateKeyPair() throws IOException {
+    SparkConf sparkConf = new SparkConf()
+        .set(AsyncShuffleDataIoSparkConfigs.ENCRYPTION_ENABLED(), "true");
+    JavaSparkConf javaSparkConf = new JavaSparkConf(sparkConf);
+    when(sparkEnv.rpcEnv()).thenReturn(rpcEnv);
+    when(sparkEnv.conf()).thenReturn(sparkConf);
+
+    HadoopAsyncShuffleDriverComponents hadoopAsyncShuffleDriverComponents =
+        new HadoopAsyncShuffleDriverComponents(
+            delegate, shuffleStorageStateTracker, () -> sparkEnv);
+
+    Map<String, String> extraConfigs = hadoopAsyncShuffleDriverComponents.initializeApplication();
+
+    assertThat(extraConfigs).containsKeys(
+        KeyPairExtraConfigKeys.PRIVATE_KEY,
+        KeyPairExtraConfigKeys.PUBLIC_KEY
+    );
+
+    // make sure the generated key deserializes properly
+    KeyPair keyPair = KeyPairs.fromStrings(
+        extraConfigs.get(KeyPairExtraConfigKeys.PRIVATE_KEY),
+        extraConfigs.get(KeyPairExtraConfigKeys.PUBLIC_KEY),
+        javaSparkConf.get(AsyncShuffleDataIoSparkConfigs.ENCRYPTION_KEY_ALGORITHM())
+    );
+
+    assertThat(keyPair).isNotNull();
+  }
+}

--- a/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
+++ b/async-shuffle-upload/async-shuffle-upload-scala/src/main/scala/org/apache/spark/palantir/shuffle/async/AsyncShuffleDataIoSparkConfigs.scala
@@ -41,6 +41,26 @@ object AsyncShuffleDataIoSparkConfigs {
     .doc("Application name to use for tagging shuffle files.")
     .fallbackConf(APP_NAME_DEPRECATED)
 
+  val ENCRYPTION_ENABLED = ConfigBuilder(
+    SparkShuffleApiConstants.SHUFFLE_PLUGIN_ENCRYPTION_ENABLED)
+    .doc(
+      "Controls whether to encrypt shuffle files or not before uploading them to remote storage")
+    .booleanConf
+    .createWithDefault(false)
+
+  val ENCRYPTION_KEY_ALGORITHM =
+    ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_PLUGIN_ENCRYPTION_KEY_ALGORITHM)
+      .doc("Algorithm used to generated the key pair used to encrypt the symmetric " +
+        "key used to encrypt the shuffle files")
+      .stringConf
+      .createWithDefault("RSA")
+
+  val ENCRYPTION_KEY_SIZE =
+    ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_PLUGIN_ENCRYPTION_KEY_SIZE)
+      .doc("Key size used to generate the key pair used to encrypt the symmetric key")
+      .intConf
+      .createWithDefault(2048)
+
   val S3A_CREDS_FILE_DEPRECATED =
     ConfigBuilder(SparkShuffleApiConstants.SHUFFLE_S3A_CREDS_FILE_CONF_DEPRECATED)
       .doc("Deprecated version of configuration pointing to s3 credentials.")
@@ -63,7 +83,6 @@ object AsyncShuffleDataIoSparkConfigs {
     .intConf
     .createWithDefault(DEFAULT_DOWNLOAD_PARALLELISM)
 
-
   val DEFAULT_UPLOAD_PARALLELISM = 5
 
   val UPLOAD_PARALLELISM = ConfigBuilder("spark.shuffle.hadoop.async.upload.parallelism")
@@ -81,9 +100,10 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val READ_LOCAL_DISK_PARALLELISM =
     ConfigBuilder("spark.shuffle.hadoop.async.storage.merging.local.read.parallelism")
-      .doc("When using the \"merging\" storage strategy, files are downloaded to local disk" +
-        " before map output data is shipped back to the shuffle reader. This configuration" +
-        " controls the parallelism for the local disk reads after files are downloaded.")
+      .doc(
+        "When using the \"merging\" storage strategy, files are downloaded to local disk" +
+          " before map output data is shipped back to the shuffle reader. This configuration" +
+          " controls the parallelism for the local disk reads after files are downloaded.")
       .intConf
       .createWithDefault(DEFAULT_READ_LOCAL_DISK_PARALLELISM)
 
@@ -130,8 +150,9 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val STREAM_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.hadoop.async.io.buffer.size")
-      .doc("Size of buffers when reading and writing data from storage, both remote and on local" +
-        " disk.")
+      .doc(
+        "Size of buffers when reading and writing data from storage, both remote and on local" +
+          " disk.")
       .bytesConf(ByteUnit.BYTE)
       .checkValue(validator = bytes => {
         Try {
@@ -148,8 +169,9 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val DOWNLOAD_SHUFFLE_BLOCK_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.hadoop.async.io.download.buffer.size")
-      .doc("Size of buffers to use when downloading shuffle blocks from remote storage down to" +
-        " local disk.")
+      .doc(
+        "Size of buffers to use when downloading shuffle blocks from remote storage down to" +
+          " local disk.")
       .fallbackConf(STREAM_BUFFER_SIZE)
 
   val DOWNLOAD_SHUFFLE_BLOCKS_IN_MEMORY_MAX_SIZE =
@@ -163,8 +185,9 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val DRIVER_REF_CACHE_MAX_SIZE =
     ConfigBuilder("spark.shuffle.hadoop.async.driverref.cache.size")
-      .doc("Maximum size of the cache used by each executor to avoid calling the driver in" +
-        " excess amounts.")
+      .doc(
+        "Maximum size of the cache used by each executor to avoid calling the driver in" +
+          " excess amounts.")
       .intConf
       .createWithDefault(DEFAULT_DRIVER_REF_CACHE_MAX_SIZE)
 
@@ -203,8 +226,9 @@ object AsyncShuffleDataIoSparkConfigs {
 
   val PREFER_DOWNLOAD_FROM_HADOOP =
     ConfigBuilder("spark.shuffle.hadoop.async.io.download.prefer.hadoop")
-      .doc("Prefer download from remote storage over download from another executor if the" +
-        " shuffle file exists on both.")
+      .doc(
+        "Prefer download from remote storage over download from another executor if the" +
+          " shuffle file exists on both.")
       .fallbackConf(PREFER_DOWNLOAD_FROM_HADOOP_DEPRECATED)
 
   val S3A_UPLOAD_MULTIPART_TYPE =

--- a/pom.xml
+++ b/pom.xml
@@ -2346,6 +2346,11 @@
         <version>${safe-logging.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.palantir.hadoop-crypto2</groupId>
+        <artifactId>hadoop-crypto</artifactId>
+        <version>2.7.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.15.0</version>


### PR DESCRIPTION
Allow users to configure `spark.plugin.shuffle.async.encryption.enabled` to encrypt shuffle files before uploading them to remote storage.

Encryption is done by [palantir/hadoop-crypto](https://github.com/palantir/hadoop-crypto).

This builds on top of #646 (`SPARK-25299`), new functionality is off by default.

cc @mccheah @robert3005 