### PR TITLE
[BUILD] Set hadoop-palantir profile for publish functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ deployable-branches-and-tags: &deployable-branches-and-tags
       only:
         - /palantir-.*/
         - master
+        - wr/fix-publish
 
 # Step templates
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ deployable-branches-and-tags: &deployable-branches-and-tags
       only:
         - /palantir-.*/
         - master
-        - wr/fix-publish
 
 # Step templates
 

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PALANTIR_FLAGS=(-Psparkr -Phadoop-cloud -Phadoop-palantir)
+PALANTIR_FLAGS=(-Psparkr -Phadoop-palantir)
 
 get_version() {
   git describe --tags --first-parent

--- a/dev/publish_functions.sh
+++ b/dev/publish_functions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PALANTIR_FLAGS=(-Psparkr -Phadoop-cloud)
+PALANTIR_FLAGS=(-Psparkr -Phadoop-cloud -Phadoop-palantir)
 
 get_version() {
   git describe --tags --first-parent


### PR DESCRIPTION
We have a hadoop-palantir profile in our [pom.xml](https://github.com/palantir/spark/blob/c0491e9f62f3f5e5a2a06636f50ef0de7556ca8b/pom.xml#L3144-L3151), and it adds the modules hadoop-palantir, hadoop-palantir-bom, and hadoop-cloud. Without the profile set, Maven ignores those modules.

In #737, I didn't make sure the profile is set for publishing. As result, e.g., the pom file is missing [here](https://pl.ntr/1Va).

This should correct that.