### PR TITLE
Re-enable secret-based volume mounts for executors

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
@@ -44,7 +44,7 @@ import org.apache.spark.util.Utils
  * Spark's out-of-the-box solution is in [[BasicDriverFeatureStep]] and serves local files by
  * uploading them to an HCFS and serving them from there.
  */
-private[spark] class MountLocalDriverFilesFeatureStep(conf: KubernetesDriverConf)
+private[spark] class MountLocalFilesFeatureStep(conf: KubernetesDriverConf)
   extends KubernetesFeatureConfigStep {
 
   private val enabled = conf.get(KUBERNETES_SECRET_FILE_MOUNT_ENABLED)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
@@ -79,6 +79,11 @@ private[spark] abstract class MountLocalFilesFeatureStep(conf: KubernetesConf)
           .withName("submitted-files")
           .withNewSecret()
             .withSecretName(secretName)
+            // While we re-enable secret mounting for executors, the secret-name between drivers
+            // and executors might not match. When that happens, we prefer empty directories over
+            // failed pods. Thus marking optional.
+            // TODO(wraschkowski): Make non-optional once SMM upgrades its spark-submit
+            .withOptional(true)
             .endSecret()
           .endVolume()
         .endSpec()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.k8s.features
 import java.io.File
 import java.net.URI
 import java.nio.file.Paths
+import java.util.Locale
 
 import scala.collection.JavaConverters._
 
@@ -51,7 +52,7 @@ private[spark] class MountLocalFilesFeatureStep(conf: KubernetesDriverConf)
 
   private val mountPath = conf.get(KUBERNETES_SECRET_FILE_MOUNT_PATH)
 
-  private val secretName = s"${conf.resourceNamePrefix}-mounted-files"
+  private val secretName = s"${secretNamePrefix()}-mounted-files"
 
   def allFiles: Seq[String] = {
     Utils.stringToSeq(conf.sparkConf.get(FILES.key, "")) ++
@@ -132,4 +133,14 @@ private[spark] class MountLocalFilesFeatureStep(conf: KubernetesDriverConf)
       case _ => false
     }
   }
+
+  // Like KubernetesConf#getResourceNamePrefix but unique per app, not per resource.
+  private def secretNamePrefix() =
+    s"${conf.appName}"
+      .trim
+      .toLowerCase(Locale.ROOT)
+      .replaceAll("\\s+", "-")
+      .replaceAll("\\.", "-")
+      .replaceAll("[^a-z0-9\\-]", "")
+      .replaceAll("-+", "-")
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStep.scala
@@ -44,6 +44,8 @@ import org.apache.spark.util.Utils
  * This is a Palantir addition that works well for the small files we tend to add in `spark.files`.
  * Spark's out-of-the-box solution is in [[BasicDriverFeatureStep]] and serves local files by
  * uploading them to an HCFS and serving them from there.
+ *
+ * Files mounted here are copied into driver and executor working directories in the entrypoint.sh.
  */
 private[spark] class MountLocalDriverFilesFeatureStep(conf: KubernetesDriverConf)
   extends MountLocalFilesFeatureStep(conf) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -49,7 +49,7 @@ private[spark] class KubernetesDriverBuilder {
       new KerberosConfDriverFeatureStep(conf),
       new PodTemplateConfigMapStep(conf),
       new LocalDirsFeatureStep(conf),
-      new MountLocalFilesFeatureStep(conf))
+      new MountLocalDriverFilesFeatureStep(conf))
 
     val spec = KubernetesDriverSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -49,7 +49,7 @@ private[spark] class KubernetesDriverBuilder {
       new KerberosConfDriverFeatureStep(conf),
       new PodTemplateConfigMapStep(conf),
       new LocalDirsFeatureStep(conf),
-      new MountLocalDriverFilesFeatureStep(conf))
+      new MountLocalFilesFeatureStep(conf))
 
     val spec = KubernetesDriverSpec(
       initialPod,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -45,7 +45,8 @@ private[spark] class KubernetesExecutorBuilder {
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
-      new LocalDirsFeatureStep(conf))
+      new LocalDirsFeatureStep(conf),
+      new MountLocalExecutorFilesFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
@@ -37,7 +37,7 @@ class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
   private var kubernetesConf: KubernetesDriverConf = _
   private var sparkFiles: Seq[String] = _
   private var localFiles: Seq[File] = _
-  private var stepUnderTest: MountLocalFilesFeatureStep = _
+  private var stepUnderTest: MountLocalDriverFilesFeatureStep = _
 
   before {
     val tempDir = Utils.createTempDir()
@@ -62,7 +62,7 @@ class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
       JavaMainAppResource(None),
       "main",
       Array.empty[String])
-    stepUnderTest = new MountLocalFilesFeatureStep(kubernetesConf)
+    stepUnderTest = new MountLocalDriverFilesFeatureStep(kubernetesConf)
   }
 
   test("Attaches a secret volume and secret name") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
@@ -32,12 +32,12 @@ import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.submit.JavaMainAppResource
 import org.apache.spark.util.Utils
 
-class MountLocalDriverFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
+class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
 
   private var kubernetesConf: KubernetesDriverConf = _
   private var sparkFiles: Seq[String] = _
   private var localFiles: Seq[File] = _
-  private var stepUnderTest: MountLocalDriverFilesFeatureStep = _
+  private var stepUnderTest: MountLocalFilesFeatureStep = _
 
   before {
     val tempDir = Utils.createTempDir()
@@ -61,7 +61,7 @@ class MountLocalDriverFilesFeatureStepSuite extends SparkFunSuite with BeforeAnd
       JavaMainAppResource(None),
       "main",
       Array.empty[String])
-    stepUnderTest = new MountLocalDriverFilesFeatureStep(kubernetesConf)
+    stepUnderTest = new MountLocalFilesFeatureStep(kubernetesConf)
   }
 
   test("Attaches a secret volume and secret name") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/MountLocalFilesFeatureStepSuite.scala
@@ -52,6 +52,7 @@ class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
       "https://localhost:9000/file4.txt")
     localFiles = Seq(firstLocalFile, secondLocalFile)
     val sparkConf = new SparkConf(false)
+      .setAppName("test-app")
       .set("spark.files", sparkFiles.mkString(","))
       .set(KUBERNETES_SECRET_FILE_MOUNT_ENABLED, true)
       .set(KUBERNETES_SECRET_FILE_MOUNT_PATH, "/var/data/spark-submitted-files")
@@ -69,7 +70,7 @@ class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
     assert(configuredPod.pod.getSpec.getVolumes.size === 1)
     val volume = configuredPod.pod.getSpec.getVolumes.get(0)
     assert(volume.getName === "submitted-files")
-    assert(volume.getSecret.getSecretName === s"${kubernetesConf.resourceNamePrefix}-mounted-files")
+    assert(volume.getSecret.getSecretName === "test-app-mounted-files")
     assert(configuredPod.container.getVolumeMounts.size === 1)
     val volumeMount = configuredPod.container.getVolumeMounts.get(0)
     assert(volumeMount.getName === "submitted-files")
@@ -98,7 +99,7 @@ class MountLocalFilesFeatureStepSuite extends SparkFunSuite with BeforeAndAfter 
     assert(secrets.size === 1)
     assert(secrets.head.isInstanceOf[Secret])
     val secret = secrets.head.asInstanceOf[Secret]
-    assert(secret.getMetadata.getName === s"${kubernetesConf.resourceNamePrefix}-mounted-files")
+    assert(secret.getMetadata.getName === "test-app-mounted-files")
     val secretData = secret.getData.asScala
     assert(secretData.size === 2)
     assert(decodeToUtf8(secretData("file1.txt")) === "a")

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -66,8 +66,11 @@ if ! [ -z ${HADOOP_CONF_DIR+x} ]; then
   SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
 fi
 
+# (Palantir) Copy files from secret-mounted volume into working directory
+# See org.apache.spark.deploy.k8s.features.MountLocalFilesFeatureStep
 if [ -n "$SPARK_MOUNTED_FILES_FROM_SECRET_DIR" ]; then
   cp -R "$SPARK_MOUNTED_FILES_FROM_SECRET_DIR/." .
+  echo "Copied secret-mounted files from $SPARK_MOUNTED_FILES_FROM_SECRET_DIR"
 fi
 
 case "$1" in


### PR DESCRIPTION
When enabling secret based volume mounting, volumes are also mounted into executors, not just drivers.

In moving to Spark 3, we disabled mounting of secret-populated volumes for executors. It seemed we don't need that because spark-submit-provided files would make it onto executors via the driver.

That seems to work but we have issues with logging configurations. It seems that in Kubernetes loggers would initialize before files were uploaded to executors. That means logging configs were made available in the expected location too late.

Previously, we were able to get config files in place in time because they were included in the volumes mounted into executors and [this line in the entrypoint.sh](resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh) copies the files into the working directory before any Java executes.