### PR TITLE
Fix published artifact name for Scala 2.12

### DIFF
--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -33,7 +33,7 @@ publish_artifacts() {
 make_dist() {
   version=$(get_version)
   hadoop_name="hadoop-palantir"
-  artifact_name="spark-dist_2.11-${hadoop_name}"
+  artifact_name="spark-dist_2.12-${hadoop_name}"
   file_name="spark-dist-${version}-${hadoop_name}.tgz"
   ./dev/make-distribution.sh --name "hadoop-palantir" --tgz "$@" "${PALANTIR_FLAGS[@]}"
 }


### PR DESCRIPTION
In moving to Scala 2.12 in #691, we didn't update the published artifact name and we still publish the 2.12-compiled distribution under `spark-dist_2.11`.