### PR TITLE
Remove dependency on spark-influx-sink

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -112,10 +112,6 @@
       <artifactId>guava</artifactId>
       <scope>${hadoop.deps.scope}</scope>
     </dependency>
-    <dependency>
-      <groupId>com.palantir.spark.influx</groupId>
-      <artifactId>spark-influx-sink</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -26,7 +26,6 @@ breeze-macros_2.12-0.13.2.jar
 breeze_2.12-0.13.2.jar
 chill-java-0.9.3.jar
 chill_2.12-0.9.3.jar
-classmate-1.1.0.jar
 commons-beanutils-1.9.3.jar
 commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
@@ -49,12 +48,6 @@ core-1.1.2.jar
 curator-client-2.7.1.jar
 curator-framework-2.7.1.jar
 curator-recipes-2.7.1.jar
-dropwizard-jackson-1.0.0.jar
-dropwizard-lifecycle-1.0.0.jar
-dropwizard-metrics-1.0.0.jar
-dropwizard-metrics-influxdb-1.2.2.jar
-dropwizard-util-1.0.0.jar
-dropwizard-validation-1.0.0.jar
 ehcache-3.3.1.jar
 flatbuffers-java-1.9.0.jar
 generex-1.0.2.jar
@@ -83,7 +76,6 @@ hadoop-yarn-common-2.9.2-palantir.10.jar
 hadoop-yarn-registry-2.9.2-palantir.10.jar
 hadoop-yarn-server-common-2.9.2-palantir.10.jar
 hadoop-yarn-server-web-proxy-2.9.2-palantir.10.jar
-hibernate-validator-5.2.4.Final.jar
 hk2-api-2.5.0-b32.jar
 hk2-locator-2.5.0-b32.jar
 hk2-utils-2.5.0-b32.jar
@@ -97,13 +89,8 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.11.0.jar
 jackson-dataformat-cbor-2.11.0.jar
 jackson-dataformat-yaml-2.11.0.jar
-jackson-datatype-guava-2.11.0.jar
-jackson-datatype-jdk8-2.11.0.jar
-jackson-datatype-joda-2.11.0.jar
-jackson-datatype-jsr310-2.11.0.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-afterburner-2.11.0.jar
 jackson-module-jaxb-annotations-2.11.0.jar
 jackson-module-paranamer-2.11.0.jar
 jackson-module-scala_2.12-2.11.0.jar
@@ -119,7 +106,6 @@ javax.inject-2.5.0-b32.jar
 javax.servlet-api-3.1.0.jar
 javax.ws.rs-api-2.0.1.jar
 jaxb-api-2.2.2.jar
-jboss-logging-3.2.1.Final.jar
 jcip-annotations-1.0-1.jar
 jcl-over-slf4j-1.7.25.jar
 jersey-client-2.25.1.jar
@@ -143,7 +129,6 @@ jsp-api-2.1.jar
 jsr305-3.0.2.jar
 jtransforms-2.4.0.jar
 jul-to-slf4j-1.7.25.jar
-kafka-clients-2.1.0.jar
 kryo-shaded-4.0.2.jar
 kubernetes-client-4.4.2.jar
 kubernetes-model-4.4.2.jar
@@ -156,7 +141,6 @@ machinist_2.12-0.6.1.jar
 macro-compat_2.12-1.1.1.jar
 metrics-core-3.2.6.jar
 metrics-graphite-3.2.6.jar
-metrics-influxdb-1.2.2.jar
 metrics-json-3.2.6.jar
 metrics-jvm-3.2.6.jar
 minlog-1.3.0.jar

--- a/dists/hadoop-palantir/pom.xml
+++ b/dists/hadoop-palantir/pom.xml
@@ -94,10 +94,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-kubernetes_${scala.binary.version}</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.palantir.spark.influx</groupId>
-      <artifactId>spark-influx-sink</artifactId>
-    </dependency>
 
     <!-- async shuffle upload modules -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,6 @@
     <oro.version>2.0.8</oro.version>
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <dropwizard.version>1.0.0</dropwizard.version>
-    <spark-influx-sink.version>0.4.0</spark-influx-sink.version>
     <avro.version>1.8.2</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <aws.kinesis.client.version>1.8.10</aws.kinesis.client.version>
@@ -751,38 +750,6 @@
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-metrics</artifactId>
         <version>${dropwizard.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.palantir.spark.influx</groupId>
-        <artifactId>spark-influx-sink</artifactId>
-        <version>${spark-influx-sink.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
-          <!-- Old lz4 dependency with different coordinates -->
-          <exclusion>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
**What?** Remove dependency on spark-influx-sink.

**Why now?** Our fork is now compiled against 2.12. spark-influx-sink is not. We could ship spark-influx-sink compiled against 2.12, but as I understand we no longer user it.

cc @tstearns 
