### PR TITLE
Remove userInfo from Conda environment lists

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironment.scala
@@ -121,6 +121,8 @@ final class CondaEnvironment(
    *   <li>In {@code Solve} mode, list resolved packages into a specfile
    *    and use that on executors.</li>
    * </ul>
+   * Always using {@code File} mode for executors reduces conda init time by avoiding
+   * re-solving conda deps.
    */
   def buildSetupInstructions: CondaSetupInstructions = {
     bootstrapMode match {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -75,6 +75,15 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     0.until(verbosity).map(_ => "-v").toList
   }
 
+  /**
+   * List of exact uris of the packages in the solved environment, dropping any credential
+   * information (user info).
+   *
+   * This method is used by executors to obtain specfiles for repro-ing conda envs. File mode
+   * creation expects pkg uris without user info, so we need to drop them before returning.
+   * @param envDir
+   * @return List of uris
+   */
   def listPackagesExplicit(envDir: String): List[String] = {
     logInfo("Retrieving a conda environment's list of installed packages")
     val command = Process(List(condaBinaryPath, "list", "-p", envDir, "--explicit"), None)

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -80,7 +80,10 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     val command = Process(List(condaBinaryPath, "list", "-p", envDir, "--explicit"), None)
 
     val out = runOrFail(command, "retrieving the conda installation's list of installed packages")
-    out.split("\n").filterNot(line => line.startsWith("#") || line.startsWith("@")).toList
+    out.split("\n")
+      .filterNot(line => line.startsWith("#") || line.startsWith("@"))
+      .map(uri => UriBuilder.fromUri(uri).userInfo(null).build().toString)
+      .toList
   }
 
   def createWithMode(

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -82,7 +82,7 @@ final class CondaEnvironmentManager(condaBinaryPath: String,
     val out = runOrFail(command, "retrieving the conda installation's list of installed packages")
     out.split("\n")
       .filterNot(line => line.startsWith("#") || line.startsWith("@"))
-      .map(uri => UriBuilder.fromUri(uri).userInfo(null).build().toString)
+      .map(CondaEnvironmentManager.dropUserInfo)
       .toList
   }
 
@@ -328,6 +328,10 @@ object CondaEnvironmentManager extends Logging {
 
   private[conda] def redactCredentials(line: String): String = {
     httpUrlToken.matcher(line).replaceAll("$1<password>")
+  }
+
+  private[conda] def dropUserInfo(uri: String): String = {
+    UriBuilder.fromUri(uri).userInfo(null).build().toString
   }
 
   def fromConf(sparkConf: SparkConf): CondaEnvironmentManager = {

--- a/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
+++ b/core/src/main/scala/org/apache/spark/api/conda/CondaEnvironmentManager.scala
@@ -339,6 +339,10 @@ object CondaEnvironmentManager extends Logging {
     httpUrlToken.matcher(line).replaceAll("$1<password>")
   }
 
+  /**
+   * Safely dropping the <code>userInfo</code> component in URI via <code>UriBuilder</code>.
+   * <code>UriBuilder</code> can safely alter URI components without throwing exceptions.
+   */
   private[conda] def dropUserInfo(uri: String): String = {
     UriBuilder.fromUri(uri).userInfo(null).build().toString
   }

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -79,5 +79,9 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
       "https://a:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
     assert(CondaEnvironmentManager.dropUserInfo(
       "https://:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+    assert(CondaEnvironmentManager.dropUserInfo(
+      "https://a:<password>@x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+    assert(CondaEnvironmentManager.dropUserInfo(
+      "https://:Bearer bf.ghi@x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
   }
 }

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -75,9 +75,9 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
   test("CondaEnvironmentManager.dropUserInfo") {
     val packageUrl = "https://x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2"
     assert(CondaEnvironmentManager.dropUserInfo(packageUrl) == packageUrl)
-    assert(CondaEnvironmentManager
-      .dropUserInfo("https://a:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
-    assert(CondaEnvironmentManager
-      .dropUserInfo("https://:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+    assert(CondaEnvironmentManager.dropUserInfo(
+      "https://a:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+    assert(CondaEnvironmentManager.dropUserInfo(
+      "https://:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
   }
 }

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -73,12 +73,12 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
   }
 
   test("CondaEnvironmentManager.dropUserInfo") {
-    val packageUrl = "https://x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2"
+    val packageUrl = "https://x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2"
     assert(CondaEnvironmentManager.dropUserInfo(packageUrl) == packageUrl)
     assert(CondaEnvironmentManager.dropUserInfo(
-      "https://a:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+      "https://a:b@x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
     assert(CondaEnvironmentManager.dropUserInfo(
-      "https://:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+      "https://:b@x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
     assert(CondaEnvironmentManager.dropUserInfo(
       "https://a:<password>@x-5.bar/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
     assert(CondaEnvironmentManager.dropUserInfo(

--- a/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
+++ b/core/src/test/scala/org/apache/spark/api/conda/CondaEnvironmentManagerTest.scala
@@ -71,4 +71,13 @@ class CondaEnvironmentManagerTest extends org.apache.spark.SparkFunSuite with Te
       "via spark.conda.bootstrapPackageUrlsUserInfo.")
         .equals(thrown.getMessage))
   }
+
+  test("CondaEnvironmentManager.dropUserInfo") {
+    val packageUrl = "https://x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2"
+    assert(CondaEnvironmentManager.dropUserInfo(packageUrl) == packageUrl)
+    assert(CondaEnvironmentManager
+      .dropUserInfo("https://a:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+    assert(CondaEnvironmentManager
+      .dropUserInfo("https://:b@x-5.bar/whatever/else/linux-64/package-0.0.1-py_0.tar.bz2") == packageUrl)
+  }
 }


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
Specific to Palantir Spark. Address new bug introduced in the #710

## What changes were proposed in this pull request?

Notice that `listPackagesExplicit` will keep the user info information. Drops the user info so that executor's `createWithFile` can finish successfully.

## How was this patch tested?

unit tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
