### PR TITLE
Always offer `File` type conda instructions to executors using driver's transitive packages

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -92,6 +92,7 @@ final class CondaEnvironment(
     manager.runCondaProcess(rootPath,
       List("install", "-n", envName, "-y")
         ::: extraArgs.toList
+        ::: manager.verbosityFlags
         ::: "--" :: packages.toList,
       description = s"install dependencies in conda env $condaEnvDir",
       channels = channels.iterator.map(_.url).toList,

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -116,9 +116,11 @@ final class CondaEnvironment(
   /**
    * This is for sending the instructions to the executors so they can replicate the same conda
    * environment.
-   * For `File` bootstrap mode, use original setup
-   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs
-   * and avoid re-solving.
+   * <p><ul>
+   *   <li>In {@code File} mode, re-use the same specfile on executors.</li>
+   *   <li>In {@code Solve} mode, list resolved packages into a specfile
+   *    and use that on executors.</li>
+   * </ul>
    */
   def buildSetupInstructions: CondaSetupInstructions = {
     bootstrapMode match {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -114,12 +114,14 @@ final class CondaEnvironment(
   }
 
   /**
-   * This is for sending the instructions to the executors so they can replicate the same conda environment.
+   * This is for sending the instructions to the executors so they can replicate the same conda
+   * environment.
    * For `File` bootstrap mode, use original setup
-   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs and avoid solving.
+   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs
+   * and avoid re-solving.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    mode match {
+    bootstrapMode match {
       case CondaBootstrapMode.Solve =>
         CondaSetupInstructions(
           CondaBootstrapMode.File,

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -114,17 +114,31 @@ final class CondaEnvironment(
   }
 
   /**
-   * This is for sending the instructions to the executors so they can replicate the same steps.
+   * This is for sending the instructions to the executors so they can replicate the same conda environment.
+   * For `File` bootstrap mode, use original setup
+   * For `Solve` bootstrap mode, convert to `File` mode to use exactly same conda pkgs and avoid solving.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
-    CondaSetupInstructions(
-      bootstrapMode,
-      packages.toList,
-      bootstrapPackageUrls,
-      bootstrapPackageUrlsUserInfo,
-      channels.toList,
-      extraArgs,
-      envVars)
+    mode match {
+      case CondaBootstrapMode.Solve =>
+        CondaSetupInstructions(
+          CondaBootstrapMode.File,
+          packages.toList,
+          getTransitivePackageUrls(),
+          bootstrapPackageUrlsUserInfo,
+          channels.toList,
+          extraArgs,
+          envVars)
+      case CondaBootstrapMode.File =>
+        CondaSetupInstructions(
+          bootstrapMode,
+          packages.toList,
+          bootstrapPackageUrls,
+          bootstrapPackageUrlsUserInfo,
+          channels.toList,
+          extraArgs,
+          envVars)
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -71,6 +71,10 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     defaultInfo("pkgs_dirs").extract[List[String]]
   }
 
+  private[conda] lazy val verbosityFlags: List[String] = {
+    0.until(verbosity).map(_ => "-v").toList
+  }
+
   def listPackagesExplicit(envDir: String): List[String] = {
     logInfo("Retrieving a conda environment's list of installed packages")
     val command = Process(List(condaBinaryPath, "list", "-p", envDir, "--explicit"), None)
@@ -114,8 +118,6 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     logInfo(s"Creating symlink $linkedBaseDir -> $baseDir")
     Files.createSymbolicLink(linkedBaseDir, Paths.get(baseDir))
 
-    val verbosityFlags = 0.until(verbosity).map(_ => "-v").toList
-
     // Attempt to create environment
     runCondaProcess(
       linkedBaseDir,
@@ -158,8 +160,6 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     val linkedBaseDir = Utils.createTempDir("/tmp", "conda").toPath.resolve("real")
     logInfo(s"Creating symlink $linkedBaseDir -> $baseDir")
     Files.createSymbolicLink(linkedBaseDir, Paths.get(baseDir))
-
-    val verbosityFlags = 0.until(verbosity).map(_ => "-v").toList
 
     // Authenticate URLs if we have a UserInfo argument
     val finalCondaPackageUrls = if (condaPackageUrlsUserInfo.isDefined) {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -94,7 +94,13 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
     condaMode match {
       case CondaBootstrapMode.Solve =>
-        create(baseDir, condaPackages, condaPackageUrlsUserInfo, condaChannelUrls, condaExtraArgs, condaEnvVars)
+        create(
+          baseDir,
+          condaPackages,
+          condaPackageUrlsUserInfo,
+          condaChannelUrls,
+          condaExtraArgs,
+          condaEnvVars)
       case CondaBootstrapMode.File =>
         createWithFile(
           baseDir, condaPackageUrls, condaPackageUrlsUserInfo, condaExtraArgs, condaEnvVars)

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -94,7 +94,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
     condaMode match {
       case CondaBootstrapMode.Solve =>
-        create(baseDir, condaPackages, condaChannelUrls, condaExtraArgs, condaEnvVars)
+        create(baseDir, condaPackages, condaPackageUrlsUserInfo, condaChannelUrls, condaExtraArgs, condaEnvVars)
       case CondaBootstrapMode.File =>
         createWithFile(
           baseDir, condaPackageUrls, condaPackageUrlsUserInfo, condaExtraArgs, condaEnvVars)
@@ -104,6 +104,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
   def create(
       baseDir: String,
       condaPackages: Seq[String],
+      condaPackageUrlsUserInfo: Option[String],
       condaChannelUrls: Seq[String],
       condaExtraArgs: Seq[String] = Nil,
       condaEnvVars: Map[String, String] = Map.empty): CondaEnvironment = {
@@ -137,7 +138,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
       CondaBootstrapMode.Solve,
       condaPackages,
       Nil,
-      None,
+      condaPackageUrlsUserInfo,
       condaChannelUrls,
       condaExtraArgs)
   }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -174,13 +174,19 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    status = open(sys.argv[1],'w')
     |
     |    def numpy_multiply(x):
-    |        # Ensure executor has access to packages in driver.
+    |        # Ensure executors have the same packages of the driver.
     |        import numpy
+    |        # Ensure there are no other previously mentioned pkgs.
+    |        try:
+    |            import addict
+    |            return 0
+    |        except ImportError:
+    |            pass
     |        return numpy.multiply(x, 2)
     |
     |    rdd = sc.parallelize(range(10)).map(numpy_multiply)
     |    rdd_sum = rdd.sum()
-    |    if rdd_sum == 90:
+    |    if rdd_sum == 90:       # sum(0:9) * 2 = 90
     |        result = "success"
     |    else:
     |        result = "failure"

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -176,12 +176,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    def numpy_multiply(x):
     |        # Ensure executors have the same packages of the driver.
     |        import numpy
-    |        # Ensure there are no other previously mentioned pkgs.
-    |        try:
-    |            import addict
-    |            return 0
-    |        except ImportError:
-    |            pass
     |        return numpy.multiply(x, 2)
     |
     |    rdd = sc.parallelize(range(10)).map(numpy_multiply)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -160,6 +160,35 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    sc.stop()
   """.stripMargin
 
+  private val TEST_CONDA_DRIVER_INIT_PYFILE = """
+    |import os
+    |import sys
+    |
+    |from pyspark import SparkConf , SparkContext
+    |if __name__ == "__main__":
+    |    if len(sys.argv) != 2:
+    |        print >> sys.stderr, "Usage: test.py [result file]"
+    |        exit(-1)
+    |    sc = SparkContext(conf=SparkConf())
+    |
+    |    status = open(sys.argv[1],'w')
+    |
+    |    def numpy_multiply(x):
+    |        # Ensure executor has access to packages in driver.
+    |        import numpy
+    |        numpy.multiply(x, 2)
+    |
+    |    rdd = sc.parallelize(range(10)).map(numpy_multiply)
+    |    rdd_sum = rdd.sum()
+    |    if rdd_sum == 90:
+    |        result = "success"
+    |    else:
+    |        result = "failure"
+    |    status.write(result)
+    |    status.close()
+    |    sc.stop()
+  """.stripMargin
+
   private val TEST_PYMODULE = """
     |def func():
     |    return 42
@@ -280,6 +309,20 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   test("run Python application within Conda in yarn-cluster mode") {
     testCondaPySparkAllModes(clientMode = false)
+  }
+
+  test("Python application within Conda in yarn-cluster mode has necessary pkgs") {
+    // run conda driver
+    val extraConfForCreate: Map[String, String] = Map(
+      "spark.conda.binaryPath" -> sys.env("CONDA_BIN"),
+      "spark.conda.channelUrls" -> "https://repo.continuum.io/pkgs/main",
+      "spark.conda.bootstrapPackages" -> "python=3.6,numpy=1.14.0"
+    )
+
+    testCondaPySpark(
+      clientMode = false,
+      TEST_CONDA_DRIVER_INIT_PYFILE,
+      extraConf = extraConfForCreate)
   }
 
   test("run Python application in yarn-cluster mode using " +

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -176,7 +176,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     |    def numpy_multiply(x):
     |        # Ensure executor has access to packages in driver.
     |        import numpy
-    |        numpy.multiply(x, 2)
+    |        return numpy.multiply(x, 2)
     |
     |    rdd = sc.parallelize(range(10)).map(numpy_multiply)
     |    rdd_sum = rdd.sum()


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
Custom change to palantir fork.

## What changes were proposed in this pull request?

Currently conda envs on executors are constructed by using the same instruction as the driver. This entails that `Solve` type environments have to re-run the time consuming `conda create` operations on executors.

Changing the instructions passed down to executors to always use `File` type with driver's transitive packages information, which can significantly improve the conda environment preparation efficiency on executors.

More detail see internal quip - 3xanAaKFc5KF

## How was this patch tested?

Integration test within `YarnClusterSuite.scala`