### PR TITLE
Get preInstalledPath value in computation in sparkR package paths

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RRunner.scala
@@ -383,7 +383,7 @@ private[r] object RRunner {
       .getOrElse({
         val sparkRPackagePaths = RUtils.sparkRPackagePath(isDriver = false)
         if (preInstalledCondaPath.isDefined) {
-          sparkRPackagePaths :+ (preInstalledCondaPath.get + rLibPath)
+          sparkRPackagePaths :+ (preInstalledCondaPath.get.value + rLibPath)
         } else {
           sparkRPackagePaths
         }


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)

n/a conda changes

## What changes were proposed in this pull request?

Get the value of the Provenance before string concatenation

## How was this patch tested?

Manually tested in consumer.

Please review http://spark.apache.org/contributing.html before opening a pull request.
