### PR TITLE
local[*] parallelism to be determined from conf first, then fallback to available processors

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2701,7 +2701,13 @@ object SparkContext extends SafeLogging {
    */
   private[spark] def numDriverCores(master: String, conf: SparkConf): Int = {
     def convertToInt(threads: String): Int = {
-      if (threads == "*") Runtime.getRuntime.availableProcessors() else threads.toInt
+      if (threads == "*") {
+        conf.getOption(DRIVER_CORES.key)
+          .map(_.toInt)
+          .getOrElse(Runtime.getRuntime.availableProcessors)
+      } else {
+        threads.toInt
+      }
     }
     master match {
       case "local" => 1


### PR DESCRIPTION
## Upstream SPARK-XXXXX ticket and PR link
This will break local mode parallelism for `local[*]`

## What changes were proposed in this pull request?

`local[*]` to first use `spark.driver.cores` to determine task parallelism, else fallback to `Runtime.getRuntime().getAvailableProcessors()`. This is to be able to run local mode applications in containerised environments. If not core hard limits are set on the container, `local[*]` would use all available processors of the underlying host.
