### PR TITLE
Use non-batch scans during sorted bucketed reads

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -153,7 +153,7 @@ case class FileSourceScanExec(
   // Note that some vals referring the file-based relation are lazy intentionally
   // so that this plan can be canonicalized on executor side too. See SPARK-23731.
   override lazy val supportsBatch: Boolean = {
-    relation.fileFormat.supportBatch(relation.sparkSession, schema)
+    scanMode == RegularMode && relation.fileFormat.supportBatch(relation.sparkSession, schema)
   }
 
   private lazy val scanMode: ScanMode =

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -391,6 +391,19 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
           joinOperator.right.find(_.isInstanceOf[SortExec]).isDefined == sortRight,
           s"expected sort in the right child to be $sortRight but found\n${joinOperator.right}")
       }
+
+      // check answer with codegen enabled
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0",
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+        val t1 = spark.table("bucketed_table1")
+        val t2 = spark.table("bucketed_table2")
+        val joined = t1.join(t2, joinCondition(t1, t2), joinType)
+
+        // First check the result is corrected.
+        checkAnswer(
+          joined.sort("bucketed_table1.k", "bucketed_table2.k"),
+          df1.join(df2, joinCondition(df1, df2), joinType).sort("df1.k", "df2.k"))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -399,7 +399,6 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils {
         val t2 = spark.table("bucketed_table2")
         val joined = t1.join(t2, joinCondition(t1, t2), joinType)
 
-        // First check the result is corrected.
         checkAnswer(
           joined.sort("bucketed_table1.k", "bucketed_table2.k"),
           df1.join(df2, joinCondition(df1, df2), joinType).sort("df1.k", "df2.k"))


### PR DESCRIPTION
Follow up fix from https://github.com/palantir/spark/pull/731. While adapting https://github.com/apache/spark/pull/29625/files to our branch, we missed a change to not do batch scans during sorted bucketed reads - specifically, this line was missed: https://github.com/apache/spark/pull/29625/files#diff-089285f1484c1598cb2839b86b6a9e65b98ab5b30462aedc210fe4bbf44cae78R177.

This results in reads failing when using codegen + vectorized reader. I have added a test that fails without this change.