### PR TITLE
[SPARK-34778][BUILD] Upgrade to Avro 1.10.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-palantir
+++ b/dev/deps/spark-deps-hadoop-palantir
@@ -16,9 +16,9 @@ arrow-format/0.15.1//arrow-format-0.15.1.jar
 arrow-memory/0.15.1//arrow-memory-0.15.1.jar
 arrow-vector/0.15.1//arrow-vector-0.15.1.jar
 audience-annotations/0.5.0//audience-annotations-0.5.0.jar
-avro-ipc/1.10.1//avro-ipc-1.10.1.jar
-avro-mapred/1.10.1//avro-mapred-1.10.1.jar
-avro/1.10.1//avro-1.10.1.jar
+avro-ipc/1.10.2//avro-ipc-1.10.2.jar
+avro-mapred/1.10.2//avro-mapred-1.10.2.jar
+avro/1.10.2//avro-1.10.2.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -309,7 +309,7 @@ applications. Read the [Advanced Dependency Management](https://spark.apache
 Submission Guide for more details. 
 
 ## Supported types for Avro -> Spark SQL conversion
-Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.10.1/spec.html#schema_primitive) and [complex types](https://avro.apache.org/docs/1.10.1/spec.html#schema_complex) under records of Avro.
+Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.10.2/spec.html#schema_primitive) and [complex types](https://avro.apache.org/docs/1.10.2/spec.html#schema_complex) under records of Avro.
 <table class="table">
   <tr><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr>
   <tr>
@@ -373,7 +373,7 @@ In addition to the types listed above, it supports reading `union` types. The fo
 3. `union(something, null)`, where something is any supported Avro type. This will be mapped to the same Spark SQL type as that of something, with nullable set to true.
 All other union types are considered complex. They will be mapped to StructType where field names are member0, member1, etc., in accordance with members of the union. This is consistent with the behavior when converting between Avro and Parquet.
 
-It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.10.1/spec.html#Logical+Types):
+It also supports reading the following Avro [logical types](https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types):
 
 <table class="table">
   <tr><th><b>Avro logical type</b></th><th><b>Avro type</b></th><th><b>Spark SQL type</b></th></tr>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -51,14 +51,14 @@ private[sql] class AvroOptions(
 
   /**
    * Top level record name in write result, which is required in Avro spec.
-   * See https://avro.apache.org/docs/1.10.1/spec.html#schema_record .
+   * See https://avro.apache.org/docs/1.10.2/spec.html#schema_record .
    * Default value is "topLevelRecord"
    */
   val recordName: String = parameters.getOrElse("recordName", "topLevelRecord")
 
   /**
    * Record namespace in write result. Default value is "".
-   * See Avro spec for details: https://avro.apache.org/docs/1.10.1/spec.html#schema_record .
+   * See Avro spec for details: https://avro.apache.org/docs/1.10.2/spec.html#schema_record .
    */
   val recordNamespace: String = parameters.getOrElse("recordNamespace", "")
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
     <codahale.metrics.version>4.1.1</codahale.metrics.version>
-    <avro.version>1.10.1</avro.version>
+    <avro.version>1.10.2</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -645,7 +645,7 @@ object DependencyOverrides {
     dependencyOverrides += "commons-io" % "commons-io" % "2.6",
     dependencyOverrides += "xerces" % "xercesImpl" % "2.12.0",
     dependencyOverrides += "jline" % "jline" % "2.14.6",
-    dependencyOverrides += "org.apache.avro" % "avro" % "1.10.1")
+    dependencyOverrides += "org.apache.avro" % "avro" % "1.10.2")
 }
 
 /**

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 
-val jacksonVersion = "2.11.3"
+val jacksonVersion = "2.12.1"
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -36,7 +36,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 addSbtPlugin("com.cavorite" % "sbt-avro" % "2.1.1")
-libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.10.1"
+libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.10.2"
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 


### PR DESCRIPTION
## Original PR description
Update the  Avro version to 1.10.2

To stay up to date with upstream and catch compatibility issues with zstd

No

Unit tests

Closes #31866 from iemejia/SPARK-27733-upgrade-avro-1.10.2.

Authored-by: Ismaël Mejía <iemejia@gmail.com>
Signed-off-by: Yuming Wang <yumwang@ebay.com>

## Upstream SPARK-XXXXX ticket and PR link (if not applicable, explain)
Upstream spark PR: https://github.com/apache/spark/pull/31866
Upstream spark commit: https://github.com/apache/spark/commit/8a552bfc767dff987be41f7f463db17395b74e6f

The change is a clean cherry-pick except for the `jackson` test version, that doesn't exist in upstream and we had to update to have it compatible with scala module 2.12

## What changes were proposed in this pull request?
Bump version of avro to 1.10.2

### Why are the changes needed?
The old Avro versions contain a critical bug fixed in this version.


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Unit tests
