### PR TITLE
Safe log TaskSetManager start task

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.math.max
 import scala.util.control.NonFatal
 
-import com.palantir.logsafe.SafeArg
+import com.palantir.logsafe.{SafeArg, UnsafeArg}
 
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
@@ -459,13 +459,14 @@ private[spark] class TaskSetManager(
         // val timeTaken = clock.getTime() - startTime
         val taskName = s"task ${info.id} in stage ${taskSet.id}"
         safeLogInfo("Starting task",
-          SafeArg.of("task", info.id),
+          SafeArg.of("taskId", taskId),
+          SafeArg.of("attemptNumber", attemptNum),
           SafeArg.of("partitionId", task.partitionId),
-          SafeArg.of("stageId", taskSet.id),
-          SafeArg.of("host", host),
-          SafeArg.of("executor", info.executorId),
+          SafeArg.of("stageId", stageId),
           SafeArg.of("taskLocality", taskLocality),
-          SafeArg.of("serializedTaskSize", serializedTask.limit()))
+          SafeArg.of("serializedTaskSize", serializedTask.limit()),
+          UnsafeArg.of("host", host),
+          UnsafeArg.of("executor", info.executorId))
 
         val extraResources = sched.resourcesReqsPerTask.map { taskReq =>
           val rName = taskReq.resourceName

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -465,8 +465,8 @@ private[spark] class TaskSetManager(
           SafeArg.of("stageId", stageId),
           SafeArg.of("taskLocality", taskLocality),
           SafeArg.of("serializedTaskSize", serializedTask.limit()),
-          UnsafeArg.of("host", host),
-          SafeArg.of("executorId", info.executorId))
+          SafeArg.of("executorId", info.executorId),
+          UnsafeArg.of("host", host))
 
         val extraResources = sched.resourcesReqsPerTask.map { taskReq =>
           val rName = taskReq.resourceName

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -466,7 +466,7 @@ private[spark] class TaskSetManager(
           SafeArg.of("taskLocality", taskLocality),
           SafeArg.of("serializedTaskSize", serializedTask.limit()),
           UnsafeArg.of("host", host),
-          UnsafeArg.of("executor", info.executorId))
+          SafeArg.of("executorId", info.executorId))
 
         val extraResources = sched.resourcesReqsPerTask.map { taskReq =>
           val rName = taskReq.resourceName


### PR DESCRIPTION
Adding safe-logging for the "starting task" log-line.

My main motivation in this PR is the `serializedTaskSize` argument, because I'm currently investigating task deserialization issues. Glad to take this logging elsewhere as long as I can log `serializedTaskSize`.