### PR TITLE
Always run file type conda instructions on executors with driver transitive packages

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -92,6 +92,7 @@ final class CondaEnvironment(
     manager.runCondaProcess(rootPath,
       List("install", "-n", envName, "-y")
         ::: extraArgs.toList
+        ::: manager.verbosityFlags
         ::: "--" :: packages.toList,
       description = s"install dependencies in conda env $condaEnvDir",
       channels = channels.iterator.map(_.url).toList,

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -114,12 +114,14 @@ final class CondaEnvironment(
   }
 
   /**
-   * This is for sending the instructions to the executors so they can replicate the same conda environment.
+   * This is for sending the instructions to the executors so they can replicate the same conda
+   * environment.
    * For `File` bootstrap mode, use original setup
-   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs and avoid solving.
+   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs
+   * and avoid re-solving.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    mode match {
+    bootstrapMode match {
       case CondaBootstrapMode.Solve =>
         CondaSetupInstructions(
           CondaBootstrapMode.File,

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -114,17 +114,31 @@ final class CondaEnvironment(
   }
 
   /**
-   * This is for sending the instructions to the executors so they can replicate the same steps.
+   * This is for sending the instructions to the executors so they can replicate the same conda environment.
+   * For `File` bootstrap mode, use original setup
+   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs and avoid solving.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    CondaSetupInstructions(
-      bootstrapMode,
-      packages.toList,
-      bootstrapPackageUrls,
-      bootstrapPackageUrlsUserInfo,
-      channels.toList,
-      extraArgs,
-      envVars)
+    mode match {
+      case CondaBootstrapMode.Solve =>
+        CondaSetupInstructions(
+          CondaBootstrapMode.File,
+          packages.toList,
+          getTransitivePackageUrls(),
+          bootstrapPackageUrlsUserInfo,
+          channels.toList,
+          extraArgs,
+          envVars)
+      case CondaBootstrapMode.File =>
+        CondaSetupInstructions(
+          bootstrapMode,
+          packages.toList,
+          bootstrapPackageUrls,
+          bootstrapPackageUrlsUserInfo,
+          channels.toList,
+          extraArgs,
+          envVars)
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -71,6 +71,10 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     defaultInfo("pkgs_dirs").extract[List[String]]
   }
 
+  private[conda] lazy val verbosityFlags: List[String] = {
+    0.until(verbosity).map(_ => "-v").toList
+  }
+
   def listPackagesExplicit(envDir: String): List[String] = {
     logInfo("Retrieving a conda environment's list of installed packages")
     val command = Process(List(condaBinaryPath, "list", "-p", envDir, "--explicit"), None)
@@ -114,8 +118,6 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     logInfo(s"Creating symlink $linkedBaseDir -> $baseDir")
     Files.createSymbolicLink(linkedBaseDir, Paths.get(baseDir))
 
-    val verbosityFlags = 0.until(verbosity).map(_ => "-v").toList
-
     // Attempt to create environment
     runCondaProcess(
       linkedBaseDir,
@@ -158,8 +160,6 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     val linkedBaseDir = Utils.createTempDir("/tmp", "conda").toPath.resolve("real")
     logInfo(s"Creating symlink $linkedBaseDir -> $baseDir")
     Files.createSymbolicLink(linkedBaseDir, Paths.get(baseDir))
-
-    val verbosityFlags = 0.until(verbosity).map(_ => "-v").toList
 
     // Authenticate URLs if we have a UserInfo argument
     val finalCondaPackageUrls = if (condaPackageUrlsUserInfo.isDefined) {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -94,7 +94,13 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
     condaMode match {
       case CondaBootstrapMode.Solve =>
-        create(baseDir, condaPackages, condaPackageUrlsUserInfo, condaChannelUrls, condaExtraArgs, condaEnvVars)
+        create(
+          baseDir,
+          condaPackages,
+          condaPackageUrlsUserInfo,
+          condaChannelUrls,
+          condaExtraArgs,
+          condaEnvVars)
       case CondaBootstrapMode.File =>
         createWithFile(
           baseDir, condaPackageUrls, condaPackageUrlsUserInfo, condaExtraArgs, condaEnvVars)

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -94,7 +94,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
     condaMode match {
       case CondaBootstrapMode.Solve =>
-        create(baseDir, condaPackages, condaChannelUrls, condaExtraArgs, condaEnvVars)
+        create(baseDir, condaPackages, condaPackageUrlsUserInfo, condaChannelUrls, condaExtraArgs, condaEnvVars)
       case CondaBootstrapMode.File =>
         createWithFile(
           baseDir, condaPackageUrls, condaPackageUrlsUserInfo, condaExtraArgs, condaEnvVars)
@@ -104,6 +104,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
   def create(
       baseDir: String,
       condaPackages: Seq[String],
+      condaPackageUrlsUserInfo: Option[String],
       condaChannelUrls: Seq[String],
       condaExtraArgs: Seq[String] = Nil,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
@@ -137,7 +138,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       CondaBootstrapMode.Solve,
       condaPackages,
       Nil,
-      None,
+      condaPackageUrlsUserInfo,
       condaChannelUrls,
       condaExtraArgs)
   }


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
Custom change to palantir fork.

## What changes were proposed in this pull request?

Currently conda envs on executors are constructed by using the same instruction as the driver. This entails that `Solve` type environments have to re-run the time consuming `conda create` operations on executors.

Changing the instructions passed down to executor to always use `File` type can significantly improve the conda environment preparation efficiency on executors.

More detail see internal quip - 3xanAaKFc5KF

## How was this patch tested?

Manual tests
