### PR TITLE
[SPARK-32753][SQL] Only copy tags to node with no tags

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -295,7 +295,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       mapChildren(_.transformDown(rule))
     } else {
       // If the transform function replaces this node with a new one, carry over the tags.
-      afterRule.tags ++= this.tags
+      afterRule.copyTagsFrom(this)
       afterRule.mapChildren(_.transformDown(rule))
     }
   }
@@ -319,7 +319,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       }
     }
     // If the transform function replaces this node with a new one, carry over the tags.
-    newNode.tags ++= this.tags
+    newNode.copyTagsFrom(this)
     newNode
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -91,7 +91,12 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
   private val tags: mutable.Map[TreeNodeTag[_], Any] = mutable.Map.empty
 
   protected def copyTagsFrom(other: BaseType): Unit = {
-    tags ++= other.tags
+    // SPARK-32753: it only makes sense to copy tags to a new node
+    // but it's too expensive to detect other cases likes node removal
+    // so we make a compromise here to copy tags to node with no tags
+    if (tags.isEmpty) {
+      tags ++= other.tags
+    }
   }
 
   def setTagValue[T](tag: TreeNodeTag[T], value: T): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -406,16 +406,16 @@ class AdaptiveQueryExecSuite
   }
 
   test("SPARK-32753: Only copy tags to node with no tags") {
-    withSQLConf(
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true"
-    ) {
-      spark.range(10).union(spark.range(10)).createOrReplaceTempView("v1")
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      withTempView("v1") {
+        spark.range(10).union(spark.range(10)).createOrReplaceTempView("v1")
 
-      val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
-        "SELECT id FROM v1 GROUP BY id DISTRIBUTE BY id")
-      assert(collect(adaptivePlan) {
-        case s: ShuffleExchangeExec => s
-      }.length == 1)
+        val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
+          "SELECT id FROM v1 GROUP BY id DISTRIBUTE BY id")
+        assert(collect(adaptivePlan) {
+          case s: ShuffleExchangeExec => s
+        }.length == 1)
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is a cherry-pick of [SPARK-32753](https://issues.apache.org/jira/browse/SPARK-32753) / https://github.com/apache/spark/pull/29593.

It fixes a correctness bug that causes duplicate rows or empty rows (as we've seen internally). It reproduces on apache/spark 3.0.1 when aggregating on a column, then repartitioning on the same. E.g. the query below. More context on the [internal ticket](https://pl.ntr/1Un). (There is no upstream release of this yet. The fix merged into branch-3.0 on Sep 8. Release 3.0.1 was cut Aug 28.).
```
scala> df.show()
+----+-----+                                                                    
| tag| data|
+----+-----+
|tag1|data1|
|tag2|data2|
+----+-----+

scala> val repartitioned = df
    .groupBy("tag")
    .agg(collect_set("data"))
    .repartition(col("tag"))
```
The written data is:
```
scala> repartitioned.write.json("json_out")

scala> spark.read.json("json_out").show()
+-----------------+----+
|collect_set(data)| tag|
+-----------------+----+
|               []|tag2|
|               []|tag1|
+-----------------+----+
```

Reason for the bug is [here](https://github.com/apache/spark/pull/29593#discussion_r482013121).

## How was this patch tested?
Upstream introduced a unit test against the shape of the adaptive plan. I also tested my repro against this which otherwise causes empty rows (upstream only reported duplicate rows - seems we're lucky in that the fix covers us as well).

