### PR TITLE
Add ExecutorPlugin methods called on Task Start/End

### DIFF
--- a/core/src/main/java/org/apache/spark/ExecutorPlugin.java
+++ b/core/src/main/java/org/apache/spark/ExecutorPlugin.java
@@ -56,20 +56,36 @@ public interface ExecutorPlugin {
   default void shutdown() {}
 
   /**
-   * TODO
+   * Perform any action before the task is run.
+   *
+   * <p>This method is invoked from the same thread the task will be executed.
+   * Task-specific information can be accessed via {@link TaskContext#get}.</p>
+   *
+   * <p>Users should avoid expensive operations here, as this method will be called
+   * on every task, and doing something expensive can significantly slow down a job.
+   * It is not recommended for a user to call a remote service, for example.</p>
+   *
+   * <p>Exceptions thrown from this method do not propagate - they're caught,
+   * logged, and suppressed. Therefore exceptions when executing this method won't
+   * make the job fail.</p>
    */
-  // Should this explicitly receive TaskContext? Should the methods below also receive TaskContext?
   default void onTaskStart() {}
 
   /**
-   * TODO
+   * Perform an action after tasks completes without exceptions.
+   *
+   * <p>As {@link #onTaskStart() onTaskStart} exceptions are suppressed, this method
+   * will still be invoked even if the corresponding {@link #onTaskStart} call for this
+   * task failed.</p>
+   *
+   * <p>Same warnings of {@link #onTaskStart() onTaskStart} apply here.</p>
    */
-  // Do we need a 'succeeded' and 'failed'?
   default void onTaskSucceeded() {}
 
   /**
-   * TODO
+   * Perform an action after tasks completes with exceptions.
+   *
+   * <p>Same warnings of {@link #onTaskStart() onTaskStart} apply here.</p>
    */
-  // Should this receive the failure reason?
-  default void onTaskFailed() {}
+  default void onTaskFailed(Throwable throwable) {}
 }

--- a/core/src/main/java/org/apache/spark/ExecutorPlugin.java
+++ b/core/src/main/java/org/apache/spark/ExecutorPlugin.java
@@ -54,4 +54,22 @@ public interface ExecutorPlugin {
    * will wait for the plugin to terminate before continuing its own shutdown.</p>
    */
   default void shutdown() {}
+
+  /**
+   * TODO
+   */
+  // Should this explicitly receive TaskContext? Should the methods below also receive TaskContext?
+  default void onTaskStart() {}
+
+  /**
+   * TODO
+   */
+  // Do we need a 'succeeded' and 'failed'?
+  default void onTaskSucceeded() {}
+
+  /**
+   * TODO
+   */
+  // Should this receive the failure reason?
+  default void onTaskFailed() {}
 }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -436,8 +436,8 @@ private[spark] class Executor(
           val res = task.run(
             taskAttemptId = taskId,
             attemptNumber = taskDescription.attemptNumber,
-            executorPlugins = executorPlugins,
-            metricsSystem = env.metricsSystem)
+            metricsSystem = env.metricsSystem,
+            executorPlugins = executorPlugins)
           threwException = false
           res
         } {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -402,7 +402,6 @@ private[spark] class Executor(
         task = ser.deserialize[Task[Any]](
           taskDescription.serializedTask, Thread.currentThread.getContextClassLoader)
         task.localProperties = taskDescription.properties
-        task.executorPlugins = executorPlugins
         task.setTaskMemoryManager(taskMemoryManager)
 
         // If this task has been killed before we deserialized it, let's quit now. Otherwise,
@@ -437,6 +436,7 @@ private[spark] class Executor(
           val res = task.run(
             taskAttemptId = taskId,
             attemptNumber = taskDescription.attemptNumber,
+            executorPlugins = executorPlugins,
             metricsSystem = env.metricsSystem)
           threwException = false
           res

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer
 import java.util.Properties
 
 import com.palantir.logsafe.UnsafeArg
+
 import org.apache.spark._
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.SafeLogging

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -83,7 +83,7 @@ private[spark] abstract class Task[T](
       taskAttemptId: Long,
       attemptNumber: Int,
       metricsSystem: MetricsSystem,
-      executorPlugins: Seq[ExecutorPlugin]): T = {
+      executorPlugins: Seq[ExecutorPlugin] = Seq.empty): T = {
     SparkEnv.get.blockManager.registerTask(taskAttemptId)
     // TODO SPARK-24874 Allow create BarrierTaskContext based on partitions, instead of whether
     // the stage is barrier.

--- a/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
+++ b/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
@@ -1,0 +1,125 @@
+package org.apache.spark;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExecutorPluginTaskSuite {
+  private static final String EXECUTOR_PLUGIN_CONF_NAME = "spark.executor.plugins";
+  private static final String taskWellBehavedPluginName = TestWellBehavedPlugin.class.getName();
+  private static final String taskBadlyBehavedPluginName = TestBadlyBehavedPlugin.class.getName();
+
+  // Static value modified by testing plugins to ensure plugins are called correctly.
+  public static int numOnTaskStart = 0;
+  public static int numOnTaskSucceeded = 0;
+  public static int numOnTaskFailed = 0;
+
+  private JavaSparkContext sc;
+
+  @Before
+  public void setUp() {
+    sc = null;
+    numOnTaskStart = 0;
+    numOnTaskSucceeded = 0;
+    numOnTaskFailed = 0;
+  }
+
+  @After
+  public void tearDown() {
+    if (sc != null) {
+      sc.stop();
+      sc = null;
+    }
+  }
+
+  private SparkConf initializeSparkConf(String pluginNames) {
+    return new SparkConf()
+        .setMaster("local")
+        .setAppName("test")
+        .set(EXECUTOR_PLUGIN_CONF_NAME, pluginNames);
+  }
+
+  @Test
+  public void testWellBehavedPlugin() {
+    SparkConf conf = initializeSparkConf(taskWellBehavedPluginName);
+
+    sc = new JavaSparkContext(conf);
+    JavaRDD<Integer> rdd = sc.parallelize(ImmutableList.of(1, 2));
+    rdd.filter(value -> value.equals(1)).collect();
+
+    assertEquals(numOnTaskStart, 1);
+    assertEquals(numOnTaskSucceeded, 1);
+    assertEquals(numOnTaskFailed, 0);
+  }
+
+  @Test
+  public void testBadlyBehavedPluginDoesNotAffectWellBehavedPlugin() {
+    SparkConf conf = initializeSparkConf(taskWellBehavedPluginName + "," + taskBadlyBehavedPluginName);
+
+    sc = new JavaSparkContext(conf);
+    JavaRDD<Integer> rdd = sc.parallelize(ImmutableList.of(1, 2));
+    rdd.filter(value -> value.equals(1)).collect();
+
+    assertEquals(numOnTaskStart, 1);
+    assertEquals(numOnTaskSucceeded, 2);
+    assertEquals(numOnTaskFailed, 0);
+  }
+
+  @Test
+  public void testTaskWhichFails() {
+    SparkConf conf = initializeSparkConf(taskWellBehavedPluginName);
+
+    sc = new JavaSparkContext(conf);
+    JavaRDD<Integer> rdd = sc.parallelize(ImmutableList.of(1, 2));
+    try {
+      rdd.foreach(integer -> {
+        throw new RuntimeException();
+      });
+    } catch (Exception e) {
+      // ignore exception
+    }
+
+    assertEquals(numOnTaskStart, 1);
+    assertEquals(numOnTaskSucceeded, 0);
+    assertEquals(numOnTaskFailed, 1);
+  }
+
+  public static class TestWellBehavedPlugin implements ExecutorPlugin {
+    @Override
+    public void onTaskStart() {
+      numOnTaskStart++;
+    }
+
+    @Override
+    public void onTaskSucceeded() {
+      numOnTaskSucceeded++;
+    }
+
+    @Override
+    public void onTaskFailed(Throwable throwable) {
+      numOnTaskFailed++;
+    }
+  }
+
+  public static class TestBadlyBehavedPlugin implements ExecutorPlugin {
+    @Override
+    public void onTaskStart() {
+      throw new RuntimeException();
+    }
+
+    @Override
+    public void onTaskSucceeded() {
+      numOnTaskSucceeded++;
+    }
+
+    @Override
+    public void onTaskFailed(Throwable throwable) {
+      numOnTaskFailed++;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
+++ b/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
@@ -76,7 +76,8 @@ public class ExecutorPluginTaskSuite {
 
   @Test
   public void testBadlyBehavedPluginDoesNotAffectWellBehavedPlugin() {
-    SparkConf conf = initializeSparkConf(taskWellBehavedPluginName + "," + taskBadlyBehavedPluginName);
+    SparkConf conf = initializeSparkConf(
+            taskWellBehavedPluginName + "," + taskBadlyBehavedPluginName);
 
     sc = new JavaSparkContext(conf);
     JavaRDD<Integer> rdd = sc.parallelize(ImmutableList.of(1, 2));

--- a/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
+++ b/core/src/test/java/org/apache/spark/ExecutorPluginTaskSuite.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -70,7 +70,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties,
       closureSerializer.serialize(TaskMetrics.registered).array())
     intercept[RuntimeException] {
-      task.run(0, 0, null, Seq.empty)
+      task.run(0, 0, null)
     }
     assert(TaskContextSuite.completed === true)
   }
@@ -92,7 +92,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties,
       closureSerializer.serialize(TaskMetrics.registered).array())
     intercept[RuntimeException] {
-      task.run(0, 0, null, Seq.empty)
+      task.run(0, 0, null)
     }
     assert(TaskContextSuite.lastError.getMessage == "damn error")
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -70,7 +70,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties,
       closureSerializer.serialize(TaskMetrics.registered).array())
     intercept[RuntimeException] {
-      task.run(0, 0, null)
+      task.run(0, 0, null, Seq.empty)
     }
     assert(TaskContextSuite.completed === true)
   }
@@ -92,7 +92,7 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
       0, 0, taskBinary, rdd.partitions(0), Seq.empty, 0, new Properties,
       closureSerializer.serialize(TaskMetrics.registered).array())
     intercept[RuntimeException] {
-      task.run(0, 0, null)
+      task.run(0, 0, null, Seq.empty)
     }
     assert(TaskContextSuite.lastError.getMessage == "damn error")
   }


### PR DESCRIPTION
## Upstream [SPARK-33088](https://issues.apache.org/jira/browse/SPARK-33088) ticket and https://github.com/apache/spark/pull/29977
Done.

## What changes were proposed in this pull request?
Add a set of endpoints on `ExecutorPlugin` which are called on the lifecycle of a `Task`. Main usage of such endpoints is for tracing purposes, i.e. to propagate the inbound tracing information from `TaskContext#getLocalProperties` to a tracing framework of choice (in our case, https://github.com/palantir/tracing-java/).

## How was this patch tested?
Unit tests on `ExecutorPluginTaskSuite`.

Please review http://spark.apache.org/contributing.html before opening a pull request.
