### PR TITLE
Add pre-installed conda configuration and use to find rlib directory

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -26,6 +26,7 @@
 * Gradle plugin to easily create custom docker images for use with k8s
 * Filter rLibDir by exists so that daemon.R references the correct file [460](https://github.com/palantir/spark/pull/460)
 * Implementation of the shuffle I/O plugins from SPARK-25299 that asynchronously backs up shuffle files to remote storage
+* Add pre-installed conda configuration and use to find rlib directory [700](https://github.com/palantir/spark/pull/700)
 
 # Reverted
 * [SPARK-25908](https://issues.apache.org/jira/browse/SPARK-25908) - Removal of `monotonicall_increasing_id`, `toDegree`, `toRadians`, `approxCountDistinct`, `unionAll`

--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -31,6 +31,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.Common.Provenance
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.BUFFER_SIZE
+import org.apache.spark.internal.config.CONDA_PRE_INSTALLED_PATH
 import org.apache.spark.internal.config.R._
 import org.apache.spark.util.Utils
 
@@ -363,6 +364,7 @@ private[r] object RRunner {
     val sparkConf = SparkEnv.get.conf
     val requestedRCommand = Provenance.fromConfOpt(sparkConf, R_COMMAND)
       .getOrElse(Provenance.fromConf(sparkConf, SPARKR_COMMAND))
+    val preInstalledCondaPath = Provenance.fromConfOpt(sparkConf, CONDA_PRE_INSTALLED_PATH)
     val condaEnv = condaSetupInstructions.map(CondaEnvironmentManager.getOrCreateCondaEnvironment)
     val rCommand = condaEnv.map { conda =>
       if (requestedRCommand.value != SPARKR_COMMAND.defaultValue.get) {
@@ -375,9 +377,17 @@ private[r] object RRunner {
 
     val rConnectionTimeout = sparkConf.get(R_BACKEND_CONNECTION_TIMEOUT)
     val rOptions = "--vanilla"
+    val rLibPath = "/lib/R/library"
     val rLibDir = condaEnv.map(conda =>
-      RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + "/lib/R/library"))
-      .getOrElse(RUtils.sparkRPackagePath(isDriver = false))
+      RUtils.sparkRPackagePath(isDriver = false) :+ (conda.condaEnvDir + rLibPath))
+      .getOrElse({
+        val sparkRPackagePaths = RUtils.sparkRPackagePath(isDriver = false)
+        if (preInstalledCondaPath.isDefined) {
+          sparkRPackagePaths :+ (preInstalledCondaPath.get + rLibPath)
+        } else {
+          sparkRPackagePaths
+        }
+      })
       .filter(dir => new File(dir).exists)
     if (rLibDir.isEmpty) {
       throw new SparkException("SparkR package is not installed on executor.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -543,6 +543,11 @@ package object config {
     .stringConf
     .createOptional
 
+  private[spark] val CONDA_PRE_INSTALLED_PATH = ConfigBuilder("spark.conda.preInstalledPath")
+    .doc("The path to pre-installed conda directory.")
+    .stringConf
+    .createOptional
+
   private[spark] val CONDA_VERBOSITY = ConfigBuilder("spark.conda.verbosity")
     .doc("How many times to apply -v to conda. A number between 0 and 3, with 0 being default.")
     .intConf


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

Conda env change, not filed in upstream.

## What changes were proposed in this pull request?

Executor uses CondaEnvironment.condaEnvPath + /lib/R/library or looks in SPARK_HOME for the sparkR package in order to launch a worker/daemon R process. Thus, when conda is already pre-installed on docker image and CondaEnvironment is not set, RRunner is unable to locate a rLibDir to look for the sparkR package files. This is not an issue for python, as python is able to locate its own installed modules when launched non-interactively, unlike the Rscript command that requires an explicit file path.

This PR introduces a SparkConf variable to note the pre-installed conda env path that can be read by RRunner when appropriate.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
