### PR TITLE
Upgrade Avro to 1.10.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -15,9 +15,10 @@ arrow-memory-0.15.1.jar
 arrow-vector-0.15.1.jar
 audience-annotations-0.7.0.jar
 automaton-1.11-8.jar
-avro-1.8.2.jar
-avro-ipc-1.8.2.jar
-avro-mapred-1.8.2-hadoop2.jar
+avro-1.10.2.jar
+avro-ipc-1.10.2.jar
+avro-ipc-jetty-1.10.2.jar
+avro-mapred-1.10.2.jar
 aws-java-sdk-bundle-1.11.201.jar
 azure-data-lake-store-sdk-2.2.7.jar
 azure-keyvault-core-0.8.0.jar
@@ -203,6 +204,7 @@ stax2-api-3.1.4.jar
 stream-2.9.6.jar
 univocity-parsers-2.8.3.jar
 validation-api-1.1.0.Final.jar
+velocity-engine-core-2.3.jar
 wildfly-openssl-1.0.7.Final.jar
 woodstox-core-5.0.3.jar
 xbean-asm7-shaded-4.15.jar

--- a/external/kafka-0-10-assembly/pom.xml
+++ b/external/kafka-0-10-assembly/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/external/kinesis-asl-assembly/pom.xml
+++ b/external/kinesis-asl-assembly/pom.xml
@@ -102,7 +102,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <oro.version>2.0.8</oro.version>
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <dropwizard.version>1.0.0</dropwizard.version>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.10.2</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <aws.kinesis.client.version>1.8.10</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <dropwizard.version>1.0.0</dropwizard.version>
     <avro.version>1.10.2</avro.version>
-    <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <aws.kinesis.client.version>1.8.10</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.271</aws.java.sdk.version>
@@ -1197,7 +1196,6 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
         <version>${avro.version}</version>
-        <classifier>${avro.mapred.classifier}</classifier>
         <scope>${hive.deps.scope}</scope>
         <exclusions>
           <exclusion>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -121,7 +121,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
This a backport to our Spark 2 branch. Upgrade to Avro 1.10.2.

1.10.2 comes with some fixes we're interested in, particularly [AVRO-2944](https://issues.apache.org/jira/browse/AVRO-2944) to fix some failures we're seeing [(ticket)](https://pl.ntr/1Vx).

Beside the upgrade, you'll see we're dropping the `avro.mapred.classifier`. It was necessary previously to pull an Avro version compatible with Hadoop 2 as opposed to Hadoop 1. As of 1.9.0 Hadoop 2 is the default and the classifier no longer works [(AVRO-2059)](https://issues.apache.org/jira/browse/AVRO-2059).