### PR TITLE
Arrow 2.0 and PyArrow 1.0.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -12,9 +12,10 @@ apacheds-kerberos-codec/2.0.0-M15//apacheds-kerberos-codec-2.0.0-M15.jar
 api-asn1-api/1.0.0-M20//api-asn1-api-1.0.0-M20.jar
 api-util/1.0.0-M20//api-util-1.0.0-M20.jar
 arpack_combined_all/0.1//arpack_combined_all-0.1.jar
-arrow-format/0.15.1//arrow-format-0.15.1.jar
-arrow-memory/0.15.1//arrow-memory-0.15.1.jar
-arrow-vector/0.15.1//arrow-vector-0.15.1.jar
+arrow-format/1.0.1//arrow-format-1.0.1.jar
+arrow-memory-core/1.0.1//arrow-memory-core-1.0.1.jar
+arrow-memory-netty/1.0.1//arrow-memory-netty-1.0.1.jar
+arrow-vector/1.0.1//arrow-vector-1.0.1.jar
 audience-annotations/0.5.0//audience-annotations-0.5.0.jar
 avro-ipc/1.8.2//avro-ipc-1.8.2.jar
 avro-mapred/1.8.2/hadoop2/avro-mapred-1.8.2-hadoop2.jar

--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -12,10 +12,10 @@ apacheds-kerberos-codec/2.0.0-M15//apacheds-kerberos-codec-2.0.0-M15.jar
 api-asn1-api/1.0.0-M20//api-asn1-api-1.0.0-M20.jar
 api-util/1.0.0-M20//api-util-1.0.0-M20.jar
 arpack_combined_all/0.1//arpack_combined_all-0.1.jar
-arrow-format/1.0.1//arrow-format-1.0.1.jar
-arrow-memory-core/1.0.1//arrow-memory-core-1.0.1.jar
-arrow-memory-netty/1.0.1//arrow-memory-netty-1.0.1.jar
-arrow-vector/1.0.1//arrow-vector-1.0.1.jar
+arrow-format/2.0.0//arrow-format-2.0.0.jar
+arrow-memory-core/2.0.0//arrow-memory-core-2.0.0.jar
+arrow-memory-netty/2.0.0//arrow-memory-netty-2.0.0.jar
+arrow-vector/2.0.0//arrow-vector-2.0.0.jar
 audience-annotations/0.5.0//audience-annotations-0.5.0.jar
 avro-ipc/1.8.2//avro-ipc-1.8.2.jar
 avro-mapred/1.8.2/hadoop2/avro-mapred-1.8.2-hadoop2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.
     -->
-    <arrow.version>1.0.1</arrow.version>
+    <arrow.version>2.0.0</arrow.version>
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,10 @@
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <!--
-    If you are changing Arrow version specification, please check ./python/pyspark/sql/utils.py,
-    and ./python/setup.py too.
+    If you are changing Arrow version specification, please check
+    ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.
     -->
-    <arrow.version>0.15.1</arrow.version>
+    <arrow.version>1.0.1</arrow.version>
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
 
@@ -2344,8 +2344,19 @@
           </exclusion>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <artifactId>jackson-core</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty</artifactId>
+        <version>${arrow.version}</version>
+        <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
@@ -2353,10 +2364,6 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -40,7 +40,7 @@ def require_minimum_pyarrow_version():
     """ Raise ImportError if minimum version of pyarrow is not installed
     """
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
-    minimum_pyarrow_version = "0.15.1"
+    minimum_pyarrow_version = "1.0.0"
 
     from distutils.version import LooseVersion
     import os

--- a/python/setup.py
+++ b/python/setup.py
@@ -102,11 +102,11 @@ if (in_spark):
               file=sys.stderr)
         sys.exit(-1)
 
-# If you are changing the versions here, please also change ./python/pyspark/sql/utils.py
+# If you are changing the versions here, please also change ./python/pyspark/sql/pandas/utils.py
 # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
 # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
 _minimum_pandas_version = "0.23.2"
-_minimum_pyarrow_version = "0.15.1"
+_minimum_pyarrow_version = "1.0.0"
 
 try:
     # We copy the shell script to be under pyspark/python/pyspark so that the launcher scripts

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -117,6 +117,10 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-netty</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>


### PR DESCRIPTION
Exact cherry picks of upstream commits that bump pyarrow to 1.0.1 and Arrow to 2.0.
* [SPARK-32312](https://issues.apache.org/jira/browse/SPARK-32312) / https://github.com/apache/spark/pull/29686 Upgrade Apache Arrow to 1.0.0.
* [SPARK-33213](https://issues.apache.org/jira/browse/SPARK-33213) / https://github.com/apache/spark/pull/30306  Upgrade Apache Arrow to 2.0.0

As result of this, the Java-side Arrow version Spark depends on is 2.0.0. Python-side the minimum installed PyArrow version must be 1.0.1.

The major version difference is fine. Arrow has a versioning scheme that separates the format from the clients. So the Python and Java sides have different major versions for their clients but they both use Arrow format 1.x (see comment [here](https://issues.apache.org/jira/browse/SPARK-33213?focusedCommentId=17219840&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17219840)).

Only difference with upstream commits is that the 1.0.1 bump modified docs which we don't have on our master branch yet [(diff)](https://github.com/apache/spark/pull/29686/files#diff-5efca7d1c60b45b8dc1af28bae300a70f2cae67e31d517ebf6b2d118710b9895). I just dropped that change. 