### PR TITLE
Infer 'mixed' types as strings when using Arrow serialization

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -24,9 +24,10 @@
 # Added
 
 * Gradle plugin to easily create custom docker images for use with k8s
-* Filter rLibDir by exists so that daemon.R references the correct file [460](https://github.com/palantir/spark/pull/460)
+* Filter rLibDir by exists so that daemon.R references the correct file [(#460)](https://github.com/palantir/spark/pull/460)
 * Implementation of the shuffle I/O plugins from SPARK-25299 that asynchronously backs up shuffle files to remote storage
-* Add pre-installed conda configuration and use to find rlib directory [700](https://github.com/palantir/spark/pull/700)
+* Add pre-installed conda configuration and use to find rlib directory [(#700)](https://github.com/palantir/spark/pull/700)
+* Supports Arrow-serialization of Python 2 strings [(#678)](https://github.com/palantir/spark/pull/678)
 
 # Reverted
 * [SPARK-25908](https://issues.apache.org/jira/browse/SPARK-25908) - Removal of `monotonicall_increasing_id`, `toDegree`, `toRadians`, `approxCountDistinct`, `unionAll`

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -361,9 +361,15 @@ class ArrowTests(ReusedSQLTestCase):
         import pandas as pd
         pdf = pd.DataFrame({"a": [u"unicode-value", "binary-under-python-2"]})
 
-        with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):
-            df, df_arrow = self._createDataFrame_toggle(pdf)
-            self.assertEqual(df.schema, df_arrow.schema)
+        df, df_arrow = self._createDataFrame_toggle(pdf)
+        self.assertEqual(df.schema, df_arrow.schema)
+
+    def test_createDataFrame_with_real_binary(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": [bytearray(b"a"), bytearray(b"c")]})
+
+        df, df_arrow = self._createDataFrame_toggle(pdf)
+        self.assertEqual(df.schema, df_arrow.schema)
 
     def test_createDataFrame_fallback_enabled(self):
         with QuietTest(self.sc):

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -357,6 +357,14 @@ class ArrowTests(ReusedSQLTestCase):
             df, df_arrow = self._createDataFrame_toggle(pdf)
             self.assertEqual(df.schema, df_arrow.schema)
 
+    def test_createDataFrame_with_str_binary_mixed(self):
+        import pandas as pd
+        pdf = pd.DataFrame({"a": [u"unicode-value", "binary-under-python-2"]})
+
+        with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):
+            df, df_arrow = self._createDataFrame_toggle(pdf)
+            self.assertEqual(df.schema, df_arrow.schema)
+
     def test_createDataFrame_fallback_enabled(self):
         with QuietTest(self.sc):
             with self.sql_conf({"spark.sql.execution.arrow.fallback.enabled": True}):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1697,7 +1697,7 @@ def _infer_binary_columns_as_arrow_string(schema, pandas_df):
 
     for field_index, field in enumerate(schema):
         if field.type == pa.binary() and \
-                pd.api.types.infer_dtype(pandas_df.iloc[:, field_index], skipna=True) == "string":
+                pd.api.types.is_string_dtype(pandas_df.iloc[:, field_index]):
             field_as_string = pa.field(field.name, pa.string())
             schema = schema.set(field_index, field_as_string)
 


### PR DESCRIPTION
### Background
Follow-up for #679. When serializing Pandas dataframes, Arrow assumes Python 2 string columns as "binary". When we encounter such a column, we try to infer if it's actually a "string" column (in a user-friendly sense). If it is, we override Arrow's assessment and use "string" as type in the Spark schema.

### Problem
When inferring whether "binary" columns are in fact "string", we rely on asking Pandas what it thinks the column is. Pandas is more friendly of Python 2, and thinks that Python 2 string columns are actually "string".

But we encounter an edge case when a column contains values of mixed type, even if all types could be treated as strings. E.g., if a column contains both unicode and binary values, Pandas infers the column as "mixed". We currently don't infer a column as string if Pandas deemed it of "mixed" type.

```ipython
In [1]: pandas_df = pd.DataFrame(data={"mixed_strings": [u"unicode", b"binary"]})

In [2]: spark.createDataFrame(pandas_df).printSchema()
root
 |-- mixed_strings: binary (nullable = true) # oops
```

You can also see this behaviour in the failing test that I added [(CircleCI)](https://app.circleci.com/pipelines/github/palantir/spark/300/workflows/b8257f14-4e92-4fd7-91ad-a946dc182c2e/jobs/22970).

### What changes were proposed in this pull request?
We are now more generous when inferring whether columns should be "string" type. When Pandas infers a column as "mixed" type, we do an additional check: We read the first value in the column. If that value is a string, we consider the whole column a string.

For this check, we're using the six package, which will correctly determine that e.g. a unicode value is of string type, but not e.g. a bytearray.

### Alternative
We could simplify this by using Pandas' `is_string_dtype` function which takes a column and infers if it's of "string" type. But the function is very lenient (https://github.com/pandas-dev/pandas/issues/15585). E.g. it will consider a column bytearrays a string (which would be an example of a "true binary" column even under Python 2). It will also consider a column of float tuplies a string (effectively anything that is an array of something).

### How was this patch tested?
Existing test and new added tests. Commit history shows that tests were failing before changes were made.
